### PR TITLE
Add logging to logfiles to all snakemake workflow scripts.

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -363,7 +363,7 @@ def input_plot_p_nom_max(wildcards):
 rule plot_p_nom_max:
     input: input_plot_p_nom_max
     output: "results/plots/{network}_s{simpl}_cum_p_nom_max_{clusters}_{technology}_{country}.{ext}"
-    log: "logs/plot_p_nom_max/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_{country}.log"
+    log: "logs/plot_p_nom_max/{network}_s{simpl}_{clusters}_{technology}_{country}_{ext}.log"
     script: "scripts/plot_p_nom_max.py"
 
 rule build_country_flh:

--- a/Snakefile
+++ b/Snakefile
@@ -347,7 +347,7 @@ def input_make_summary(w):
 rule make_summary:
     input: input_make_summary
     output: directory("results/summaries/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_{country}")
-    log: 'logs/make_summary/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_{country}.log",
+    log: "logs/make_summary/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_{country}.log",
     script: "scripts/make_summary.py"
 
 rule plot_summary:

--- a/Snakefile
+++ b/Snakefile
@@ -326,7 +326,7 @@ rule plot_network:
     output:
         only_map="results/plots/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_{attr}.{ext}",
         ext="results/plots/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_{attr}_ext.{ext}"
-    log: "logs/plot_network/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.log"
+    log: "logs/plot_network/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_{attr}_{ext}.log"
     script: "scripts/plot_network.py"
 
 def input_make_summary(w):
@@ -353,7 +353,7 @@ rule make_summary:
 rule plot_summary:
     input: "results/summaries/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_{country}"
     output: "results/plots/summary_{summary}_{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_{country}.{ext}"
-    log: "logs/plot_summary/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_{country}.log"
+    log: "logs/plot_summary/{summary}_{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_{country}_{ext}.log"
     script: "scripts/plot_summary.py"
 
 def input_plot_p_nom_max(wildcards):

--- a/Snakefile
+++ b/Snakefile
@@ -48,6 +48,7 @@ if not config.get('tutorial', False):
 if config['enable'].get('retrieve_databundle', True):
     rule retrieve_databundle:
         output:  expand('data/bundle/{file}', file=datafiles)
+        log: "logs/retrieve_databundle.log"
         script: 'scripts/retrieve_databundle.py'
 
 rule build_powerplants:

--- a/Snakefile
+++ b/Snakefile
@@ -29,6 +29,7 @@ rule solve_all_elec_networks:
 if config['enable'].get('prepare_links_p_nom', False):
     rule prepare_links_p_nom:
         output: 'data/links_p_nom.csv'
+        log: 'logs/prepare_links_p_nom.log'
         threads: 1
         resources: mem=500
         # group: 'nonfeedin_preparation'

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -1,6 +1,7 @@
 version: 0.1
 tutorial: false
 logging_level: INFO
+logging_format: '%(levelname)s:%(name)s:%(message)s' # Custom format for log messages, see logging's LogRecord attributes
 
 summary_dir: results
 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -1,7 +1,9 @@
 version: 0.1
 tutorial: false
-logging_level: INFO
-logging_format: '%(levelname)s:%(name)s:%(message)s'
+
+logging:
+  level: INFO
+  format: '%(levelname)s:%(name)s:%(message)s'
 
 summary_dir: results
 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -1,7 +1,7 @@
 version: 0.1
 tutorial: false
 logging_level: INFO
-logging_format: '%(levelname)s:%(name)s:%(message)s' # Custom format for log messages, see logging's LogRecord attributes
+logging_format: '%(levelname)s:%(name)s:%(message)s'
 
 summary_dir: results
 

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -1,6 +1,7 @@
 version: 0.1
 tutorial: true
 logging_level: INFO
+logging_format: '%(levelname)s:%(name)s:%(message)s'
 
 summary_dir: results
 

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -1,7 +1,8 @@
 version: 0.1
 tutorial: true
-logging_level: INFO
-logging_format: '%(levelname)s:%(name)s:%(message)s'
+logging:
+  level: INFO
+  format: '%(levelname)s:%(name)s:%(message)s'
 
 summary_dir: results
 

--- a/doc/configtables/toplevel.csv
+++ b/doc/configtables/toplevel.csv
@@ -2,6 +2,7 @@
 version,--,0.1,"Version of PyPSA-Eur"
 tutorial,bool,"{true, false}","Switch to retrieve the tutorial data set instead of the full data set."
 logging_level,--,"Any of {'INFO', 'WARNING', 'ERROR'}","Restrict console outputs to all infos, warning or errors only"
+logging_format,--,"e.g. ``%(levelname)s:%(name)s:%(message)s``","Custom format for log messages. See `LogRecord <https://docs.python.org/3/library/logging.html#logging.LogRecord`_ attributes."
 summary_dir,--,"e.g. 'results'","Directory into which results are written."
 countries,--,"Subset of {'AL', 'AT', 'BA', 'BE', 'BG', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'GR', 'HR', 'HU', 'IE', 'IT', 'LT', 'LU', 'LV', 'ME', 'MK', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'SE', 'SI', 'SK'}","European countries defined by their `Two-letter country codes (ISO 3166-1) <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>`_ which should be included in the energy system model."
 focus_weights,--,"Keys should be two-digit country codes (e.g. DE) and values should range between 0 and 1","Ratio of total clusters for particular countries. the remaining weight is distributed according to mean load. An example: ``focus_weights: DE: 0.6 FR: 0.2``."

--- a/doc/configtables/toplevel.csv
+++ b/doc/configtables/toplevel.csv
@@ -1,8 +1,9 @@
 ,Unit,Values,Description
 version,--,0.1,"Version of PyPSA-Eur"
 tutorial,bool,"{true, false}","Switch to retrieve the tutorial data set instead of the full data set."
-logging_level,--,"Any of {'INFO', 'WARNING', 'ERROR'}","Restrict console outputs to all infos, warning or errors only"
-logging_format,--,"e.g. ``%(levelname)s:%(name)s:%(message)s``","Custom format for log messages. See `LogRecord <https://docs.python.org/3/library/logging.html#logging.LogRecord`_ attributes."
+logging,,,
+-- level,--,"Any of {'INFO', 'WARNING', 'ERROR'}","Restrict console outputs to all infos, warning or errors only"
+-- format,--,"e.g. ``%(levelname)s:%(name)s:%(message)s``","Custom format for log messages. See `LogRecord <https://docs.python.org/3/library/logging.html#logging.LogRecord`_ attributes."
 summary_dir,--,"e.g. 'results'","Directory into which results are written."
 countries,--,"Subset of {'AL', 'AT', 'BA', 'BE', 'BG', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'GR', 'HR', 'HU', 'IE', 'IT', 'LT', 'LU', 'LV', 'ME', 'MK', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'SE', 'SI', 'SK'}","European countries defined by their `Two-letter country codes (ISO 3166-1) <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>`_ which should be included in the energy system model."
 focus_weights,--,"Keys should be two-digit country codes (e.g. DE) and values should range between 0 and 1","Ratio of total clusters for particular countries. the remaining weight is distributed according to mean load. An example: ``focus_weights: DE: 0.6 FR: 0.2``."

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -37,7 +37,7 @@ facilitate running multiple scenarios through a single command
     
     snakemake solve_all_elec_networks
 
-For each wildcard, a **list of values** is provided. The rule ``solve_all_elec_networks`` will trigger the rules for creating ``results/networks/elec_s{simpl}_{clusters}_l{ll}_{opts}.nc`` for **all combinations** of the provided wildcard values as defined by Python's `itertools.product(...) <https://docs.python.org/2/library/itertools.html#itertools.product>`_ function that snakemake's `expand(...) function <https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#targets>`_ uses.
+For each wildcard, a **list of values** is provided. The rule ``solve_all_elec_networks`` will trigger the rules for creating ``results/networks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc`` for **all combinations** of the provided wildcard values as defined by Python's `itertools.product(...) <https://docs.python.org/2/library/itertools.html#itertools.product>`_ function that snakemake's `expand(...) function <https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#targets>`_ uses.
 
 An exemplary dependency graph (starting from the simplification rules) then looks like this:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -13,7 +13,7 @@ Top-level configuration
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 1-6,14
+   :lines: 1-7,15
 
 .. csv-table::
    :header-rows: 1
@@ -45,7 +45,7 @@ An exemplary dependency graph (starting from the simplification rules) then look
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 7-12
+   :lines: 8-13
 
 .. csv-table::
    :header-rows: 1
@@ -61,7 +61,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 16-19
+   :lines: 17-20
 
 .. csv-table::
    :header-rows: 1
@@ -75,7 +75,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 26-42
+   :lines: 28-45
 
 .. csv-table::
    :header-rows: 1
@@ -92,7 +92,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 50-63
+   :lines: 53-66
 
 .. csv-table::
    :header-rows: 1
@@ -109,7 +109,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 65-82
+   :lines: 68-85
 
 .. csv-table::
    :header-rows: 1
