### PR TITLE
add assertions for cutout bounds, solves #158

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -128,6 +128,9 @@ rule build_bus_regions:
 
 if config['enable'].get('build_cutout', False):        
     rule build_cutout:
+        input:
+            regions_onshore="resources/regions_onshore.geojson",
+            regions_offshore="resources/regions_offshore.geojson"
         output: directory("cutouts/{cutout}")
         log: "logs/build_cutout/{cutout}.log"
         resources: mem=config['atlite'].get('nprocesses', 4) * 1000


### PR DESCRIPTION
Closes #158

## Changes proposed in this Pull Request
See #158 

It still remains to figure out whether the grid should totally include all offshore regions 
* If not, the second assertion (now commented) can be deleted
* If yes, the second assertion has to be uncommented and the bounds of the cutout adjusted in the config.default.  

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] ~Code and workflow changes are sufficiently documented.~
- [ ] ~Newly introduced dependencies are added to `environment.yaml` and `environment.docs.yaml`.~
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.