### PR TITLE
Snakefile: load default config if config.yaml does not exist

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,4 +1,8 @@
-from os.path import normpath
+from os.path import normpath, exists
+from shutil import copyfile
+
+if not exists("config.yaml"):
+    copyfile("config.default.yaml", "config.yaml")
 
 configfile: "config.yaml"
 


### PR DESCRIPTION
Copy `config.default.yaml` to `config.yaml` if there is no `config.yaml` yet when the workflow is started.

This PR is useful when the main PyPSA-Eur is used as a subworkflow. 
This is because there is no `config.yaml` tracked in the repository anymore, but it is required as it is referenced in the `Snakefile` (cf. https://github.com/snakemake/snakemake/issues/123). The `configfile` provided in the superordinate workflow is intended rather to overwrite settings.