### PR TITLE
solve: include {min,max}_iterations parameters

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -181,8 +181,8 @@ solving:
     formulation: kirchhoff
     load_shedding: false
     noisy_costs: true
-    min_iterations: 3
-    max_iterations: 5
+    min_iterations: 4
+    max_iterations: 6
     clip_p_max_pu: 0.01
     skip_iterations: false
     track_iterations: false

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -214,8 +214,8 @@ def solve_network(n, config, solver_log=None, opts='', **kwargs):
     solver_options = config['solving']['solver'].copy()
     solver_name = solver_options.pop('name')
     track_iterations = config['solving']['options'].get('track_iterations', False)
-    min_iterations = config['solving']['options'].get('min_iterations', False)
-    max_iterations = config['solving']['options'].get('max_iterations', False)
+    min_iterations = config['solving']['options'].get('min_iterations', 4)
+    max_iterations = config['solving']['options'].get('max_iterations', 6)
 
     # add to network for extra_functionality
     n.config = config

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -214,6 +214,8 @@ def solve_network(n, config, solver_log=None, opts='', **kwargs):
     solver_options = config['solving']['solver'].copy()
     solver_name = solver_options.pop('name')
     track_iterations = config['solving']['options'].get('track_iterations', False)
+    min_iterations = config['solving']['options'].get('min_iterations', False)
+    max_iterations = config['solving']['options'].get('max_iterations', False)
 
     # add to network for extra_functionality
     n.config = config
@@ -225,6 +227,8 @@ def solve_network(n, config, solver_log=None, opts='', **kwargs):
     else:
         ilopf(n, solver_name=solver_name, solver_options=solver_options,
               track_iterations=track_iterations,
+              min_iterations=min_iterations,
+              max_iterations=max_iterations,
               extra_functionality=extra_functionality, **kwargs)
     return n
 


### PR DESCRIPTION
```yaml
solving:
    options:
        min_iterations:
        max_iterations:
```
had no effect in the new `solve_network` rule. This PR corrects this.

Additionally, given the iteration counts from 1 now, I propose to change the defaults accordingly.