@@ -121,7 +121,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 65,83-95
+   :lines: 68,86-98
 
 .. csv-table::
    :header-rows: 1
@@ -133,7 +133,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 65,96-109
+   :lines: 68,99-112
 
 .. csv-table::
    :header-rows: 1
@@ -145,7 +145,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 65,110-129
+   :lines: 68,113-132
 
 .. csv-table::
    :header-rows: 1
@@ -157,7 +157,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 65,130-136
+   :lines: 68,133-139
 
 .. csv-table::
    :header-rows: 1
@@ -171,7 +171,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 138-145
+   :lines: 131-148
 
 .. csv-table::
    :header-rows: 1
@@ -185,7 +185,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 147-150
+   :lines: 150-153
 
 .. csv-table::
    :header-rows: 1
@@ -199,7 +199,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 152-155
+   :lines: 155-158
 
 .. csv-table::
    :header-rows: 1
@@ -213,7 +213,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 157-158
+   :lines: 160-161
 
 .. csv-table::
    :header-rows: 1
@@ -227,7 +227,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 160-172
+   :lines: 163-175
 
 .. csv-table::
    :header-rows: 1
@@ -249,7 +249,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 174-182
+   :lines: 177-185
 
 .. csv-table::
    :header-rows: 1
@@ -261,7 +261,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 174,183-199
+   :lines: 177,186-202
 
 .. csv-table::
    :header-rows: 1
@@ -275,7 +275,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 201-335
+   :lines: 204-338
 
 .. csv-table::
    :header-rows: 1

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -13,7 +13,7 @@ Top-level configuration
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 1-7,15
+   :lines: 1-8,17
 
 .. csv-table::
    :header-rows: 1
@@ -45,7 +45,7 @@ An exemplary dependency graph (starting from the simplification rules) then look
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 8-13
+   :lines: 10-15
 
 .. csv-table::
    :header-rows: 1
@@ -61,7 +61,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 17-20
+   :lines: 19-22
 
 .. csv-table::
    :header-rows: 1
@@ -75,7 +75,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 28-45
+   :lines: 30-47
 
 .. csv-table::
    :header-rows: 1
@@ -92,7 +92,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 53-66
+   :lines: 55-68
 
 .. csv-table::
    :header-rows: 1
@@ -109,7 +109,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 68-85
+   :lines: 70-87
 
 .. csv-table::
    :header-rows: 1
@@ -121,7 +121,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 68,86-98
+   :lines: 70,88-100
 
 .. csv-table::
    :header-rows: 1
@@ -133,7 +133,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 68,99-112
+   :lines: 70,101-114
 
 .. csv-table::
    :header-rows: 1
@@ -145,7 +145,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 68,113-132
+   :lines: 70,115-134
 
 .. csv-table::
    :header-rows: 1
@@ -157,7 +157,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 68,133-139
+   :lines: 70,135-141
 
 .. csv-table::
    :header-rows: 1
@@ -171,7 +171,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 131-148
+   :lines: 133-150
 
 .. csv-table::
    :header-rows: 1
@@ -185,7 +185,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 150-153
+   :lines: 152-155
 
 .. csv-table::
    :header-rows: 1
@@ -199,7 +199,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 155-158
+   :lines: 157-160
 
 .. csv-table::
    :header-rows: 1
@@ -213,7 +213,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 160-161
+   :lines: 162-163
 
 .. csv-table::
    :header-rows: 1
@@ -227,7 +227,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 163-175
+   :lines: 165-177
 
 .. csv-table::
    :header-rows: 1
@@ -249,7 +249,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 177-185
+   :lines: 179-187
 
 .. csv-table::
    :header-rows: 1
@@ -261,7 +261,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 177,186-202
+   :lines: 179,188-204
 
 .. csv-table::
    :header-rows: 1
@@ -275,7 +275,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 204-338
+   :lines: 206-340
 
 .. csv-table::
    :header-rows: 1

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -38,47 +38,47 @@ The model can be adapted to only include selected countries (e.g. Germany) inste
 
 .. literalinclude:: ../config.tutorial.yaml
    :language: yaml
-   :lines: 14
+   :lines: 15
    
 Likewise, the example's temporal scope can be restricted (e.g. to a single month).
 
 .. literalinclude:: ../config.tutorial.yaml
    :language: yaml
-   :lines: 16-19
+   :lines: 17-20
 
 It is also possible to allow less or more carbon-dioxide emissions. Here, we limit the emissions of Germany 100 Megatonnes per year.
 
 .. literalinclude:: ../config.tutorial.yaml
    :language: yaml
-   :lines: 28
+   :lines: 30
 
 PyPSA-Eur also includes a database of existing conventional powerplants.
 We can select which types of powerplants we like to be included with fixed capacities:
 
 .. literalinclude:: ../config.tutorial.yaml
    :language: yaml
-   :lines: 40
+   :lines: 43
 
 To accurately model the temporal and spatial availability of renewables such as wind and solar energy, we rely on historical weather data.
 It is advisable to adapt the required range of coordinates to the selection of countries.
 
 .. literalinclude:: ../config.tutorial.yaml
    :language: yaml
-   :lines: 42-50
+   :lines: 45-53
 
 We can also decide which weather data source should be used to calculate potentials and capacity factor time-series for each carrier.
 For example, we may want to use the ERA-5 dataset for solar and not the default SARAH-2 dataset.
 
 .. literalinclude:: ../config.tutorial.yaml
    :language: yaml
-   :lines: 52,95-96
+   :lines: 55,98-99
 
 Finally, it is possible to pick a solver. For instance, this tutorial uses the open-source solvers CBC and Ipopt and does not rely
 on the commercial solvers Gurobi or CPLEX (for which free academic licenses are available).
 
 .. literalinclude:: ../config.tutorial.yaml
    :language: yaml
-   :lines: 151,160-161
+   :lines: 154,163-164
 
 .. note::
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -110,8 +110,8 @@ orders ``snakemake`` to run the script ``solve_network`` that produces the solve
 .. code::
 
     rule solve_network:
-        input: "networks/{network}_s{simpl}_{clusters}_l{ll}_{opts}.nc"
-        output: "results/networks/{network}_s{simpl}_{clusters}_l{ll}_{opts}.nc"
+        input: "networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc"
+        output: "results/networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc"
         [...]
         script: "scripts/solve_network.py"
 

--- a/environment.docs.yaml
+++ b/environment.docs.yaml
@@ -17,7 +17,7 @@ dependencies:
   - memory_profiler
   - yaml
   - pytables
-  - powerplantmatching>=0.4.2
+  - powerplantmatching>=0.4.3
 
   # Second order dependencies which should really be deps of atlite
   - xarray

--- a/environment.yaml
+++ b/environment.yaml
@@ -18,7 +18,7 @@ dependencies:
   - memory_profiler
   - yaml
   - pytables
-  - powerplantmatching>=0.4.2
+  - powerplantmatching>=0.4.3
 
   # Second order dependencies which should really be deps of atlite
   - xarray

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1,10 +1,6 @@
 import pandas as pd
-from six import iterkeys, itervalues
-import urllib
 
-import pypsa
-
-def configure_logging(logging, snakemake, skip_handlers=False):
+def configure_logging(snakemake, skip_handlers=False):
     """
     Configure the basic behaviour for the logging module.
 
@@ -17,13 +13,13 @@ def configure_logging(logging, snakemake, skip_handlers=False):
 
     Parameters
     ----------
-    logging : module
-        The logging module imported.
     snakemake : snakemake object
         Your snakemake object containing a snakemake.config and snakemake.log.
     skip_handlers : True | False (default)
         Do (not) skip the default handlers created for redirecting output to STDERR and file.
     """
+
+    import logging
 
     kwargs = snakemake.config.get('logging', dict())
     kwargs.setdefault("level", "INFO")
@@ -44,6 +40,7 @@ def pdbcast(v, h):
                         index=v.index, columns=h.index)
 
 def load_network(fn, tech_costs, config, combine_hydro_ps=True):
+    import pypsa
     from add_electricity import update_transmission_costs, load_costs
 
     opts = config['plotting']
@@ -107,6 +104,8 @@ def aggregate_p_curtailed(n):
     ])
 
 def aggregate_costs(n, flatten=False, opts=None, existing_only=False):
+    from six import iterkeys, itervalues
+    
     components = dict(Link=("p_nom", "p0"),
                       Generator=("p_nom", "p"),
                       StorageUnit=("p_nom", "p"),
@@ -141,6 +140,7 @@ def aggregate_costs(n, flatten=False, opts=None, existing_only=False):
     return costs
 
 def progress_retrieve(url, file):
+    import urllib
     from progressbar import ProgressBar
 
     pbar = ProgressBar(0, 100)

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1,7 +1,6 @@
 import pandas as pd
 from six import iterkeys, itervalues
 import urllib
-from progressbar import ProgressBar
 
 import pypsa
 
@@ -107,6 +106,8 @@ def aggregate_costs(n, flatten=False, opts=None, existing_only=False):
     return costs
 
 def progress_retrieve(url, file):
+    from progressbar import ProgressBar
+
     pbar = ProgressBar(0, 100)
 
     def dlProgress(count, blockSize, totalSize):

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -524,7 +524,7 @@ if __name__ == "__main__":
                     for t in snakemake.config['renewable']})
         )
 
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.base_network)
     Nyears = n.snapshot_weightings.sum()/8760.

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -522,7 +522,8 @@ if __name__ == "__main__":
                     for t in snakemake.config['renewable']})
         )
 
