### PR TITLE
paralellise builds and use env: to distinguish tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
+language: bash
+
 os: 
   - windows
   - linux
   - osx
 
-language: bash
+env:
+  - TEST_SUITE=test1
 
 before_install:
   # install conda
@@ -18,7 +21,5 @@ before_install:
   - conda install -c conda-forge ipopt glpk
 
 script:
-  - cp ./test/config.test1.yaml ./config.yaml
-  - snakemake solve_all_elec_networks
-  - rm -rf resources/*.nc resources/*.geojson resources/*.h5 networks results
-  # could repeat for more configurations in future
+  - cp ./test/config.$TEST_SUITE.yaml ./config.yaml
+  - snakemake -j 2 solve_all_elec_networks

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -32,3 +32,5 @@ This is the first release of PyPSA-Eur:
 * Logfiles for all rules of the ``snakemake`` workflow are now written in the folder ``log/`` (`#102 <https://github.com/PyPSA/pypsa-eur/pull/102>`_). 
 
 * The new function ``_helpers.mock_snakemake`` creates a ``snakemake`` object which mimics the actual ``snakemake`` object produced by workflow by parsing the ``Snakefile`` and setting all paths for inputs, outputs, and logs. This allows running all scripts within a (I)python terminal (or just by calling ``python <script-name>``) and thereby facilitates developing and debugging scripts significantly (`#107 <https://github.com/PyPSA/pypsa-eur/pull/107>`_).
+
+* Acceleration of Travis CI builds (`#115 <https://github.com/PyPSA/pypsa-eur/pull/115>`_).


### PR DESCRIPTION
## Changes proposed in this Pull Request

Attempt at parallelising multiple tests for continuous integration with Travis CI.
In the file `.travis.yml`, use the `env:` section to specifify files in `./test` folder.

I am not yet 100% convinced that this would be the best way to test multiple configurations of pypsa-eur. One could also just iterate the test configurations in the `scripts: ` section without paralellisation and save the conda installation overhead. What do you think?

Also parallelise snakemake a bit with `snakemake -j 2 ...` using given infrastructure: https://docs.travis-ci.com/user/reference/overview/#virtualization-environments

Build times reduced by ~ 2-3 minutes.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `environment.yaml` and `environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.