### PR TITLE
environment: Free pyproj from version constraint (fixes #119)

### DIFF
--- a/environment.docs.yaml
+++ b/environment.docs.yaml
@@ -35,7 +35,7 @@ dependencies:
   # GIS dependencies have to come all from conda-forge
   - conda-forge::cartopy
   - conda-forge::fiona
-  - conda-forge::pyproj<=1.9.6 # until cartopy release with proj>=6.2
+  - conda-forge::proj
   - conda-forge::pyshp
   - conda-forge::geopandas
   - conda-forge::rasterio

--- a/environment.yaml
+++ b/environment.yaml
@@ -36,7 +36,7 @@ dependencies:
   # GIS dependencies have to come all from conda-forge
   - conda-forge::cartopy
   - conda-forge::fiona
-  - conda-forge::pyproj<=1.9.6 # until cartopy release with proj>=6.2
+  - conda-forge::proj
   - conda-forge::pyshp
   - conda-forge::geopandas
   - conda-forge::rasterio

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -163,9 +163,6 @@ import xarray as xr
 import pandas as pd
 import multiprocessing as mp
 
-import glaes as gl
-import geokit as gk
-from osgeo import gdal
 from scipy.sparse import csr_matrix, vstack
 
 from pypsa.geo import haversine
@@ -176,6 +173,12 @@ import progressbar as pgb
 
 bounds = dx = dy = config = paths = gebco = clc = natura = None
 def init_globals(bounds_xXyY, n_dx, n_dy, n_config, n_paths):
+    # Late import so that the GDAL Context is only created in the new processes
+    global gl, gk, gdal
+    import glaes as gl
+    import geokit as gk
+    from osgeo import gdal as gdal
+
     # global in each process of the multiprocessing.Pool
     global bounds, dx, dy, config, paths, gebco, clc, natura
 
@@ -267,6 +270,11 @@ if __name__ == '__main__':
     # mp.set_start_method('spawn')
     with mp.Pool(initializer=init_globals, initargs=(bounds_xXyY, dx, dy, config, paths),
                  maxtasksperchild=20, processes=snakemake.config['atlite'].get('nprocesses', 2)) as pool:
+
+        # The GDAL library creates a GDAL context on module import, which may not be shared over multiple
+        # processes or the PROJ4 library has a hickup, so we import only after forking.
+        import geokit as gk
+
         regions = gk.vector.extractFeatures(paths["regions"], onlyAttr=True)
         buses = pd.Index(regions['name'], name="bus")
         widgets = [


### PR DESCRIPTION
pyproj was constrained to 1.9.6, since cartopy was incompatible with
recent proj versions.

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] ~Code and workflow changes are sufficiently documented.~
- [x] Newly introduced dependencies are added to `environment.yaml` and `environment.docs.yaml`.
- [ ] ~Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.~
- [ ] ~Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.~
- [ ] ~A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.~