### PR TITLE
own databundle

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -24,7 +24,7 @@ rule solve_all_elec_networks:
         expand("results/networks/elec_s{simpl}_{clusters}_l{ll}_{opts}.nc",
                **config['scenario'])
 
-if config['enable'].get('prepare_links_p_nom', false):
+if config['enable'].get('prepare_links_p_nom', False):
     rule prepare_links_p_nom:
         output: 'data/links_p_nom.csv'
         threads: 1
@@ -40,10 +40,10 @@ datafiles = ['ch_cantons.csv', 'je-e-21.03.02.xls',
             'nama_10r_3gdp.tsv.gz', 'time_series_60min_singleindex_filtered.csv', 
             'corine/g250_clc06_V18_5.tif']
 
-if not config.get('tutorial', false):
+if not config.get('tutorial', False):
     datafiles.extend(["natura/Natura2000_end2015.shp", "GEBCO_2014_2D.nc"])
 
-if config['enable'].get('retrieve_databundle', true):
+if config['enable'].get('retrieve_databundle', True):
     rule retrieve_databundle:
         output:  expand('data/bundle/{file}', file=datafiles)
         script: 'scripts/retrieve_databundle.py'
@@ -109,7 +109,7 @@ rule build_bus_regions:
     # group: 'nonfeedin_preparation'
     script: "scripts/build_bus_regions.py"
 
-if config['enable'].get('build_cutout', false):        
+if config['enable'].get('build_cutout', False):        
     rule build_cutout:
         output: directory("cutouts/{cutout}")
         resources: mem=config['atlite'].get('nprocesses', 4) * 1000
@@ -123,7 +123,7 @@ else:
         script: 'scripts/retrieve_cutout.py'
 
 
-if config['enable'].get('build_natura_raster', false):        
+if config['enable'].get('build_natura_raster', False):        
     rule build_natura_raster:
         input: 
             natura="data/bundle/natura/Natura2000_end2015.shp",

--- a/Snakefile
+++ b/Snakefile
@@ -24,7 +24,7 @@ rule solve_all_elec_networks:
         expand("results/networks/elec_s{simpl}_{clusters}_l{ll}_{opts}.nc",
                **config['scenario'])
 
-if config['enable']['prepare_links_p_nom']:
+if config['enable'].get('prepare_links_p_nom', false):
     rule prepare_links_p_nom:
         output: 'data/links_p_nom.csv'
         threads: 1
@@ -40,10 +40,10 @@ datafiles = ['ch_cantons.csv', 'je-e-21.03.02.xls',
             'nama_10r_3gdp.tsv.gz', 'time_series_60min_singleindex_filtered.csv', 
             'corine/g250_clc06_V18_5.tif']
 
-if not config['tutorial']:
+if not config.get('tutorial', false):
     datafiles.extend(["natura/Natura2000_end2015.shp", "GEBCO_2014_2D.nc"])
 
-if config['enable']['retrieve_databundle']:
+if config['enable'].get('retrieve_databundle', true):
     rule retrieve_databundle:
         output:  expand('data/bundle/{file}', file=datafiles)
         script: 'scripts/retrieve_databundle.py'
@@ -109,7 +109,7 @@ rule build_bus_regions:
     # group: 'nonfeedin_preparation'
     script: "scripts/build_bus_regions.py"
 
-if config['enable']['build_cutout']:        
+if config['enable'].get('build_cutout', false):        
     rule build_cutout:
         output: directory("cutouts/{cutout}")
         resources: mem=config['atlite'].get('nprocesses', 4) * 1000
@@ -123,7 +123,7 @@ else:
         script: 'scripts/retrieve_cutout.py'
 
 
-if config['enable']['build_natura_raster']:        
+if config['enable'].get('build_natura_raster', false):        
     rule build_natura_raster:
         input: 
             natura="data/bundle/natura/Natura2000_end2015.shp",

