### PR TITLE
ec: attach hydrogen pipelines

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -37,6 +37,7 @@ electricity:
     Generator: [OCGT]
     StorageUnit: [battery, H2]
     Store: [] # battery, H2
+    Link: []
 
   max_hours:
     battery: 6

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -34,6 +34,7 @@ electricity:
     Generator: [OCGT]
     StorageUnit: [battery, H2]
     Store: [] #battery, H2
+    Link: []
 
   max_hours:
     battery: 6

--- a/data/costs.csv
+++ b/data/costs.csv
@@ -96,6 +96,12 @@ fuel cell,2030,lifetime,20,years,NREL http://www.nrel.gov/docs/fy09osti/45873.pd
 fuel cell,2030,efficiency,0.58,per unit,NREL http://www.nrel.gov/docs/fy09osti/45873.pdf; budischak2013 conservative 2020
 hydrogen storage,2030,investment,11.2,USD/kWh,budischak2013
 hydrogen storage,2030,lifetime,20,years,budischak2013
+hydrogen underground storage,2030,investment,0.5,EUR/kWh,maximum from https://www.nrel.gov/docs/fy10osti/46719.pdf
+hydrogen underground storage,2030,lifetime,40,years,http://www.acatech.de/fileadmin/user_upload/Baumstruktur_nach_Website/Acatech/root/de/Publikationen/Materialien/ESYS_Technologiesteckbrief_Energiespeicher.pdf
+H2 pipeline,2030,investment,267,EUR/MW/km,Welder et al https://doi.org/10.1016/j.ijhydene.2018.12.156
+H2 pipeline,2030,lifetime,40,years,Krieg2012 http://juser.fz-juelich.de/record/136392/files/Energie%26Umwelt_144.pdf
+H2 pipeline,2030,FOM,5,%/year,Krieg2012 http://juser.fz-juelich.de/record/136392/files/Energie%26Umwelt_144.pdf
+H2 pipeline,2030,efficiency,0.98,per unit,Krieg2012 http://juser.fz-juelich.de/record/136392/files/Energie%26Umwelt_144.pdf
 methanation,2030,investment,1000,EUR/kWH2,Schaber thesis
 methanation,2030,lifetime,25,years,Schaber thesis
 methanation,2030,FOM,3,%/year,Schaber thesis

--- a/doc/configtables/electricity.csv
+++ b/doc/configtables/electricity.csv
@@ -7,6 +7,7 @@ extendable_carriers,,,
 -- Generator,--,"Any subset  of {'OCGT','CCGT'}","Places extendable conventional power plants (OCGT and/or CCGT) where gas power plants are located today without capacity limits."
 -- StorageUnit,--,"Any subset of {'battery','H2'}","Adds extendable storage units (battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity."
 -- Store,--,"Any subset of {'battery','H2'}","Adds extendable storage units (battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity."
+-- Link,--,"Any subset of {'H2 pipeline'}","Adds extendable links (H2 pipelines only) at every connection where there are lines or HVDC links without capacity limits and with zero initial capacity. Hydrogen pipelines require hydrogen storage to be modelled as ``Store``."
 max_hours,,,
 -- battery,h,float,"Maximum state of charge capacity of the battery in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_."
 -- H2,h,float,"Maximum state of charge capacity of the hydrogen storage in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_."

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -32,8 +32,9 @@ electricity:
 
   extendable_carriers:
     Generator: [OCGT]
-    StorageUnit: [battery, H2]
-    Store: [] #battery, H2
+    StorageUnit: [battery]
+    Store: [H2]
+    Link: [H2 pipeline]
 
   max_hours:
     battery: 6


### PR DESCRIPTION
- adds h2 pipelines alongside clustered network connections
- h2 storage has to be modelled as store!
- partly inspired by recent commit in pypsa-eur-sec
- cost assumptions included

This is a first, simplified issue. Future tasks for hydrogen networks:
- **storage capacity:** is modelling gas network as links sufficient or should it be some link-store-link combination or storageunit with 2 buses?
- **bidirectional flow:** is operation in both directions easily possible? or do we need 2 links with each `p_min_pu=0`? 
- **recompression:** is it necessary to consider energy demand for recompression? or marginal cost of recompression?