### PR TITLE
build_bus_regions: fix 'cannot insert name, already exists' in geopandas 0.7.0

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -41,7 +41,7 @@ dependencies:
   - fiona
   - proj
   - pyshp
-  - geopandas<=0.6.3
+  - geopandas
   - rasterio
   - shapely
   - libgdal

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -71,13 +71,15 @@ if __name__ == "__main__":
 
         onshore_shape = country_shapes[country]
         onshore_locs = n.buses.loc[c_b & n.buses.substation_lv, ["x", "y"]]
-        onshore_regions.append(gpd.GeoDataFrame({
+        onshore_regions_c = gpd.GeoDataFrame({
                 'name': onshore_locs.index,
                 'x': onshore_locs['x'],
                 'y': onshore_locs['y'],
                 'geometry': voronoi_partition_pts(onshore_locs.values, onshore_shape),
                 'country': country
-            }))
+            })
+        onshore_regions_c.reset_index(drop=True, inplace=True)
+        onshore_regions.append(onshore_regions_c)
 
         if country not in offshore_shapes.index: continue
         offshore_shape = offshore_shapes[country]
@@ -88,8 +90,9 @@ if __name__ == "__main__":
                 'y': offshore_locs['y'],
                 'geometry': voronoi_partition_pts(offshore_locs.values, offshore_shape),
                 'country': country
-            }, index=offshore_locs.index)
+            })
         offshore_regions_c = offshore_regions_c.loc[offshore_regions_c.area > 1e-2]
+        offshore_regions_c.reset_index(drop=True, inplace=True)
         offshore_regions.append(offshore_regions_c)
 
     def save_to_geojson(s, fn):

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -71,15 +71,13 @@ if __name__ == "__main__":
 
         onshore_shape = country_shapes[country]
         onshore_locs = n.buses.loc[c_b & n.buses.substation_lv, ["x", "y"]]
-        onshore_regions_c = gpd.GeoDataFrame({
+        onshore_regions.append(gpd.GeoDataFrame({
                 'name': onshore_locs.index,
                 'x': onshore_locs['x'],
                 'y': onshore_locs['y'],
                 'geometry': voronoi_partition_pts(onshore_locs.values, onshore_shape),
                 'country': country
-            })
-        onshore_regions_c.reset_index(drop=True, inplace=True)
-        onshore_regions.append(onshore_regions_c)
+            }))
 
         if country not in offshore_shapes.index: continue
         offshore_shape = offshore_shapes[country]
@@ -92,7 +90,6 @@ if __name__ == "__main__":
                 'country': country
             })
         offshore_regions_c = offshore_regions_c.loc[offshore_regions_c.area > 1e-2]
-        offshore_regions_c.reset_index(drop=True, inplace=True)
         offshore_regions.append(offshore_regions_c)
 
     def save_to_geojson(s, fn):
@@ -101,6 +98,6 @@ if __name__ == "__main__":
         schema = {**gpd.io.file.infer_schema(s), 'geometry': 'Unknown'}
         s.to_file(fn, driver='GeoJSON', schema=schema)
 
-    save_to_geojson(pd.concat(onshore_regions), snakemake.output.regions_onshore)
+    save_to_geojson(pd.concat(onshore_regions, ignore_index=True), snakemake.output.regions_onshore)
 
-    save_to_geojson(pd.concat(offshore_regions), snakemake.output.regions_offshore)
+    save_to_geojson(pd.concat(offshore_regions, ignore_index=True), snakemake.output.regions_offshore)


### PR DESCRIPTION
## Changes proposed in this Pull Request

Adjustments for `geopandas>=0.7.0`:
- fix `build_bus_regions` as raised on the PyPSA Mailing List.

[does **not** require `geopandas>=0.7.0`]

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
~~- [ ] Code and workflow changes are sufficiently documented.~~
- [x] Newly introduced dependencies are added to `environment.yaml` and `environment.docs.yaml`.
~~- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.~~
~~- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.~~
~~- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.~~