### PR TITLE
Update make_summary for pandas-0.25 compatability.

### DIFF
--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -38,7 +38,11 @@ def calculate_costs(n,label,costs):
         capital_costs = c.df.capital_cost*c.df[opt_name.get(c.name,"p") + "_nom_opt"]
         capital_costs_grouped = capital_costs.groupby(c.df.carrier).sum()
 
-        costs = costs.reindex(costs.index|pd.MultiIndex.from_product([[c.list_name],["capital"],capital_costs_grouped.index]))
+        new_index = costs.index|pd.MultiIndex.from_product([[c.list_name],["capital"],capital_costs_grouped.index])
+        if isinstance(new_index, pd.Index):
+            new_index = pd.MultiIndex.from_tuples(new_index)
+            
+        costs = costs.reindex(new_index)
 
         costs.loc[idx[c.list_name,"capital",list(capital_costs_grouped.index)],label] = capital_costs_grouped.values
 


### PR DESCRIPTION
The pandas Index union operation does no longer produce a MultiIndex but a Index tuple in pandas-0.25.2.
This causes the script to fail. (The problem does not exist with pandas-0.24.0.)

Fix by explicitly checking for this case (only the first loop iteration).