### PR TITLE
cluster: fix removing deprec squeeze=True in groupby

### DIFF
--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -258,7 +258,7 @@ def busmap_for_n_clusters(n, n_clusters, solver_name, focus_weights=None, algori
             raise ValueError(f"`algorithm` must be one of 'kmeans', 'spectral' or 'louvain'. Is {algorithm}.")
 
     return (n.buses.groupby(['country', 'sub_network'], group_keys=False)
-            .apply(busmap_for_country).rename('busmap'))
+            .apply(busmap_for_country).squeeze().rename('busmap'))
 
 def plot_busmap_for_n_clusters(n, n_clusters=50):
     busmap = busmap_for_n_clusters(n, n_clusters)


### PR DESCRIPTION
9331f1ec46ceafd8aeffbbb655e3ec9acee3acdb breaks the code for me. @eb5194 next time, let's use a pull request which runs automated tests.

```
Traceback (most recent call last):
  File "/home/ws/sp2668/bwss/playgrounds/pr/pypsa-eur/.snakemake/scripts/tmp927_i94b.cluster_network.py", line 375, in <module>
    focus_weights=focus_weights)
  File "/home/ws/sp2668/bwss/playgrounds/pr/pypsa-eur/.snakemake/scripts/tmp927_i94b.cluster_network.py", line 288, in clustering_for_n_clusters
    n, busmap_for_n_clusters(n, n_clusters, solver_name, focus_weights, algorithm),
  File "/home/ws/sp2668/bwss/playgrounds/pr/pypsa-eur/.snakemake/scripts/tmp927_i94b.cluster_network.py", line 265, in busmap_for_n_clusters
    .apply(busmap_for_country).rename('busmap'))
  File "/home/ws/sp2668/miniconda3/envs/pypsa-eur-dev/lib/python3.7/site-packages/pandas/util/_decorators.py", line 309, in wrapper
    return func(*args, **kwargs)
  File "/home/ws/sp2668/miniconda3/envs/pypsa-eur-dev/lib/python3.7/site-packages/pandas/core/frame.py", line 4301, in rename
    errors=errors,
  File "/home/ws/sp2668/miniconda3/envs/pypsa-eur-dev/lib/python3.7/site-packages/pandas/core/generic.py", line 938, in rename
    indexer = ax.get_indexer_for(replacements)
  File "/home/ws/sp2668/miniconda3/envs/pypsa-eur-dev/lib/python3.7/site-packages/pandas/core/indexes/base.py", line 4707, in get_indexer_for
    return self.get_indexer(target, **kwargs)
  File "/home/ws/sp2668/miniconda3/envs/pypsa-eur-dev/lib/python3.7/site-packages/pandas/core/indexes/multi.py", line 2433, in get_indexer
    target = ensure_index(target)
  File "/home/ws/sp2668/miniconda3/envs/pypsa-eur-dev/lib/python3.7/site-packages/pandas/core/indexes/base.py", line 5612, in ensure_index
    return Index(index_like)
  File "/home/ws/sp2668/miniconda3/envs/pypsa-eur-dev/lib/python3.7/site-packages/pandas/core/indexes/base.py", line 411, in __new__
    raise cls._scalar_data_error(data)
TypeError: Index(...) must be called with a collection of some kind, 'busmap' was passed
```