### PR TITLE
fix emission prices

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -179,7 +179,7 @@ costs:
     hydro: 0.
     H2: 0.
     battery: 0.
-  emission_prices: # only used with the option Ep
+  emission_prices: # in currency per tonne emission, only used with the option Ep
     co2: 0.
 
 solving:

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -156,7 +156,7 @@ costs:
     offwind: 0.015
     H2: 0.
     battery: 0.
-  emission_prices: # only used with the option Ep
+  emission_prices: # in currency per tonne emission, only used with the option Ep
     co2: 0.
 
 solving:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,6 +13,8 @@ Upcoming Release
 
 * ...
 
+* Corrected setting of exogenous emission price (in config -> cost -> emission price). This was not weighted by the efficiency and effective emission of the generators. Fixed in `#171 <https://github.com/PyPSA/pypsa-eur/pull/171>`_.
+
 
 PyPSA-Eur 0.2.0 (8th June 2020)
 ==================================

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -7,7 +7,7 @@
 Prepare PyPSA network for solving according to :ref:`opts` and :ref:`ll`, such as
 
 - adding an annual **limit** of carbon-dioxide emissions,
-- adding an exogenous **price** of carbon-dioxide emissions (or other kinds),
+- adding an exogenous **price** per tonne emissions of carbon-dioxide (or other kinds),
 - setting an **N-1 security margin** factor for transmission line capacities,
 - specifying a limit on the **cost** of transmission expansion,
 - specifying a limit on the **volume** of transmission expansion, and

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -85,8 +85,10 @@ def add_emission_prices(n, emission_prices=None, exclude_co2=False):
     if exclude_co2: emission_prices.pop('co2')
     ep = (pd.Series(emission_prices).rename(lambda x: x+'_emissions') *
           n.carriers.filter(like='_emissions')).sum(axis=1)
-    n.generators['marginal_cost'] += n.generators.carrier.map(ep)
-    n.storage_units['marginal_cost'] += n.storage_units.carrier.map(ep)
+    gen_ep = n.generators.carrier.map(ep) / n.generators.efficiency
+    n.generators['marginal_cost'] += gen_ep
+    su_ep = n.storage_units.carrier.map(ep) / n.storage_units.efficiency
+    n.storage_units['marginal_cost'] += su_ep
 
 def set_line_s_max_pu(n):
     # set n-1 security margin to 0.5 for 37 clusters and to 0.7 from 200 clusters

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -87,7 +87,7 @@ def add_emission_prices(n, emission_prices=None, exclude_co2=False):
           n.carriers.filter(like='_emissions')).sum(axis=1)
     gen_ep = n.generators.carrier.map(ep) / n.generators.efficiency
     n.generators['marginal_cost'] += gen_ep
-    su_ep = n.storage_units.carrier.map(ep) / n.storage_units.efficiency
+    su_ep = n.storage_units.carrier.map(ep) / n.storage_units.efficiency_dispatch
     n.storage_units['marginal_cost'] += su_ep
 
 def set_line_s_max_pu(n):


### PR DESCRIPTION
## Changes proposed in this Pull Request

I'm not sure if the previous setup was intentional, but regarding that different generators might have different efficiencies and the emissions are carrier-specific only, it makes more sense assume that the price in the config sets net emission price.



## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] ~Code and workflow changes are sufficiently documented.~
- [x] ~Newly introduced dependencies are added to `environment.yaml` and `environment.docs.yaml`.~
- [x] ~Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.~
- [x] ~Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.~
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.