### PR TITLE
Fix two issues with new 2020 ENTSO-E grid extract

### DIFF
--- a/data/parameter_corrections.yaml
+++ b/data/parameter_corrections.yaml
@@ -26,4 +26,8 @@ Link:
       "14537": 1000 # NEMO GB-BE
       "14538": 1000 # ALEGrO BE-DE
       "14556": 600  # Storebaelt
-      "12997": 1000 # Sardignia      
+      "12997": 1000 # Sardignia
+  bus1:
+    index:
+      "11511": "6240" # fix wrong bus allocation
+      "14559": "6240" # fix wrong bus allocation

--- a/data/parameter_corrections.yaml
+++ b/data/parameter_corrections.yaml
@@ -29,5 +29,16 @@ Link:
       "12997": 1000 # Sardignia
   bus1:
     index:
-      "11511": "6240" # fix wrong bus allocation
-      "14559": "6240" # fix wrong bus allocation
+      "11511": "6240" # fix wrong bus allocation from 6241
+      "14559": "6240" # fix wrong bus allocation from 6241
+      "12998": "1333" # combine link 12998 + 12997 in 12998
+      "5627": '2309' # combine link 5627 + 5628 in 5627
+  length: 
+    index:
+      "12998": 409.0 
+      "5627": 26.39
+  bus0: 
+    index: 
+      # set bus0 == bus1 for removing the link in remove_unconnected_components
+      "5628": "7276" 
+      "12997": "7276"

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -15,6 +15,8 @@ Upcoming Release
 
 * Add compatibility for pyomo 5.7.0 in :mod:`cluster_network` and :mod:`simplify_network`.
 
+* Corrected HVDC link connections (a) between Norway and Denmark and (b) mainland Italy, Corsica (FR) and Sardinia (IT) (`#181 <https://github.com/PyPSA/pypsa-eur/pull/181>`_)
+
 PyPSA-Eur 0.2.0 (8th June 2020)
 ==================================
 

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -275,6 +275,13 @@ def _apply_parameter_corrections(n):
                 inds = r.index.intersection(df.index)
                 df.loc[inds, attr] = r[inds].astype(df[attr].dtype)
 
+def _apply_sardinia_corsica_link_corrections(n):
+    for lk_keep, lk_remove in [("12998", "12997"),("5627", "5628")]:
+        n.links.at[lk_keep, "bus1"] = n.links.at[lk_remove, "bus0"]
+        n.links.at[lk_keep, "length"] += n.links.at[lk_remove, "length"]
+        n.remove("Link", lk_remove)
+    n.remove("Bus", "7276")
+
 def _set_electrical_parameters_lines(lines):
     v_noms = snakemake.config['electricity']['voltages']
     linetypes = snakemake.config['lines']['types']
@@ -547,6 +554,8 @@ def base_network():
     _set_lines_s_nom_from_linetypes(n)
 
     _apply_parameter_corrections(n)
+
+    _apply_sardinia_corsica_link_corrections(n)
 
     _set_countries_and_substations(n)
 

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -275,13 +275,6 @@ def _apply_parameter_corrections(n):
                 inds = r.index.intersection(df.index)
                 df.loc[inds, attr] = r[inds].astype(df[attr].dtype)
 
-def _apply_sardinia_corsica_link_corrections(n):
-    for lk_keep, lk_remove in [("12998", "12997"),("5627", "5628")]:
-        n.links.at[lk_keep, "bus1"] = n.links.at[lk_remove, "bus0"]
-        n.links.at[lk_keep, "length"] += n.links.at[lk_remove, "length"]
-        n.remove("Link", lk_remove)
-    n.remove("Bus", "7276")
-
 def _set_electrical_parameters_lines(lines):
     v_noms = snakemake.config['electricity']['voltages']
     linetypes = snakemake.config['lines']['types']
@@ -549,13 +542,11 @@ def base_network():
     n.import_components_from_dataframe(links, "Link")
     n.import_components_from_dataframe(converters, "Link")
 
-    n = _remove_unconnected_components(n)
-
     _set_lines_s_nom_from_linetypes(n)
 
     _apply_parameter_corrections(n)
 
-    _apply_sardinia_corsica_link_corrections(n)
+    n = _remove_unconnected_components(n)
 
     _set_countries_and_substations(n)
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

There were two issues with the 2020 ENTSO-E grid extract from https://www.entsoe.eu/data/map/ preventing clustering down to 37 nodes (39 was the minimum because additional subnetworks not connected to AC network or cross-country HVDC links were formed).

**Skagerrak HVDC links between DK and NO** were partially allocated to the wrong terminal bus in NO and included a "self-link".

For **HVDC connections mainland IT, Sardinia and Corsica** a node was wrongly created at the intersection between two actually separate connections.

![Note 22 Aug 2020](https://user-images.githubusercontent.com/29101152/90978486-951ae900-e54e-11ea-975a-d562bf72b827.png)

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
~- [ ] Code and workflow changes are sufficiently documented.~
~- [ ] Newly introduced dependencies are added to `environment.yaml` and `environment.docs.yaml`.~
~- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.~
~- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.~
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.