### PR TITLE
simplify_ and cluster_network: clustermaps to csv

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -226,7 +226,7 @@ rule simplify_network:
         network='networks/{network}_s{simpl}.nc',
         regions_onshore="resources/regions_onshore_{network}_s{simpl}.geojson",
         regions_offshore="resources/regions_offshore_{network}_s{simpl}.geojson",
-        clustermaps='resources/clustermaps_{network}_s{simpl}.h5'
+        busmap='resources/busmap_{network}_s{simpl}.csv'
     log: "logs/simplify_network/{network}_s{simpl}.log"
     benchmark: "benchmarks/simplify_network/{network}_s{simpl}"
     threads: 1
@@ -239,13 +239,16 @@ rule cluster_network:
         network='networks/{network}_s{simpl}.nc',
         regions_onshore="resources/regions_onshore_{network}_s{simpl}.geojson",
         regions_offshore="resources/regions_offshore_{network}_s{simpl}.geojson",
-        clustermaps=ancient('resources/clustermaps_{network}_s{simpl}.h5'),
+        busmap=ancient('resources/busmap_{network}_s{simpl}.csv'),
         tech_costs=COSTS
     output:
         network='networks/{network}_s{simpl}_{clusters}.nc',
         regions_onshore="resources/regions_onshore_{network}_s{simpl}_{clusters}.geojson",
         regions_offshore="resources/regions_offshore_{network}_s{simpl}_{clusters}.geojson",
-        clustermaps='resources/clustermaps_{network}_s{simpl}_{clusters}.h5'
+        busmap="resources/busmap_{network}_s{simpl}_{clusters}.csv",
+        linemap="resources/linemap_{network}_s{simpl}_{clusters}.csv",
+        linemap_positive="resources/linemap_positive_{network}_s{simpl}_{clusters}.csv",
+        linemap_negative="resources/linemap_negative_{network}_s{simpl}_{clusters}.csv"
     log: "logs/cluster_network/{network}_s{simpl}_{clusters}.log"
     benchmark: "benchmarks/cluster_network/{network}_s{simpl}_{clusters}"
     threads: 1

--- a/Snakefile
+++ b/Snakefile
@@ -246,9 +246,7 @@ rule cluster_network:
         regions_onshore="resources/regions_onshore_{network}_s{simpl}_{clusters}.geojson",
         regions_offshore="resources/regions_offshore_{network}_s{simpl}_{clusters}.geojson",
         busmap="resources/busmap_{network}_s{simpl}_{clusters}.csv",
-        linemap="resources/linemap_{network}_s{simpl}_{clusters}.csv",
-        linemap_positive="resources/linemap_positive_{network}_s{simpl}_{clusters}.csv",
-        linemap_negative="resources/linemap_negative_{network}_s{simpl}_{clusters}.csv"
+        linemap="resources/linemap_{network}_s{simpl}_{clusters}.csv"
     log: "logs/cluster_network/{network}_s{simpl}_{clusters}.log"
     benchmark: "benchmarks/cluster_network/{network}_s{simpl}_{clusters}"
     threads: 1

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -35,6 +35,8 @@ Upcoming Release
 
 * Use `mamba` (https://github.com/mamba-org/mamba) for faster Travis CI builds (`#196 <https://github.com/PyPSA/pypsa-eur/pull/196>`_)
 
+* Output of `simplify_network.py` and `cluster_network.py` changed from Hierarchical Data Format (.h5) to Comma-Separated Values format (.csv), i.e. all busmaps and linemaps.
+
 PyPSA-Eur 0.2.0 (8th June 2020)
 ==================================
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -35,7 +35,7 @@ Upcoming Release
 
 * Use `mamba` (https://github.com/mamba-org/mamba) for faster Travis CI builds (`#196 <https://github.com/PyPSA/pypsa-eur/pull/196>`_)
 
-* Output of `simplify_network.py` and `cluster_network.py` changed from Hierarchical Data Format (.h5) to Comma-Separated Values format (.csv), i.e. all busmaps and linemaps.
+*  The mappings for clustered lines and buses produced by the ``simplify_network`` and ``cluster_network`` rules changed from Hierarchical Data Format (.h5) to Comma-Separated Values format (.csv) (`#198 <https://github.com/PyPSA/pypsa-eur/pull/198>`_)
 
 PyPSA-Eur 0.2.0 (8th June 2020)
 ==================================

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -371,11 +371,9 @@ if __name__ == "__main__":
                                                focus_weights=focus_weights)
 
     clustering.network.export_to_netcdf(snakemake.output.network)
-    with pd.HDFStore(snakemake.output.clustermaps, mode='w') as store:
-        with pd.HDFStore(snakemake.input.clustermaps, mode='r') as clustermaps:
-            for attr in clustermaps.keys():
-                store.put(attr, clustermaps[attr], format="table", index=False)
-        for attr in ('busmap', 'linemap', 'linemap_positive', 'linemap_negative'):
-            store.put(attr, getattr(clustering, attr), format="table", index=False)
+    for attr in ('busmap', 'linemap', 'linemap_positive', 'linemap_negative'):
+        getattr(clustering, attr).to_csv("resources/{}_{}_s{}_{}.csv"
+                                         .format(attr, snakemake.wildcards.network,
+                                                 snakemake.wildcards.simpl, n_clusters))
 
     cluster_regions((clustering.busmap,))

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -371,9 +371,7 @@ if __name__ == "__main__":
                                                focus_weights=focus_weights)
 
     clustering.network.export_to_netcdf(snakemake.output.network)