-    logging.basicConfig(level=snakemake.config['logging_level'])
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
 
     n = pypsa.Network(snakemake.input.base_network)
     Nyears = n.snapshot_weightings.sum()/8760.

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -522,7 +522,9 @@ if __name__ == "__main__":
                     for t in snakemake.config['renewable']})
         )
 
-    logging.basicConfig(filename=snakemake.log,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     n = pypsa.Network(snakemake.input.base_network)

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -91,6 +91,9 @@ from vresutils.load import timeseries_opsd
 from vresutils import transfer as vtransfer
 
 import logging
+logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
 import pandas as pd
 import numpy as np
 import xarray as xr
@@ -99,7 +102,6 @@ import pypsa
 import powerplantmatching as ppm
 
 idx = pd.IndexSlice
-logger = logging.getLogger(__name__)
 
 
 def normed(s): return s/s.sum()
@@ -522,10 +524,7 @@ if __name__ == "__main__":
                     for t in snakemake.config['renewable']})
         )
 
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    configure_logging(logging, snakemake)
 
     n = pypsa.Network(snakemake.input.base_network)
     Nyears = n.snapshot_weightings.sum()/8760.

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -150,7 +150,8 @@ if __name__ == "__main__":
             Dict(network='networks/elec_s_5.nc',
                  tech_costs='data/costs.csv'))
 
-    logging.basicConfig(level=snakemake.config['logging_level'])
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
 
     n = pypsa.Network(snakemake.input.network)
     Nyears = n.snapshot_weightings.sum()/8760.

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -150,7 +150,7 @@ if __name__ == "__main__":
             Dict(network='networks/elec_s_5.nc',
                  tech_costs='data/costs.csv'))
 
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)
     Nyears = n.snapshot_weightings.sum()/8760.

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -45,16 +45,16 @@ The rule :mod:`add_extra_components` attaches additional extendable components t
 
 - ``Stores`` of carrier 'H2' and/or 'battery' in combination with ``Links``. If this option is chosen, the script adds extra buses with corresponding carrier where energy ``Stores`` are attached and which are connected to the corresponding power buses via two links, one each for charging and discharging. This leads to three investment variables for the energy capacity, charging and discharging capacity of the storage unit.
 """
-
 import logging
+logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
 import pandas as pd
 import pypsa
 from add_electricity import (load_costs, normed, add_nice_carrier_names,
                              _add_missing_carriers_from_costs)
 
 idx = pd.IndexSlice
-logger = logging.getLogger(__name__)
-
 
 def attach_storageunits(n, costs):
     elec_opts = snakemake.config['electricity']
@@ -150,10 +150,7 @@ if __name__ == "__main__":
             Dict(network='networks/elec_s_5.nc',
                  tech_costs='data/costs.csv'))
 
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    configure_logging(logging, snakemake)
 
     n = pypsa.Network(snakemake.input.network)
     Nyears = n.snapshot_weightings.sum()/8760.

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -150,7 +150,9 @@ if __name__ == "__main__":
             Dict(network='networks/elec_s_5.nc',
                  tech_costs='data/costs.csv'))
 
-    logging.basicConfig(filename=snakemake.log,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     n = pypsa.Network(snakemake.input.network)

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -58,6 +58,10 @@ Description
 
 """
 
+import logging
+logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
 import yaml
 import pandas as pd
 import geopandas as gpd
@@ -71,9 +75,6 @@ from shapely.geometry import Point, LineString
 import shapely, shapely.prepared, shapely.wkt
 
 import networkx as nx
-
-import logging
-logger = logging.getLogger(__name__)
 
 import pypsa
 
@@ -569,10 +570,7 @@ if __name__ == "__main__":
             output = ['networks/base.nc']
         )
 
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    configure_logging(logging, snakemake)
 
     n = base_network()
     n.export_to_netcdf(snakemake.output[0])

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -570,7 +570,7 @@ if __name__ == "__main__":
             output = ['networks/base.nc']
         )
 
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     n = base_network()
     n.export_to_netcdf(snakemake.output[0])

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -568,8 +568,8 @@ if __name__ == "__main__":
             ),
             output = ['networks/base.nc']
         )
-
-    logging.basicConfig(level=snakemake.config['logging_level'])
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
 
     n = base_network()
     n.export_to_netcdf(snakemake.output[0])

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -568,7 +568,10 @@ if __name__ == "__main__":
             ),
             output = ['networks/base.nc']
         )
-    logging.basicConfig(filename=snakemake.log,
+
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     n = base_network()

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -43,12 +43,14 @@ import os
 import pandas as pd
 import geopandas as gpd
 
-
 import pypsa
+
 import logging
+logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
-    logging.basicConfig(level=snakemake.config["logging_level"])
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])    
 
     countries = snakemake.config['countries']
 

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -49,8 +49,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
-    logging.basicConfig(filename=snakemake.log,
-                        level=snakemake.config['logging_level'])    
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
+                        level=snakemake.config['logging_level'])
 
     countries = snakemake.config['countries']
 

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -36,6 +36,11 @@ Description
 -----------
 
 """
+
+import logging
+logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
 from vresutils.graph import voronoi_partition_pts
 
 import os
@@ -45,14 +50,8 @@ import geopandas as gpd
 
 import pypsa
 
-import logging
-logger = logging.getLogger(__name__)
-
 if __name__ == "__main__":
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    configure_logging(logging, snakemake)
 
     countries = snakemake.config['countries']
 

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -51,7 +51,7 @@ import geopandas as gpd
 import pypsa
 
 if __name__ == "__main__":
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     countries = snakemake.config['countries']
 

--- a/scripts/build_country_flh.py
+++ b/scripts/build_country_flh.py
@@ -57,6 +57,10 @@ Description
 
 """
 
+import logging
+logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
 import os
 import atlite
 import numpy as np
@@ -72,8 +76,6 @@ from vresutils import landuse as vlanduse
 from vresutils.array import spdiag
 
 import progressbar as pgb
-import logging
-logger = logging.getLogger(__name__)
 
 from build_renewable_profiles import init_globals, calculate_potential
 
@@ -175,10 +177,8 @@ if __name__ == '__main__':
                                                  snakemake.config["renewable"][snakemake.wildcards.technology]['cutout'])
 
     pgb.streams.wrap_stderr()
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+
+    configure_logging(logging, snakemake)
 
     config = snakemake.config['renewable'][snakemake.wildcards.technology]
 

--- a/scripts/build_country_flh.py
+++ b/scripts/build_country_flh.py
@@ -178,7 +178,7 @@ if __name__ == '__main__':
 
     pgb.streams.wrap_stderr()
 
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     config = snakemake.config['renewable'][snakemake.wildcards.technology]
 

--- a/scripts/build_country_flh.py
+++ b/scripts/build_country_flh.py
@@ -175,7 +175,8 @@ if __name__ == '__main__':
                                                  snakemake.config["renewable"][snakemake.wildcards.technology]['cutout'])
 
     pgb.streams.wrap_stderr()
-    logging.basicConfig(level=snakemake.config['logging_level'])
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])    
 
     config = snakemake.config['renewable'][snakemake.wildcards.technology]
 

--- a/scripts/build_country_flh.py
+++ b/scripts/build_country_flh.py
@@ -175,8 +175,10 @@ if __name__ == '__main__':
                                                  snakemake.config["renewable"][snakemake.wildcards.technology]['cutout'])
 
     pgb.streams.wrap_stderr()
-    logging.basicConfig(filename=snakemake.log,
-                        level=snakemake.config['logging_level'])    
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
+                        level=snakemake.config['logging_level'])
 
     config = snakemake.config['renewable'][snakemake.wildcards.technology]
 

