### PR TITLE
add option for nuclear expansion at current locations

### DIFF
--- a/doc/configtables/electricity.csv
+++ b/doc/configtables/electricity.csv
@@ -4,7 +4,7 @@ co2limit,:math:`t_{CO_2-eq}/a`,float,"Cap on total annual system carbon dioxide 
 co2base,:math:`t_{CO_2-eq}/a`,float,"Reference value of total annual system carbon dioxide emissions if relative emission reduction target is specified in ``{opts}`` wildcard."
 agg_p_nom_limits,--,file path,"Reference to ``.csv`` file specifying per carrier generator nominal capacity constraints for individual countries if ``'CCL'`` is in ``{opts}`` wildcard. Defaults to ``data/agg_p_nom_minmax.csv``."
 extendable_carriers,,,
--- Generator,--,"Any subset  of {'OCGT','CCGT'}","Places extendable conventional power plants (OCGT and/or CCGT) where gas power plants are located today without capacity limits."
+-- Generator,--,"Any subset  of {'OCGT','CCGT', 'nuclear'}","Places extendable conventional power plants (OCGT, CCGT and/or nuclear) where such power plants are located today without capacity limits."
 -- StorageUnit,--,"Any subset of {'battery','H2'}","Places extendable storage units (battery and/or hydrogen) at every node/bus without capacity limits."
 max_hours,,,
 -- battery,h,float,"Maximum state of charge capacity of the battery in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_."

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -463,10 +463,23 @@ def attach_extendable_generators(n, costs, ppl):
                    capital_cost=costs.at['CCGT', 'capital_cost'],
                    marginal_cost=costs.at['CCGT', 'marginal_cost'],
                    efficiency=costs.at['CCGT', 'efficiency'])
+
+        elif suptech == 'nuclear':
+            nuclear = ppl.query("carrier == 'nuclear'").groupby('bus', as_index=False).first()
+            n.madd('Generator', nuclear.index,
+                suffix=' nuclear',
+                bus=nuclear['bus'],
+                carrier=tech,
+                p_nom_extendable=True,
+                p_nom=0.,
+                capital_cost=costs.at['nuclear', 'capital_cost'],
+                marginal_cost=costs.at['nuclear', 'marginal_cost'],
+                efficiency=costs.at['nuclear', 'efficiency'])
+
         else:
             raise NotImplementedError(f"Adding extendable generators for carrier "
                                       "'{tech}' is not implemented, yet. "
-                                      "Only OCGT and CCGT are allowed at the moment.")
+                                      "Only OCGT, CCGT and nuclear are allowed at the moment.")
 
 
 def attach_storage(n, costs):


### PR DESCRIPTION
Similar to OCGT and CCGT capacity expansion, this PR adds nuclear power plant expansion options where nuclear power plants are currently existing.

I am, of course, aware of the controversy, but adding this option might actually avert criticism of the model by some people.

The necessary cost assumptions are already included in the costs.csv file.