### PR TITLE
base_network: scale snapshot weightings to sum up to 1 year

### DIFF
--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -461,6 +461,7 @@ def base_network():
     n.name = 'PyPSA-Eur'
 
     n.set_snapshots(pd.date_range(freq='h', **snakemake.config['snapshots']))
+    n.snapshot_weightings[:] *= 8760./n.snapshot_weightings.sum()
 
     n.import_components_from_dataframe(buses, "Bus")
     n.import_components_from_dataframe(lines, "Line")


### PR DESCRIPTION
If the user selects a date range of less than a year in `config.yaml` the snapshot weightings should be scaled to add up to represet 8760 hours (1 year) such that operational expenses and investments are aligned in the objective function.