--- a/scripts/build_cutout.py
+++ b/scripts/build_cutout.py
@@ -86,16 +86,16 @@ Description
 -----------
 
 """
-import os
-import atlite
+
 import logging
 logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
+import os
+import atlite
 
 if __name__ == "__main__":
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    configure_logging(logging, snakemake)
 
     cutout_params = snakemake.config['atlite']['cutouts'][snakemake.wildcards.cutout]
     for p in ('xs', 'ys', 'years', 'months'):

--- a/scripts/build_cutout.py
+++ b/scripts/build_cutout.py
@@ -92,7 +92,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
-    logging.basicConfig(filename=snakemake.log,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     cutout_params = snakemake.config['atlite']['cutouts'][snakemake.wildcards.cutout]

--- a/scripts/build_cutout.py
+++ b/scripts/build_cutout.py
@@ -92,7 +92,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
-    logging.basicConfig(level=snakemake.config['logging_level'])
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
 
     cutout_params = snakemake.config['atlite']['cutouts'][snakemake.wildcards.cutout]
     for p in ('xs', 'ys', 'years', 'months'):

--- a/scripts/build_cutout.py
+++ b/scripts/build_cutout.py
@@ -95,7 +95,7 @@ import os
 import atlite
 
 if __name__ == "__main__":
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     cutout_params = snakemake.config['atlite']['cutouts'][snakemake.wildcards.cutout]
     for p in ('xs', 'ys', 'years', 'months'):

--- a/scripts/build_hydro_profile.py
+++ b/scripts/build_hydro_profile.py
@@ -62,7 +62,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
-    logging.basicConfig(filename=snakemake.log,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     config = snakemake.config['renewable']['hydro']

--- a/scripts/build_hydro_profile.py
+++ b/scripts/build_hydro_profile.py
@@ -59,10 +59,11 @@ import atlite
 import geopandas as gpd
 from vresutils import hydro as vhydro
 import logging
-
+logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
-    logging.basicConfig(level=snakemake.config['logging_level'])
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
 
     config = snakemake.config['renewable']['hydro']
     cutout = atlite.Cutout(config['cutout'],

--- a/scripts/build_hydro_profile.py
+++ b/scripts/build_hydro_profile.py
@@ -64,7 +64,7 @@ import geopandas as gpd
 from vresutils import hydro as vhydro
 
 if __name__ == "__main__":
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
     
     config = snakemake.config['renewable']['hydro']
     cutout = atlite.Cutout(config['cutout'],

--- a/scripts/build_hydro_profile.py
+++ b/scripts/build_hydro_profile.py
@@ -54,19 +54,18 @@ Description
     :mod:`build_renewable_profiles`
 """
 
+import logging
+logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
 import os
 import atlite
 import geopandas as gpd
 from vresutils import hydro as vhydro
-import logging
-logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
-
+    configure_logging(logging, snakemake)
+    
     config = snakemake.config['renewable']['hydro']
     cutout = atlite.Cutout(config['cutout'],
                         cutout_dir=os.path.dirname(snakemake.input.cutout))

--- a/scripts/build_natura_raster.py
+++ b/scripts/build_natura_raster.py
@@ -35,12 +35,13 @@ Description
 
 """
 
+import logging
+logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
 import numpy as np
 import atlite
 import geokit as gk
-
-import logging
-logger = logging.getLogger(__name__)
 
 def determine_cutout_xXyY(cutout_name):
     cutout = atlite.Cutout(cutout_name, cutout_dir="cutouts")
@@ -50,10 +51,7 @@ def determine_cutout_xXyY(cutout_name):
     return [x - dx/2., X + dx/2., y - dy/2., Y + dy/2.]
 
 if __name__ == "__main__":
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    configure_logging(logging, snakemake)
 
     cutout_names = np.unique([res['cutout'] for res in snakemake.config['renewable'].values()])
     xs, Xs, ys, Ys = zip(*(determine_cutout_xXyY(cutout) for cutout in cutout_names))

--- a/scripts/build_natura_raster.py
+++ b/scripts/build_natura_raster.py
@@ -50,7 +50,9 @@ def determine_cutout_xXyY(cutout_name):
     return [x - dx/2., X + dx/2., y - dy/2., Y + dy/2.]
 
 if __name__ == "__main__":
-    logging.basicConfig(filename=snakemake.log,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     cutout_names = np.unique([res['cutout'] for res in snakemake.config['renewable'].values()])

--- a/scripts/build_natura_raster.py
+++ b/scripts/build_natura_raster.py
@@ -39,6 +39,9 @@ import numpy as np
 import atlite
 import geokit as gk
 
+import logging
+logger = logging.getLogger(__name__)
+
 def determine_cutout_xXyY(cutout_name):
     cutout = atlite.Cutout(cutout_name, cutout_dir="cutouts")
     x, X, y, Y = cutout.extent
@@ -47,6 +50,9 @@ def determine_cutout_xXyY(cutout_name):
     return [x - dx/2., X + dx/2., y - dy/2., Y + dy/2.]
 
 if __name__ == "__main__":
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
+
     cutout_names = np.unique([res['cutout'] for res in snakemake.config['renewable'].values()])
     xs, Xs, ys, Ys = zip(*(determine_cutout_xXyY(cutout) for cutout in cutout_names))
     xXyY = min(xs), max(Xs), min(ys), max(Ys)

--- a/scripts/build_natura_raster.py
+++ b/scripts/build_natura_raster.py
@@ -51,7 +51,7 @@ def determine_cutout_xXyY(cutout_name):
     return [x - dx/2., X + dx/2., y - dy/2., Y + dy/2.]
 
 if __name__ == "__main__":
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     cutout_names = np.unique([res['cutout'] for res in snakemake.config['renewable'].values()])
     xs, Xs, ys, Ys = zip(*(determine_cutout_xXyY(cutout) for cutout in cutout_names))

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -68,14 +68,14 @@ The configuration options ``electricity: powerplants_filter`` and ``electricity:
 """
 
 import logging
+logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
 from scipy.spatial import cKDTree as KDTree
 
 import pypsa
 import powerplantmatching as pm
 import pandas as pd
-
-logger = logging.getLogger(__name__)
-
 
 def add_custom_powerplants(ppl):
     custom_ppl_query = snakemake.config['electricity']['custom_powerplants']
@@ -88,6 +88,7 @@ def add_custom_powerplants(ppl):
 
 
 if __name__ == "__main__":
+
     if 'snakemake' not in globals():
         from vresutils.snakemake import MockSnakemake, Dict
 
@@ -97,10 +98,7 @@ if __name__ == "__main__":
             output=['resources/powerplants.csv']
         )
 
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    configure_logging(logging, snakemake)
 
     n = pypsa.Network(snakemake.input.base_network)
     countries = n.buses.country.unique()

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -97,7 +97,9 @@ if __name__ == "__main__":
             output=['resources/powerplants.csv']
         )
 
-    logging.basicConfig(filename=snakemake.log,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     n = pypsa.Network(snakemake.input.base_network)

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
             output=['resources/powerplants.csv']
         )
 
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.base_network)
     countries = n.buses.country.unique()

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -97,7 +97,8 @@ if __name__ == "__main__":
             output=['resources/powerplants.csv']
         )
 
-    logging.basicConfig(level=snakemake.config['logging_level'])
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
 
     n = pypsa.Network(snakemake.input.base_network)
     countries = n.buses.country.unique()

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -239,7 +239,9 @@ def calculate_potential(gid, save_map=None):
 
 if __name__ == '__main__':
     pgb.streams.wrap_stderr()
-    logging.basicConfig(filename=snakemake.log,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     config = snakemake.config['renewable'][snakemake.wildcards.technology]

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -239,7 +239,8 @@ def calculate_potential(gid, save_map=None):
 
 if __name__ == '__main__':
     pgb.streams.wrap_stderr()
-    logging.basicConfig(level=snakemake.config['logging_level'])
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
 
     config = snakemake.config['renewable'][snakemake.wildcards.technology]
 

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -241,7 +241,7 @@ def calculate_potential(gid, save_map=None):
 if __name__ == '__main__':
     pgb.streams.wrap_stderr()
 
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     config = snakemake.config['renewable'][snakemake.wildcards.technology]
 

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -150,6 +150,9 @@ node (`p_nom_max`): ``simple`` and ``conservative``:
   reached.
 
 """
+import logging
+logger = logging.getLogger(__name__)
+from _helpers import configure_logging
 
 import matplotlib.pyplot as plt
 
@@ -170,8 +173,6 @@ from vresutils import landuse as vlanduse
 from vresutils.array import spdiag
 
 import progressbar as pgb
-import logging
-logger = logging.getLogger(__name__)
 
 bounds = dx = dy = config = paths = gebco = clc = natura = None
 def init_globals(bounds_xXyY, n_dx, n_dy, n_config, n_paths):
@@ -239,10 +240,8 @@ def calculate_potential(gid, save_map=None):
 
 if __name__ == '__main__':
     pgb.streams.wrap_stderr()
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+
+    configure_logging(logging, snakemake)
 
     config = snakemake.config['renewable'][snakemake.wildcards.technology]
 

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -225,7 +225,7 @@ if __name__ == "__main__":
             )
         )
 
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     country_shapes = countries()
     save_to_geojson(country_shapes, snakemake.output.country_shapes)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -224,7 +224,9 @@ if __name__ == "__main__":
             )
         )
 
-    logging.basicConfig(filename=snakemake.log,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     country_shapes = countries()

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -76,6 +76,9 @@ from shapely.ops import cascaded_union
 
 import pycountry as pyc
 
+import logging
+logger = logging.getLogger(__name__)
+
 def _get_country(target, **keys):
     assert len(keys) == 1
     try:
@@ -220,6 +223,9 @@ if __name__ == "__main__":
                 nuts3_shapes='resources/nuts3_shapes.geojson'
             )
         )
+
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
 
     country_shapes = countries()
     save_to_geojson(country_shapes, snakemake.output.country_shapes)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -63,6 +63,10 @@ Description
 
 """
 
+import logging
+logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
 import os
 import numpy as np
 from operator import attrgetter
@@ -75,9 +79,6 @@ from shapely.geometry import MultiPolygon, Polygon
 from shapely.ops import cascaded_union
 
 import pycountry as pyc
-
-import logging
-logger = logging.getLogger(__name__)
 
 def _get_country(target, **keys):
     assert len(keys) == 1
@@ -224,10 +225,7 @@ if __name__ == "__main__":
             )
         )
 
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    configure_logging(logging, snakemake)
 
     country_shapes = countries()
     save_to_geojson(country_shapes, snakemake.output.country_shapes)

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -311,7 +311,9 @@ if __name__ == "__main__":
                 clustermaps='resources/clustermaps_{network}_s{simpl}_{clusters}.h5'
             )
         )
