### PR TITLE
import and bug fix for custom ppl

### DIFF
--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -81,9 +81,10 @@ def add_custom_powerplants(ppl):
     custom_ppl_query = snakemake.config['electricity']['custom_powerplants']
     if not custom_ppl_query:
         return ppl
-    add_ppls = pd.read_csv(snakemake.input.custom_powerplants, index_col=0)
+    add_ppls = pd.read_csv(snakemake.input.custom_powerplants, index_col=0,
+                           dtype={'bus': 'str'})
     if isinstance(custom_ppl_query, str):
-        add_ppls.query(add_ppls, inplace=True)
+        add_ppls.query(custom_ppl_query, inplace=True)
     return ppl.append(add_ppls, sort=False)
 
 


### PR DESCRIPTION
As @coroa figured out, `add_custom_powerplants` needs a type stable import for the `bus` column (and a second bug was detected)