### PR TITLE
Snakefile: use normpath for solver logs

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,3 +1,5 @@
+from os.path import normpath
+
 configfile: "config.yaml"
 
 COSTS="data/costs.csv"
@@ -234,16 +236,6 @@ rule add_extra_components:
     script: "scripts/add_extra_components.py"
 
 
-# rule add_sectors:
-#     input:
-#         network="networks/elec_{cost}_{resarea}_{opts}.nc",
-#         emobility="data/emobility"
-#     output: "networks/sector_{cost}_{resarea}_{sectors}_{opts}.nc"
-#     benchmark: "benchmarks/add_sectors/sector_{resarea}_{sectors}_{opts}"
-#     threads: 1
-#     resources: mem=1000
-#     script: "scripts/add_sectors.py"
-
 rule prepare_network:
     input: 'networks/{network}_s{simpl}_{clusters}_ec.nc', tech_costs=COSTS
     output: 'networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc'
@@ -270,7 +262,7 @@ rule solve_network:
     output: "results/networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc"
     shadow: "shallow"
     log:
-        solver="logs/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_solver.log",
+        solver=normpath("logs/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_solver.log"),
         python="logs/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_python.log",
         memory="logs/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_memory.log"
     benchmark: "benchmarks/solve_network/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}"
@@ -295,7 +287,7 @@ rule solve_operations_network:
     output: "results/networks/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_op.nc"
     shadow: "shallow"
     log:
-        solver="logs/solve_operations_network/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_op_solver.log",
+        solver=normpath("logs/solve_operations_network/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_op_solver.log"),
         python="logs/solve_operations_network/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_op_python.log",
         memory="logs/solve_operations_network/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}_op_memory.log"
     benchmark: "benchmarks/solve_operations_network/{network}_s{simpl}_{clusters}_ec_l{ll}_{opts}"


### PR DESCRIPTION
Re: pypsa-eur_questions related: generated data and solver conf issues, 2019/11/19, 19:13
https://groups.google.com/forum/#!topic/pypsa/3_uB7DmQKzY

```
ValueError: Unallowed character (/) found in CPLEX log file path/name.
Sol:include / in folder C:\Users\David\Anaconda3\Lib\site-packages\pyomo\solvers\plugins\solvers\CPLEX.py
_validate_file_name.allowed_characters = r"a-zA-Z0-9 ~:\.\-_\%s" % (
    os.path.sep,)
```

Potential solutions by @coroa :
1. Use solver=os.path.normpath("logs/{network}...") ?
2. Advocate for snakemake to use normpath before passing through the
  log settings?
3. Advocate for pyomo's cplex model to apply normpath?

This PR implements 1., since it doesn't depend on the other packages.