-    logging.basicConfig(filename=snakemake.log,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     n = pypsa.Network(snakemake.input.network)

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -313,7 +313,7 @@ if __name__ == "__main__":
             )
         )
  
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)
 

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -91,11 +91,12 @@ Description
 
 """
 
-import pandas as pd
-idx = pd.IndexSlice
-
 import logging
 logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
+import pandas as pd
+idx = pd.IndexSlice
 
 import os
 import numpy as np
@@ -311,10 +312,8 @@ if __name__ == "__main__":
                 clustermaps='resources/clustermaps_{network}_s{simpl}_{clusters}.h5'
             )
         )
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+ 
+    configure_logging(logging, snakemake)
 
     n = pypsa.Network(snakemake.input.network)
 

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -311,8 +311,8 @@ if __name__ == "__main__":
                 clustermaps='resources/clustermaps_{network}_s{simpl}_{clusters}.h5'
             )
         )
-
-    logging.basicConfig(level=snakemake.config['logging_level'])
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
 
     n = pypsa.Network(snakemake.input.network)
 

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -483,7 +483,7 @@ if __name__ == "__main__":
     else:
         ll = [snakemake.wildcards.ll]
 
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     networks_dict = {(simpl,clusters,l,opts) : ('results/networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc'
                                                  .format(network=snakemake.wildcards.network,

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -50,6 +50,9 @@ Replacing '/summaries/' with '/plots/' creates nice colored maps of the results.
 """
 
 import os
+import logging
+logger = logging.getLogger(__name__)
+
 from six import iteritems
 import pandas as pd
 
@@ -477,6 +480,9 @@ if __name__ == "__main__":
             ll = [l for l in ll if l[0] == snakemake.wildcards.ll[0]]
     else:
         ll = [snakemake.wildcards.ll]
+
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
 
     networks_dict = {(simpl,clusters,l,opts) : ('results/networks/{network}_s{simpl}_{clusters}_l{ll}_{opts}.nc'
                                                  .format(network=snakemake.wildcards.network,

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -49,9 +49,11 @@ Replacing '/summaries/' with '/plots/' creates nice colored maps of the results.
 
 """
 
-import os
 import logging
 logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
+import os
 
 from six import iteritems
 import pandas as pd
@@ -481,10 +483,7 @@ if __name__ == "__main__":
     else:
         ll = [snakemake.wildcards.ll]
 
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    configure_logging(logging, snakemake)
 
     networks_dict = {(simpl,clusters,l,opts) : ('results/networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc'
                                                  .format(network=snakemake.wildcards.network,

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -484,7 +484,7 @@ if __name__ == "__main__":
     logging.basicConfig(filename=snakemake.log,
                         level=snakemake.config['logging_level'])
 
-    networks_dict = {(simpl,clusters,l,opts) : ('results/networks/{network}_s{simpl}_{clusters}_l{ll}_{opts}.nc'
+    networks_dict = {(simpl,clusters,l,opts) : ('results/networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc'
                                                  .format(network=snakemake.wildcards.network,
                                                          simpl=simpl,
                                                          clusters=clusters,

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -481,7 +481,9 @@ if __name__ == "__main__":
     else:
         ll = [snakemake.wildcards.ll]
 
-    logging.basicConfig(filename=snakemake.log,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     networks_dict = {(simpl,clusters,l,opts) : ('results/networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc'

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -258,7 +258,7 @@ if __name__ == "__main__":
                         ext="results/plots/{network}_s{simpl}_{clusters}_lv{lv}_{opts}_{attr}_ext.{ext}")
         )
 
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
     
     set_plot_style()
 

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -258,7 +258,9 @@ if __name__ == "__main__":
                         ext="results/plots/{network}_s{simpl}_{clusters}_lv{lv}_{opts}_{attr}_ext.{ext}")
         )
 
-    logging.basicConfig(filename=snakemake.log,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     set_plot_style()

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -21,6 +21,7 @@ import pandas as pd
 import numpy as np
 from six.moves import zip
 import logging
+logger = logging.getLogger(__name__)
 
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
@@ -257,7 +258,8 @@ if __name__ == "__main__":
                         ext="results/plots/{network}_s{simpl}_{clusters}_lv{lv}_{opts}_{attr}_ext.{ext}")
         )
 
-    logging.basicConfig(level=snakemake.config['logging_level'])
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
 
     set_plot_style()
 

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -15,13 +15,13 @@ Description
 
 """
 
-from _helpers import load_network, aggregate_p, aggregate_costs
+import logging
+logger = logging.getLogger(__name__)
+from _helpers import load_network, aggregate_p, aggregate_costs, configure_logging
 
 import pandas as pd
 import numpy as np
 from six.moves import zip
-import logging
-logger = logging.getLogger(__name__)
 
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
@@ -258,11 +258,8 @@ if __name__ == "__main__":
                         ext="results/plots/{network}_s{simpl}_{clusters}_lv{lv}_{opts}_{attr}_ext.{ext}")
         )
 
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
-
+    configure_logging(logging, snakemake)
+    
     set_plot_style()
 
     opts = snakemake.config['plotting']

--- a/scripts/plot_p_nom_max.py
+++ b/scripts/plot_p_nom_max.py
@@ -60,7 +60,9 @@ if __name__ == "__main__":
             output=['results/plots/cum_p_nom_max_{clusters}_{country}.pdf']
         )
 
-    logging.basicConfig(filename=snakemake.log,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     plot_kwds = dict(drawstyle="steps-post")

--- a/scripts/plot_p_nom_max.py
+++ b/scripts/plot_p_nom_max.py
@@ -16,6 +16,9 @@ Description
 """
 
 import pypsa
+import logging
+logger = logging.getLogger(__name__)
+
 import pandas as pd
 import matplotlib.pyplot as plt
 
@@ -57,7 +60,8 @@ if __name__ == "__main__":
             output=['results/plots/cum_p_nom_max_{clusters}_{country}.pdf']
         )
 
-    logging.basicConfig(level=snakemake.config['logging_level'])
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
 
     plot_kwds = dict(drawstyle="steps-post")
 

--- a/scripts/plot_p_nom_max.py
+++ b/scripts/plot_p_nom_max.py
@@ -14,10 +14,11 @@ Description
 -----------
 
 """
-
-import pypsa
 import logging
 logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
+import pypsa
 
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -59,11 +60,8 @@ if __name__ == "__main__":
             ),
             output=['results/plots/cum_p_nom_max_{clusters}_{country}.pdf']
         )
-
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    
+    configure_logging(logging, snakemake)
 
     plot_kwds = dict(drawstyle="steps-post")
 

--- a/scripts/plot_p_nom_max.py
+++ b/scripts/plot_p_nom_max.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
             output=['results/plots/cum_p_nom_max_{clusters}_{country}.pdf']
         )
     
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     plot_kwds = dict(drawstyle="steps-post")
 

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -16,6 +16,9 @@ Description
 """
 
 import os
+import logging
+logger = logging.getLogger(__name__)
+
 import pandas as pd
 import matplotlib.pyplot as plt
 
@@ -178,6 +181,10 @@ def plot_energy(infn, fn=None):
 
 
 if __name__ == "__main__":
+
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
+
     summary = snakemake.wildcards.summary
     try:
         func = globals()[f"plot_{summary}"]

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -182,7 +182,7 @@ def plot_energy(infn, fn=None):
 
 if __name__ == "__main__":
 
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     summary = snakemake.wildcards.summary
     try:

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -182,7 +182,9 @@ def plot_energy(infn, fn=None):
 
 if __name__ == "__main__":
 
-    logging.basicConfig(filename=snakemake.log,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     summary = snakemake.wildcards.summary

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -182,10 +182,7 @@ def plot_energy(infn, fn=None):
 
 if __name__ == "__main__":
 
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    configure_logging(logging, snakemake)
 
     summary = snakemake.wildcards.summary
     try:

--- a/scripts/prepare_links_p_nom.py
+++ b/scripts/prepare_links_p_nom.py
@@ -39,7 +39,7 @@ import pandas as pd
 
 if __name__ == "__main__":
 
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     links_p_nom = pd.read_html('https://en.wikipedia.org/wiki/List_of_HVDC_projects', header=0, match="SwePol")[0]
 

--- a/scripts/prepare_links_p_nom.py
+++ b/scripts/prepare_links_p_nom.py
@@ -31,9 +31,16 @@ Description
 
 """
 