--- a/Snakefile
+++ b/Snakefile
@@ -39,12 +39,14 @@ datafiles = ['ch_cantons.csv', 'je-e-21.03.02.xls',
             'NUTS_2013_60M_SH/data/NUTS_RG_60M_2013.shp', 'nama_10r_3popgdp.tsv.gz', 
             'nama_10r_3gdp.tsv.gz', 'time_series_60min_singleindex_filtered.csv', 
             'corine/g250_clc06_V18_5.tif']
+
 if not config['tutorial']:
     datafiles.extend(["natura/Natura2000_end2015.shp", "GEBCO_2014_2D.nc"])
 
-rule retrieve_databundle:
-    output:  expand('data/bundle/{file}', file=datafiles)
-    script: 'scripts/retrieve_databundle.py'
+if config['enable']['retrieve_databundle']:
+    rule retrieve_databundle:
+        output:  expand('data/bundle/{file}', file=datafiles)
+        script: 'scripts/retrieve_databundle.py'
 
 rule build_powerplants:
     input:

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -22,6 +22,7 @@ enable:
   prepare_links_p_nom: false
   build_cutout: false
   build_natura_raster: false
+  retrieve_databundle: enable # enable: to retrieve databundle from zenodo; false: to use own databundle
 
 electricity:
   voltages: [220., 300., 380.]

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -20,9 +20,9 @@ snapshots:
 
 enable:
   prepare_links_p_nom: false
+  retrieve_databundle: true
   build_cutout: false
   build_natura_raster: false
-  retrieve_databundle: enable # enable: to retrieve databundle from zenodo; false: to use own databundle
 
 electricity:
   voltages: [220., 300., 380.]

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -334,4 +334,4 @@ plotting:
     H2: "Hydrogen\nStorage"
     lines: "Transmission\nlines"
     ror: "Run of\nriver"
-    
+

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -20,6 +20,7 @@ snapshots:
 
 enable:
   prepare_links_p_nom: false
+  retrieve_databundle: true
   build_cutout: false
   build_natura_raster: false
 

--- a/doc/configtables/toplevel.csv
+++ b/doc/configtables/toplevel.csv
@@ -7,5 +7,6 @@ countries,--,"Subset of {'AL', 'AT', 'BA', 'BE', 'BG', 'CH', 'CZ', 'DE', 'DK', '
 focus_weights,--,"Keys should be two-digit country codes (e.g. DE) and values should range between 0 and 1","Ratio of total clusters for particular countries. the remaining weight is distributed according to mean load. An example: ``focus_weights: DE: 0.6 FR: 0.2``."
 enable,,,
 -- prepare_links_p_nom,bool,"{true, false}","Switch to retrieve current HVDC projects from `Wikipedia <https://en.wikipedia.org/wiki/List_of_HVDC_projects>`_"
+-- retrieve_databundle,bool,"{true, false}","Switch to retrieve databundle from zenodo via the rule :mod:`retrieve_databundle` or whether to keep a custom databundle located in the corresponding folder.
 -- build_cutout,bool,"{true, false}","Switch to build cutouts via the rule :mod:`build_cutout` or whether to retrieve the data from zenodo with :mod:`retrieve_cutout`."
 -- build_natura_raster,bool,"{true, false}","Switch to create raster ``natura.tiff`` via the rule :mod:`build_natura_raster` or whether to retrieve ``natura.tiff`` from zenodo with :mod:`retrieve_natura_raster`."

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -20,6 +20,7 @@ snapshots:
 
 enable:
   prepare_links_p_nom: false
+  retrieve_databundle: true
   build_cutout: false
   build_natura_raster: false
   


### PR DESCRIPTION
add and option to use own databundles in `config.yaml`

```
enable:
  prepare_links_p_nom: false
  build_cutout: false
  build_natura_raster: false
  retrieve_databundle: enable # enable: to retrieve databundle from zenodo; false: to use own databundle
```
