### PR TITLE
allow usage of own powerplants for selected country

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,6 +43,9 @@ electricity:
   #   Solar: [solar]
 
   conventional_carriers: [] # nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
+  my_carriers_for_countries: ['DE'] # will replace generators in Germany by those saved in resources/powerplants_DE.csv
+  my_carriers_switch: replace-selection #replace-all, replace-selection or add (replace whole country/replace carriertype within country/add and do not delete from original generators)
+  restrict_buildyear: 2050 #delete generators built in between x-2050 
 
 atlite:
   nprocesses: 4

--- a/config.yaml
+++ b/config.yaml
@@ -43,9 +43,8 @@ electricity:
   #   Solar: [solar]
 
   conventional_carriers: [] # nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
-  my_carriers_for_countries: ['DE'] # will replace generators in Germany by those saved in resources/powerplants_DE.csv
-  my_carriers_switch: replace-selection #replace-all, replace-selection or add (replace whole country/replace carriertype within country/add and do not delete from original generators)
-  restrict_buildyear: 2050 #delete generators built in between x-2050 
+  custom_powerplants: replace #replace or add
+  restrict_buildyear: 2015 #delete generators built after 2015
 
 atlite:
   nprocesses: 4

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -18,30 +18,27 @@ def country_alpha_2(name):
         cntry = pyc.countries.get(official_name=name)
     return cntry.alpha_2
 
-def add_my_carriers(ppl):
-    switch = snakemake.config['electricity']['my_carriers_switch']
-    if switch == 'replace-all' or switch == 'replace-selection' or switch == 'add':
-        countries_dict = snakemake.config['countries_dict'] # dictionary, eg. GB: United Kindgom
-        for country in snakemake.config['electricity']['my_carriers_for_countries']:
-            dirname = os.path.abspath(os.path.join(os.path.dirname(__file__),".."))
-            add_ppls = pd.read_csv(dirname + "/resources/powerplants_" + country + ".csv", index_col=0)
-            if switch == 'replace-all' or switch == 'replace-selection':
-                to_drop = ppl[ppl.Country == countries_dict[country]]
-                if switch == 'replace-selection':
-                    to_drop = to_drop[to_drop.Fueltype.isin(add_ppls.groupby('Fueltype').mean().index)]
-                ppl = ppl.drop(to_drop.index)
-            ppl = ppl.append(add_ppls, sort='False')
-    else:
-        logger.warning('my_carriers_switch is invalid keyword, try one of [add, replace-all, replace-selection]. powerplants remain unchanged.')
-    return ppl
+def add_custom_carriers(ppl):
+    switch = snakemake.config['electricity']['custom_powerplants']
+    if switch not in ('replace', 'add'):
+        logger.warning('custom_carriers is invalid keyword, try "replace" or "add"]. powerplants remain unchanged.')
+        return ppl
+    dirname = os.path.abspath(os.path.join(os.path.dirname(__file__),".."))
+    add_ppls = pd.read_csv(dirname + "/data/custom_powerplants.csv", index_col=0)
+    if switch == 'replace':
+        countries = add_ppls.Country.unique().tolist()
+        carriers = add_ppls.Fueltype.unique().tolist()
+        logger.info('replacing ' + str(carriers) + ' in ' + str(countries) + '...')
+        ppl.query('Fueltype != @carriers or Country != @countries',inplace=True)
+    logger.info('adding custom carriers...')
+    return ppl.append(add_ppls, sort='False')
 
 def restrict_buildyear(ppl):
     year = snakemake.config['electricity']['restrict_buildyear']
-    search_pattern = [str(int(year)+x) for x in range(1,2050-int(year))]
     logger.info('restricting build year of generators to ' + str(year) + '...')
-    for pattern in search_pattern: #do it in forloop+contains instead of map as YearCommissioned might have the weirdest formats
-        ppl = ppl[ppl['YearCommissioned'].str.contains(pattern) == False]
-    return ppl
+    ppl.YearCommissioned = ppl.YearCommissioned.fillna(0).astype(int) #in case of bad arrangement
+    ppl.YearCommissioned = ppl.YearCommissioned.astype(int)
+    ppl.query('YearCommissioned <= @year',inplace=True)
 
 if __name__ == "__main__":
     if 'snakemake' not in globals():
@@ -63,8 +60,8 @@ if __name__ == "__main__":
             df.Fueltype.where(df.Fueltype != 'Natural Gas',
                                 df.Technology.replace('Steam Turbine', 'OCGT').fillna('OCGT'))))
         .pipe(ppm.utils.fill_geoposition))
-    ppl = add_my_carriers(ppl) # add carriers from own powerplant files
-    ppl = restrict_buildyear(ppl)
+    ppl = add_custom_carriers(ppl) # add carriers from own powerplant files
+    restrict_buildyear(ppl)
 
     # ppl.loc[(ppl.Fueltype == 'Other') & ppl.Technology.str.contains('CCGT'), 'Fueltype'] = 'CCGT'
     # ppl.loc[(ppl.Fueltype == 'Other') & ppl.Technology.str.contains('Steam Turbine'), 'Fueltype'] = 'CCGT'


### PR DESCRIPTION
in build_powerplants.py add the feature to add own carriers (add_my_carriers) and restrict to a specific build year (restrict_buildyear), which both can be configured in config.yaml (my_carriers_for_countries, my_carriers_switch, restrict_buildyear).