### PR TITLE
Add coincbc to environment

### DIFF
--- a/environment.fixedversions.yaml
+++ b/environment.fixedversions.yaml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - coincbc
   - snakemake=5.4.0=0
   - snakemake-minimal=5.4.0=py_0
   - affine=2.2.1=py_0


### PR DESCRIPTION
It might be useful to add this to the default setup. Than everyone can run the whole model without any additional licenses.