### PR TITLE
Renewable profiles option using all available areas

### DIFF
--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -289,7 +289,8 @@ if __name__ == '__main__':
 
     potentials = config['capacity_per_sqkm'] * vlanduse._cutout_cell_areas(cutout)
     potmatrix = matrix * spdiag(potentials.ravel())
-    potmatrix.data[potmatrix.data < 1.] = 0 # ignore weather cells where only less than 1 MW can be installed
+    if config.get('keep_all_available_areas', False) != True:
+        potmatrix.data[potmatrix.data < 1.] = 0 # ignore weather cells where only less than 1 MW can be installed
     potmatrix.eliminate_zeros()
 
     resource = config['resource']

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -289,7 +289,7 @@ if __name__ == '__main__':
 
     potentials = config['capacity_per_sqkm'] * vlanduse._cutout_cell_areas(cutout)
     potmatrix = matrix * spdiag(potentials.ravel())
-    if config.get('keep_all_available_areas', False) != True: # check config file whether user wants to use all availbe weather cells for renewable profile and potential generation
+    if not config.get('keep_all_available_areas', False): # check config file whether user wants to use all availbe weather cells for renewable profile and potential generation
         potmatrix.data[potmatrix.data < 1.] = 0 # ignore weather cells where only less than 1 MW can be installed
     potmatrix.eliminate_zeros()
 

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -289,7 +289,7 @@ if __name__ == '__main__':
 
     potentials = config['capacity_per_sqkm'] * vlanduse._cutout_cell_areas(cutout)
     potmatrix = matrix * spdiag(potentials.ravel())
-    if config.get('keep_all_available_areas', False) != True:
+    if config.get('keep_all_available_areas', False) != True: # check config file if user wants to use all availbe areas for renewable potentials
         potmatrix.data[potmatrix.data < 1.] = 0 # ignore weather cells where only less than 1 MW can be installed
     potmatrix.eliminate_zeros()
 

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -289,7 +289,7 @@ if __name__ == '__main__':
 
     potentials = config['capacity_per_sqkm'] * vlanduse._cutout_cell_areas(cutout)
     potmatrix = matrix * spdiag(potentials.ravel())
-    if config.get('keep_all_available_areas', False) != True: # check config file if user wants to use all availbe areas for renewable potentials
+    if config.get('keep_all_available_areas', False) != True: # check config file whether user wants to use all availbe weather cells for renewable profile and potential generation
         potmatrix.data[potmatrix.data < 1.] = 0 # ignore weather cells where only less than 1 MW can be installed
     potmatrix.eliminate_zeros()
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
The user can use this functionality to decide whether he wants to use all available area for the potential calculation or not.
As a result, two options are now available to reduce the available potential for areas with very low potential. This can be used for example to generated CF for renewable generation units that are already existing (a system that represents today's capacity's) as reported  #103 
This can results in the problem, that renewable generators are connected to buses that do not have a CF time series, because no potential was determined at the bus. 

Option 1 (line 292)-> new implementation
```
if config.get('keep_all_available_areas', False) != True: # check config file whether user wants to use all availbe weather cells for renewable profile and potential generation
        potmatrix.data[potmatrix.data < 1.] = 0 # ignore weather cells where only less than 1 MW can be installed
```
This option works directly on the resulting potential areas and not on the assigned pypsa grid potentials.


Option 2 (line 359)-> already existing option
 ```
# select only buses with some capacity and minimal capacity factor
    ds = ds.sel(bus=((ds['profile'].mean('time') > config.get('min_p_max_pu', 0.)) &
                     (ds['p_nom_max'] > config.get('min_p_nom_max', 0.))))
```
This option works on the resulting / assigned pypsa grid potentials and CF

Should we add both options to the config and documentation files?

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
~~- [ ] Newly introduced dependencies are added to `environment.yaml` and `environment.docs.yaml`.~~
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.