+import logging
+logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
 import pandas as pd
 
 if __name__ == "__main__":
+
+    configure_logging(logging, snakemake)
+
     links_p_nom = pd.read_html('https://en.wikipedia.org/wiki/List_of_HVDC_projects', header=0, match="SwePol")[0]
 
     def extract_coordinates(s):

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -185,7 +185,8 @@ if __name__ == "__main__":
             output=['networks/{network}_s{simpl}_{clusters}_l{ll}_{opts}.nc']
         )
 
-    logging.basicConfig(level=snakemake.config['logging_level'])
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
 
     opts = snakemake.wildcards.opts.split('-')
 

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -38,7 +38,7 @@ Inputs
 Outputs
 -------
 
-- ``networks/{network}_s{simpl}_{clusters}_l{ll}_{opts}.nc``: Complete PyPSA network that will be handed to the ``solve_network`` rule.
+- ``networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc``: Complete PyPSA network that will be handed to the ``solve_network`` rule.
 
 Description
 -----------
@@ -182,7 +182,7 @@ if __name__ == "__main__":
         snakemake = MockSnakemake(
             wildcards=dict(network='elec', simpl='', clusters='37', ll='v2', opts='Co2L-3H'),
             input=['networks/{network}_s{simpl}_{clusters}.nc'],
-            output=['networks/{network}_s{simpl}_{clusters}_l{ll}_{opts}.nc']
+            output=['networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc']
         )
 
     logging.basicConfig(filename=snakemake.log,

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -50,6 +50,10 @@ Description
 
 """
 
+import logging
+logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
 from add_electricity import load_costs, update_transmission_costs
 from six import iteritems
 
@@ -57,10 +61,8 @@ import numpy as np
 import re
 import pypsa
 import pandas as pd
-import logging
 
 idx = pd.IndexSlice
-logger = logging.getLogger(__name__)
 
 def add_co2limit(n, Nyears=1., factor=None):
 
@@ -185,10 +187,7 @@ if __name__ == "__main__":
             output=['networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc']
         )
 
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    configure_logging(logging, snakemake)
 
     opts = snakemake.wildcards.opts.split('-')
 

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -187,7 +187,7 @@ if __name__ == "__main__":
             output=['networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc']
         )
 
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     opts = snakemake.wildcards.opts.split('-')
 

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -185,7 +185,9 @@ if __name__ == "__main__":
             output=['networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc']
         )
 
-    logging.basicConfig(filename=snakemake.log,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     opts = snakemake.wildcards.opts.split('-')

--- a/scripts/retrieve_cutout.py
+++ b/scripts/retrieve_cutout.py
@@ -44,6 +44,9 @@ logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
 
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
+
     if snakemake.config['tutorial']:
         url = "https://zenodo.org/record/3518020/files/pypsa-eur-tutorial-cutouts.tar.xz"
     else:

--- a/scripts/retrieve_cutout.py
+++ b/scripts/retrieve_cutout.py
@@ -46,7 +46,7 @@ from _helpers import progress_retrieve, configure_logging
 
 if __name__ == "__main__":
 
-    configure_logging(logging, snakemake) # TODO Make logging compatible with progressbar (see PR #102)
+    configure_logging(snakemake) # TODO Make logging compatible with progressbar (see PR #102)
 
     if snakemake.config['tutorial']:
         url = "https://zenodo.org/record/3518020/files/pypsa-eur-tutorial-cutouts.tar.xz"

--- a/scripts/retrieve_cutout.py
+++ b/scripts/retrieve_cutout.py
@@ -37,21 +37,16 @@ The :ref:`tutorial` uses smaller `cutouts <https://zenodo.org/record/3518020/fil
 
 """
 
-from pathlib import Path
-import tarfile
-from _helpers import progress_retrieve
-
 import logging
 logger = logging.getLogger(__name__)
 
+from pathlib import Path
+import tarfile
+from _helpers import progress_retrieve, configure_logging
 
 if __name__ == "__main__":
 
-    logging.basicConfig(format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level']
-                        # Logging to file doesn't work; collission with _helpers.progress_retrieve
-                        # handlers=[logging.FileHandler(snakemake.log[0]), logging.StreamHandler()],
-                        )    
+    configure_logging(logging, snakemake) # TODO Make logging compatible with progressbar (see PR #102)
 
     if snakemake.config['tutorial']:
         url = "https://zenodo.org/record/3518020/files/pypsa-eur-tutorial-cutouts.tar.xz"

--- a/scripts/retrieve_cutout.py
+++ b/scripts/retrieve_cutout.py
@@ -69,4 +69,4 @@ if __name__ == "__main__":
 
     tarball_fn.unlink()
 
-    logger.info(f"Cutouts available in '{tarball_fn}'.")
+    logger.info(f"Cutouts available in '{Path(tarball_fn.stem).stem}'.")

--- a/scripts/retrieve_cutout.py
+++ b/scripts/retrieve_cutout.py
@@ -37,15 +37,21 @@ The :ref:`tutorial` uses smaller `cutouts <https://zenodo.org/record/3518020/fil
 
 """
 
-import logging, os, tarfile
+import os
+import tarfile
 from _helpers import progress_retrieve
 
+import logging
 logger = logging.getLogger(__name__)
+
 
 if __name__ == "__main__":
 
-    logging.basicConfig(filename=snakemake.log,
-                        level=snakemake.config['logging_level'])
+    logging.basicConfig(format=snakemake.config['logging_format'],
+                        level=snakemake.config['logging_level']
+                        # Logging to file doesn't work; collission with _helpers.progress_retrieve
+                        # handlers=[logging.FileHandler(snakemake.log[0]), logging.StreamHandler()],
+                        )    
 
     if snakemake.config['tutorial']:
         url = "https://zenodo.org/record/3518020/files/pypsa-eur-tutorial-cutouts.tar.xz"
@@ -54,8 +60,12 @@ if __name__ == "__main__":
 
     tarball_fn = "./cutouts.tar.xz"
 
+    logger.info(f"Downloading cutouts from '{url}'.")
     progress_retrieve(url, tarball_fn)
 
+    logger.info(f"Extracting cutouts.")
     tarfile.open(tarball_fn).extractall()
 
     os.remove(tarball_fn)
+    
+    logger.info(f"Cutouts available in '{tarball_fn}'."

--- a/scripts/retrieve_cutout.py
+++ b/scripts/retrieve_cutout.py
@@ -37,7 +37,7 @@ The :ref:`tutorial` uses smaller `cutouts <https://zenodo.org/record/3518020/fil
 
 """
 
-import os
+from pathlib import Path
 import tarfile
 from _helpers import progress_retrieve
 
@@ -58,7 +58,8 @@ if __name__ == "__main__":
     else:
         url = "https://zenodo.org/record/3517949/files/pypsa-eur-cutouts.tar.xz"
 
-    tarball_fn = "./cutouts.tar.xz"
+    # Save location
+    tarball_fn = Path("./cutouts.tar.xz")
 
     logger.info(f"Downloading cutouts from '{url}'.")
     progress_retrieve(url, tarball_fn)
@@ -66,6 +67,6 @@ if __name__ == "__main__":
     logger.info(f"Extracting cutouts.")
     tarfile.open(tarball_fn).extractall()
 
-    os.remove(tarball_fn)
-    
-    logger.info(f"Cutouts available in '{tarball_fn}'."
+    tarball_fn.unlink()
+
+    logger.info(f"Cutouts available in '{tarball_fn}'.")

--- a/scripts/retrieve_databundle.py
+++ b/scripts/retrieve_databundle.py
@@ -28,21 +28,16 @@ The :ref:`tutorial` uses a smaller `data bundle <https://zenodo.org/record/35179
 
 """
 
-import os
-from pathlib import Path
-import tarfile
-from _helpers import progress_retrieve
-
 import logging
 logger = logging.getLogger(__name__)
+from _helpers import progress_retrieve, configure_logging
+
+from pathlib import Path
+import tarfile
 
 if __name__ == "__main__":
 
-    logging.basicConfig(format=snakemake.config['logging_format'],
-                    level=snakemake.config['logging_level']
-                    # Logging to file doesn't work; collission with _helpers.progress_retrieve
-                    # handlers=[logging.FileHandler(snakemake.log[0]), logging.StreamHandler()],
-                    )
+    configure_logging(logging, snakemake) # TODO Make logging compatible with progressbar (see PR #102)
 
     if snakemake.config['tutorial']:
         url = "https://zenodo.org/record/3517921/files/pypsa-eur-tutorial-data-bundle.tar.xz"

--- a/scripts/retrieve_databundle.py
+++ b/scripts/retrieve_databundle.py
@@ -29,6 +29,7 @@ The :ref:`tutorial` uses a smaller `data bundle <https://zenodo.org/record/35179
 """
 
 import os
+from pathlib import Path
 import tarfile
 from _helpers import progress_retrieve
 
@@ -48,16 +49,16 @@ if __name__ == "__main__":
     else:
         url = "https://zenodo.org/record/3517935/files/pypsa-eur-data-bundle.tar.xz"
 
-    tarball_fn = "./bundle.tar.xz"
+    # Save locations
+    tarball_fn = Path("./bundle.tar.xz")
+    to_fn = Path("./data")
 
     logger.info(f"Downloading databundle from '{url}'.")
     progress_retrieve(url, tarball_fn)
 
-    to_fn = "./data"
-
     logger.info(f"Extracting databundle.")
     tarfile.open(tarball_fn).extractall(to_fn)
     
-    os.remove(tarball_fn)
+    tarball_fn.unlink()
     
-    logger.info(f"Cutouts available in '{to_fn}'."
+    logger.info(f"Cutouts available in '{to_fn}'.")

--- a/scripts/retrieve_databundle.py
+++ b/scripts/retrieve_databundle.py
@@ -37,7 +37,7 @@ import tarfile
 
 if __name__ == "__main__":
 
-    configure_logging(logging, snakemake) # TODO Make logging compatible with progressbar (see PR #102)
+    configure_logging(snakemake) # TODO Make logging compatible with progressbar (see PR #102)
 
     if snakemake.config['tutorial']:
         url = "https://zenodo.org/record/3517921/files/pypsa-eur-tutorial-data-bundle.tar.xz"

--- a/scripts/retrieve_databundle.py
+++ b/scripts/retrieve_databundle.py
@@ -61,4 +61,4 @@ if __name__ == "__main__":
     
     tarball_fn.unlink()
     
-    logger.info(f"Cutouts available in '{to_fn}'.")
+    logger.info(f"Databundle available in '{to_fn}'.")

--- a/scripts/retrieve_databundle.py
+++ b/scripts/retrieve_databundle.py
@@ -28,12 +28,20 @@ The :ref:`tutorial` uses a smaller `data bundle <https://zenodo.org/record/35179
 
 """
 
-import logging, os, tarfile
+import os
+import tarfile
 from _helpers import progress_retrieve
 
+import logging
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
+
+    logging.basicConfig(format=snakemake.config['logging_format'],
+                    level=snakemake.config['logging_level']
+                    # Logging to file doesn't work; collission with _helpers.progress_retrieve
+                    # handlers=[logging.FileHandler(snakemake.log[0]), logging.StreamHandler()],
+                    )
 
     if snakemake.config['tutorial']:
         url = "https://zenodo.org/record/3517921/files/pypsa-eur-tutorial-data-bundle.tar.xz"
@@ -42,8 +50,14 @@ if __name__ == "__main__":
 
     tarball_fn = "./bundle.tar.xz"
 
+    logger.info(f"Downloading databundle from '{url}'.")
     progress_retrieve(url, tarball_fn)
 
-    tarfile.open(tarball_fn).extractall('./data')
+    to_fn = "./data"
 
+    logger.info(f"Extracting databundle.")
+    tarfile.open(tarball_fn).extractall(to_fn)
+    
     os.remove(tarball_fn)
+    
+    logger.info(f"Cutouts available in '{to_fn}'."

--- a/scripts/retrieve_natura_raster.py
+++ b/scripts/retrieve_natura_raster.py
@@ -26,20 +26,15 @@ This rule, as a substitute for :mod:`build_natura_raster`, downloads an already 
 
 """
 
-from pathlib import Path
-from _helpers import progress_retrieve
-
 import logging
 logger = logging.getLogger(__name__)
 
+from pathlib import Path
+from _helpers import progress_retrieve, configure_logging
 
 if __name__ == "__main__":
 
-    logging.basicConfig(format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level']
-                        # Logging to file doesn't work; collission with _helpers.progress_retrieve
-                        # handlers=[logging.FileHandler(snakemake.log[0]), logging.StreamHandler()],
-                        )
+    configure_logging(logging, snakemake) # TODO Make logging compatible with progressbar (see PR #102)
 
     # Save location, ensure folder existence
     to_fn = Path("resources/natura.tiff")

--- a/scripts/retrieve_natura_raster.py
+++ b/scripts/retrieve_natura_raster.py
@@ -34,6 +34,9 @@ logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
 
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
+
     d = './resources'
     if not os.path.exists(d):
         os.makedirs(d)

--- a/scripts/retrieve_natura_raster.py
+++ b/scripts/retrieve_natura_raster.py
@@ -34,7 +34,7 @@ from _helpers import progress_retrieve, configure_logging
 
 if __name__ == "__main__":
 
-    configure_logging(logging, snakemake) # TODO Make logging compatible with progressbar (see PR #102)
+    configure_logging(snakemake) # TODO Make logging compatible with progressbar (see PR #102)
 
     # Save location, ensure folder existence
     to_fn = Path("resources/natura.tiff")

--- a/scripts/retrieve_natura_raster.py
+++ b/scripts/retrieve_natura_raster.py
@@ -26,20 +26,29 @@ This rule, as a substitute for :mod:`build_natura_raster`, downloads an already 
 
 """
 
-import logging, os
+import os
 from _helpers import progress_retrieve
 
+import logging
 logger = logging.getLogger(__name__)
 
 
 if __name__ == "__main__":
 
-    logging.basicConfig(filename=snakemake.log,
-                        level=snakemake.config['logging_level'])
+    logging.basicConfig(format=snakemake.config['logging_format'],
+                        level=snakemake.config['logging_level']
+                        # Logging to file doesn't work; collission with _helpers.progress_retrieve
+                        # handlers=[logging.FileHandler(snakemake.log[0]), logging.StreamHandler()],
+                        )
 
     d = './resources'
     if not os.path.exists(d):
         os.makedirs(d)
 
-    progress_retrieve("https://zenodo.org/record/3518215/files/natura.tiff",
-                    "resources/natura.tiff")
+    url = "https://zenodo.org/record/3518215/files/natura.tiff"
+    to_fn = "resources/natura.tiff"
+
+    logger.info(f"Downloading natura raster from '{url}'.")
+    progress_retrieve(url, to_fn)
+    
+    logger.info(f"Natura raster available as '{to_fn}'.")

--- a/scripts/retrieve_natura_raster.py
+++ b/scripts/retrieve_natura_raster.py
@@ -26,7 +26,7 @@ This rule, as a substitute for :mod:`build_natura_raster`, downloads an already 
 
 """
 
-import os
+from pathlib import Path
 from _helpers import progress_retrieve
 
 import logging
@@ -41,12 +41,11 @@ if __name__ == "__main__":
                         # handlers=[logging.FileHandler(snakemake.log[0]), logging.StreamHandler()],
                         )
 