-    for attr in ('busmap', 'linemap', 'linemap_positive', 'linemap_negative'):
-        getattr(clustering, attr).to_csv("resources/{}_{}_s{}_{}.csv"
-                                         .format(attr, snakemake.wildcards.network,
-                                                 snakemake.wildcards.simpl, n_clusters))
+    for attr in ('busmap', 'linemap'): #also available: linemap_positive, linemap_negative
+        getattr(clustering, attr).to_csv(snakemake.output[attr])
 
     cluster_regions((clustering.busmap,))

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -356,8 +356,7 @@ if __name__ == "__main__":
 
     n.export_to_netcdf(snakemake.output.network)
 
-    busemap_s = reduce(lambda x, y: x.map(y), busmaps[1:], busmaps[0])
-    with pd.HDFStore(snakemake.output.clustermaps, mode='w') as store:
-        store.put('busmap_s', busemap_s, format="table", index=False)
+    (reduce(lambda x, y: x.map(y), busmaps[1:], busmaps[0])
+     .to_csv('resources/busmap_{}_s{}.csv'.format(snakemake.wildcards.network,snakemake.wildcards.simpl)))
 
     cluster_regions(busmaps, snakemake.input, snakemake.output)

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -356,7 +356,7 @@ if __name__ == "__main__":
 
     n.export_to_netcdf(snakemake.output.network)
 
-    (reduce(lambda x, y: x.map(y), busmaps[1:], busmaps[0])
-     .to_csv('resources/busmap_{}_s{}.csv'.format(snakemake.wildcards.network,snakemake.wildcards.simpl)))
+    busmap_s = reduce(lambda x, y: x.map(y), busmaps[1:], busmaps[0])
+    busmap_s.to_csv(snakemake.output.busmap)
 
     cluster_regions(busmaps, snakemake.input, snakemake.output)


### PR DESCRIPTION
## Changes proposed in this Pull Request
Output file `clustermaps` of `simplify_network` and `cluster_network` splitted into seperate output files: `busmap_{network}_s{simpl}`, `busmap_{network}_s{simpl}_{nclusters}`, `linemap_{network}_s{simpl}_{nclusters}`, `linemap_positive_{network}_s{simpl}_{nclusters}` and `linemap_negative_{network}_s{simpl}_{nclusters}`.  The format changed from Hierarchical Data Format (`.h5`) to Comma Seperated Values format (`.csv`) for easier user handling.

Should we save all output files? Or would it be sufficient to save only the busmaps, not the linemaps as they are derived based on the busmapping?

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `environment.yaml` and `environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.