### PR TITLE
Fix clustering sites

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -25,6 +25,8 @@ Upcoming Release
 
 * Don't remove capital costs from lines and links, when imposing a line volume limit (wildcard ``lv``) or a line cost limit (``lc``). Previously, these were removed to move the expansion in direction of the limit. 
 
+* Fix bug of clustering offwind-{ac,dc} sites in the option of high-resolution sites for renewables. Now, there are more sites for offwind-{ac,dc} available than network nodes. Before, they were clustered to the resolution of the network. (e.g. elec_s1024_37m.nc: 37 network nodes, 1024 sites)
+
 PyPSA-Eur 0.2.0 (8th June 2020)
 ==================================
 

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -333,7 +333,7 @@ if __name__ == "__main__":
 
     renewable_carriers = pd.Index([tech
                                    for tech in n.generators.carrier.unique()
-                                   if tech.split('-', 2)[0] in snakemake.config['renewable']])
+                                   if tech in snakemake.config['renewable']])
 
     if snakemake.wildcards.clusters.endswith('m'):
         n_clusters = int(snakemake.wildcards.clusters[:-1])


### PR DESCRIPTION
## Changes proposed in this Pull Request

Fix bug of clustering offwind-{ac,dc} sites in the option of high-resolution sites for renewables. Now, there are more sites for offwind-{ac,dc} available than network nodes. Before, they were clustered to the resolution of the network. (e.g. elec_s1024_37m.nc: 37 network nodes, 1024 sites - now up to 1024 sites are available for offwind-{ac,dc}).

It's really just one line of code that has to be adjusted.

## Checklist
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `environment.yaml` and `environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.