-    d = './resources'
-    if not os.path.exists(d):
-        os.makedirs(d)
+    # Save location, ensure folder existence
+    to_fn = Path("resources/natura.tiff")
+    to_fn.parent.mkdir(parents=True, exist_ok=True)
 
     url = "https://zenodo.org/record/3518215/files/natura.tiff"
-    to_fn = "resources/natura.tiff"
 
     logger.info(f"Downloading natura raster from '{url}'.")
     progress_retrieve(url, to_fn)

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -351,7 +351,7 @@ if __name__ == "__main__":
             )
         )
     
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)
 

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -349,7 +349,9 @@ if __name__ == "__main__":
                 clustermaps='resources/clustermaps_{network}_s{simpl}.h5'
             )
         )
-    logging.basicConfig(filename=snakemake.log,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     n = pypsa.Network(snakemake.input.network)

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -349,8 +349,8 @@ if __name__ == "__main__":
                 clustermaps='resources/clustermaps_{network}_s{simpl}.h5'
             )
         )
-
-    logging.basicConfig(level=snakemake.config['logging_level'])
+    logging.basicConfig(filename=snakemake.log,
+                        level=snakemake.config['logging_level'])
 
     n = pypsa.Network(snakemake.input.network)
 

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -78,10 +78,13 @@ The rule :mod:`simplify_network` does up to four things:
 4. Optionally, if an integer were provided for the wildcard ``{simpl}`` (e.g. ``networks/elec_s500.nc``), the network is clustered to this number of clusters with the routines from the ``cluster_network`` rule with the function ``cluster_network.cluster(...)``. This step is usually skipped!
 """
 
+import logging
+logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
 from cluster_network import clustering_for_n_clusters, cluster_regions
 from add_electricity import load_costs
 
-import logging
 import pandas as pd
 import numpy as np
 import scipy as sp
@@ -94,8 +97,6 @@ import pypsa
 from pypsa.io import import_components_from_dataframe, import_series_from_dataframe
 from pypsa.networkclustering import busmap_by_stubs, aggregategenerators, aggregateoneport
 
-
-logger = logging.getLogger(__name__)
 idx = pd.IndexSlice
 
 def simplify_network_to_380(n):
@@ -349,10 +350,8 @@ if __name__ == "__main__":
                 clustermaps='resources/clustermaps_{network}_s{simpl}.h5'
             )
         )
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    
+    configure_logging(logging, snakemake)
 
     n = pypsa.Network(snakemake.input.network)
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -379,7 +379,7 @@ if __name__ == "__main__":
                      python="logs/{network}_s{simpl}_{clusters}_lv{lv}_{opts}_python.log")
         )
 
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log.python),
                                   logging.StreamHandler()],
                         format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -381,7 +381,7 @@ if __name__ == "__main__":
                      python="logs/{network}_s{simpl}_{clusters}_lv{lv}_{opts}_python.log")
         )
 
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     tmpdir = snakemake.config['solving'].get('tmpdir')
     if tmpdir is not None:

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -34,12 +34,12 @@ Relevant Settings
 Inputs
 ------
 
-- ``networks/{network}_s{simpl}_{clusters}_l{ll}_{opts}.nc``: confer :ref:`prepare`
+- ``networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc``: confer :ref:`prepare`
 
 Outputs
 -------
 
-- ``results/networks/{network}_s{simpl}_{clusters}_l{ll}_{opts}.nc``: Solved PyPSA network including optimisation results
+- ``results/networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc``: Solved PyPSA network including optimisation results
 
     .. image:: ../img/results.png
         :scale: 40 %

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -379,12 +379,12 @@ if __name__ == "__main__":
                      python="logs/{network}_s{simpl}_{clusters}_lv{lv}_{opts}_python.log")
         )
 
+    logging.basicConfig(filename=snakemake.log.python,
+                        level=snakemake.config['logging_level'])
+
     tmpdir = snakemake.config['solving'].get('tmpdir')
     if tmpdir is not None:
         patch_pyomo_tmpdir(tmpdir)
-
-    logging.basicConfig(filename=snakemake.log.python,
-                        level=snakemake.config['logging_level'])
 
     with memory_logger(filename=getattr(snakemake.log, 'memory', None), interval=30.) as mem:
         n = pypsa.Network(snakemake.input[0])

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -379,7 +379,9 @@ if __name__ == "__main__":
                      python="logs/{network}_s{simpl}_{clusters}_lv{lv}_{opts}_python.log")
         )
 
-    logging.basicConfig(filename=snakemake.log.python,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     tmpdir = snakemake.config['solving'].get('tmpdir')

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -77,10 +77,12 @@ Details (and errors made through this heuristic) are discussed in the paper
 
 """
 
