### PR TITLE
travis: use mamba for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,15 @@ before_install:
 
   # install conda environment
   - conda env create -f ./environment.yaml
+  - conda install -c conda-forge mamba
+  - mamba env create -f ./envs/environment.yaml
   - conda activate pypsa-eur
 
   # install open-source solver
-  - conda install -c conda-forge ipopt glpk
+  - mamba install -c conda-forge ipopt glpk
+
+  # list packages for easier debugging
+  - conda list
 
 script:
   - cp ./test/config.test1.yaml ./config.yaml

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -27,6 +27,8 @@ Upcoming Release
 
 * Fix bug of clustering offwind-{ac,dc} sites in the option of high-resolution sites for renewables. Now, there are more sites for offwind-{ac,dc} available than network nodes. Before, they were clustered to the resolution of the network. (e.g. elec_s1024_37m.nc: 37 network nodes, 1024 sites)
 
+* Use `mamba` (https://github.com/mamba-org/mamba) for faster Travis CI builds (`#196 <https://github.com/PyPSA/pypsa-eur/pull/196>`_)
+
 PyPSA-Eur 0.2.0 (8th June 2020)
 ==================================
 


### PR DESCRIPTION
Closes #188  (if applicable).

## Changes proposed in this Pull Request

Use mamba https://github.com/mamba-org/mamba for faster Travis CI builds.

## Checklist

- ~[ ] I tested my contribution locally and it seems to work fine.~
- [x] Code and workflow changes are sufficiently documented.
- ~[ ] Newly introduced dependencies are added to `environment.yaml` and `environment.docs.yaml`.~
- ~[ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.~
- ~[ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.~
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.