### PR TITLE
helpers: importing networks with override_components

### DIFF
--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -172,7 +172,7 @@ def plot_map(n, ax=None, attribute='p_nom', opts={}):
 
     return fig
 
-#n = load_network(snakemake.input.network, opts, combine_hydro_ps=False)
+#n = load_network_for_plots(snakemake.input.network, opts, combine_hydro_ps=False)
 
 
 def plot_total_energy_pie(n, ax=None):
@@ -261,7 +261,7 @@ if __name__ == "__main__":
     map_figsize = opts['map']['figsize']
     map_boundaries = opts['map']['boundaries']
 
-    n = load_network(snakemake.input.network, snakemake.input.tech_costs, snakemake.config)
+    n = load_network_for_plot(snakemake.input.network, snakemake.input.tech_costs, snakemake.config)
 
     scenario_opts = snakemake.wildcards.opts.split('-')
 

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -261,7 +261,7 @@ if __name__ == "__main__":
     map_figsize = opts['map']['figsize']
     map_boundaries = opts['map']['boundaries']
 
-    n = load_network_for_plot(snakemake.input.network, snakemake.input.tech_costs, snakemake.config)
+    n = load_network_for_plots(snakemake.input.network, snakemake.input.tech_costs, snakemake.config)
 
     scenario_opts = snakemake.wildcards.opts.split('-')
 


### PR DESCRIPTION
Closes #122.

See discussion in #122.

Adds a new function `_helpers.load_network()` that loads pypsa.Network with overridden components as specified in `snakemake.config['override_components']`. Docstrings provided.
This is more a precursor for future merges with PyPSA-Eur-Sec, which I added already now due to a recent specific request on the PyPSA mailing list. It's not used in the existing rules, but contributes to extensibility of PyPSA-Eur downstream of the workflow. I think this is fair to add it but not (yet) use it, as I currently do not see a use case where you would want to add extra components in the workflow earlier than maybe `add_extra_components`. This is also why I did not add it in the documentation of `config.yaml`. Convince me if you think otherwise.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.