-import numpy as np
-import pandas as pd
 import logging
 logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
+import numpy as np
+import pandas as pd
 import gc
 
 import pypsa
@@ -379,10 +381,7 @@ if __name__ == "__main__":
                      python="logs/{network}_s{simpl}_{clusters}_lv{lv}_{opts}_python.log")
         )
 
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log.python),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    configure_logging(logging, snakemake)
 
     tmpdir = snakemake.config['solving'].get('tmpdir')
     if tmpdir is not None:

--- a/scripts/solve_operations_network.py
+++ b/scripts/solve_operations_network.py
@@ -93,7 +93,9 @@ if __name__ == "__main__":
     if tmpdir is not None:
         patch_pyomo_tmpdir(tmpdir)
 
-    logging.basicConfig(filename=snakemake.log.python,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     n = pypsa.Network(snakemake.input.unprepared)

--- a/scripts/solve_operations_network.py
+++ b/scripts/solve_operations_network.py
@@ -41,11 +41,13 @@ Description
 
 """
 
+import logging
+logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
 import pypsa
 import numpy as np
 import re
-import logging
-logger = logging.getLogger(__name__)
 
 from vresutils.benchmark import memory_logger
 from solve_network import patch_pyomo_tmpdir, solve_network, prepare_network
@@ -93,10 +95,7 @@ if __name__ == "__main__":
     if tmpdir is not None:
         patch_pyomo_tmpdir(tmpdir)
 
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log.python),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    configure_logging(logging, snakemake)
 
     n = pypsa.Network(snakemake.input.unprepared)
 

--- a/scripts/solve_operations_network.py
+++ b/scripts/solve_operations_network.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     if tmpdir is not None:
         patch_pyomo_tmpdir(tmpdir)
 
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.unprepared)
 

--- a/scripts/solve_operations_network.py
+++ b/scripts/solve_operations_network.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":
     if tmpdir is not None:
         patch_pyomo_tmpdir(tmpdir)
 
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log.python),
                                   logging.StreamHandler()],
                         format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])

--- a/scripts/solve_operations_network.py
+++ b/scripts/solve_operations_network.py
@@ -29,12 +29,12 @@ Inputs
 ------
 
 - ``networks/{network}_s{simpl}_{clusters}.nc``: confer :ref:`cluster`
-- ``results/networks/{network}_s{simpl}_{clusters}_l{ll}_{opts}.nc``: confer :ref:`solve`
+- ``results/networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc``: confer :ref:`solve`
 
 Outputs
 -------
 
-- ``results/networks/{network}_s{simpl}_{clusters}_l{ll}_{opts}_op.nc``: Solved PyPSA network for optimal dispatch including optimisation results
+- ``results/networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_op.nc``: Solved PyPSA network for optimal dispatch including optimisation results
 
 Description
 -----------

--- a/scripts/trace_solve_network.py
+++ b/scripts/trace_solve_network.py
@@ -28,12 +28,12 @@ Relevant Settings
 Inputs
 ------
 
-- ``networks/{network}_s{simpl}_{clusters}_l{ll}_{opts}.nc``: confer :ref:`prepare`
+- ``networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc``: confer :ref:`prepare`
 
 Outputs
 -------
 
-- ``results/networks/{network}_s{simpl}_{clusters}_l{ll}_{opts}_trace.nc``: Solved PyPSA network including optimisation results (with trace)
+- ``results/networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_trace.nc``: Solved PyPSA network including optimisation results (with trace)
 
 Description
 -----------

--- a/scripts/trace_solve_network.py
+++ b/scripts/trace_solve_network.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     if tmpdir is not None:
         patch_pyomo_tmpdir(tmpdir)
 
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log.python),
                                   logging.StreamHandler()],
                         format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])

--- a/scripts/trace_solve_network.py
+++ b/scripts/trace_solve_network.py
@@ -62,7 +62,9 @@ if __name__ == "__main__":
     if tmpdir is not None:
         patch_pyomo_tmpdir(tmpdir)
 
-    logging.basicConfig(filename=snakemake.log.python,
+    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log[0]),
+                                  logging.StreamHandler()],
+                        format=snakemake.config['logging_format'],
                         level=snakemake.config['logging_level'])
 
     n = pypsa.Network(snakemake.input[0])

--- a/scripts/trace_solve_network.py
+++ b/scripts/trace_solve_network.py
@@ -40,12 +40,13 @@ Description
 
 """
 
+import logging
+logger = logging.getLogger(__name__)
+from _helpers import configure_logging
+
 from solve_network import patch_pyomo_tmpdir, prepare_network, solve_network
 
-import logging
 import pypsa
-
-logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     # Detect running outside of snakemake and mock snakemake for testing
@@ -62,10 +63,7 @@ if __name__ == "__main__":
     if tmpdir is not None:
         patch_pyomo_tmpdir(tmpdir)
 
-    logging.basicConfig(handlers=[logging.FileHandler(snakemake.log.python),
-                                  logging.StreamHandler()],
-                        format=snakemake.config['logging_format'],
-                        level=snakemake.config['logging_level'])
+    configure_logging(logging, snakemake)
 
     n = pypsa.Network(snakemake.input[0])
 

--- a/scripts/trace_solve_network.py
+++ b/scripts/trace_solve_network.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     if tmpdir is not None:
         patch_pyomo_tmpdir(tmpdir)
 
-    configure_logging(logging, snakemake)
+    configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input[0])
 

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -1,7 +1,7 @@
 version: 0.1
 tutorial: true
 logging_level: INFO
-logging_format: '%(levelname)s:%(name)s:%(message)s' # Custom format for log messages, see logging's LogRecord attributes
+logging_format: '%(levelname)s:%(name)s:%(message)s'
 
 summary_dir: results
 

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -1,7 +1,8 @@
 version: 0.1
 tutorial: true
-logging_level: INFO
-logging_format: '%(levelname)s:%(name)s:%(message)s'
+logging:
+  level: INFO
+  format: '%(levelname)s:%(name)s:%(message)s'
 
 summary_dir: results
 

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -1,6 +1,7 @@
 version: 0.1
 tutorial: true
 logging_level: INFO
+logging_format: '%(levelname)s:%(name)s:%(message)s' # Custom format for log messages, see logging's LogRecord attributes
 
 summary_dir: results
 


### PR DESCRIPTION
Until now only a few scripts actually wrote their logging information to the `log/` directory.
This PR unifies the behaviour and adds writing to a logfile in `log/` for all scripts in the snakemake workflow.