### PR TITLE
prepare_network: fix nmo security margin

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -35,6 +35,8 @@ Upcoming Release
 
 * Use `mamba` (https://github.com/mamba-org/mamba) for faster Travis CI builds (`#196 <https://github.com/PyPSA/pypsa-eur/pull/196>`_)
 
+* N-1 security margin is fixed to provided value in config file, removed linear interpolation between 0.5 and 0.7 in the range of 37 to 200 nodes.
+
 PyPSA-Eur 0.2.0 (8th June 2020)
 ==================================
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -35,7 +35,7 @@ Upcoming Release
 
 * Use `mamba` (https://github.com/mamba-org/mamba) for faster Travis CI builds (`#196 <https://github.com/PyPSA/pypsa-eur/pull/196>`_)
 
-* N-1 security margin is fixed to provided value in config file, removed linear interpolation between 0.5 and 0.7 in the range of 37 to 200 nodes.
+* The N-1 security margin for transmission lines is now fixed to a provided value in ``config.yaml``, removing an undocumented linear interpolation between 0.5 and 0.7 in the range between 37 and 200 nodes.
 
 PyPSA-Eur 0.2.0 (8th June 2020)
 ==================================

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -93,10 +93,8 @@ def add_emission_prices(n, emission_prices=None, exclude_co2=False):
 
 
 def set_line_s_max_pu(n):
-    # set n-1 security margin to 0.5 for 37 clusters and to 0.7 from 200 clusters
-    n_clusters = len(n.buses)
-    s_max_pu = np.clip(0.5 + 0.2 * (n_clusters - 37) / (200 - 37), 0.5, 0.7)
-    n.lines['s_max_pu'] = s_max_pu
+    n.lines['s_max_pu'] = snakemake.config['lines']['s_max_pu']
+    logger.info("N-1 security margin set to {}".format(snakemake.config['lines']['s_max_pu']))
 
 
 def set_transmission_limit(n, ll_type, factor, Nyears=1):

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -93,8 +93,9 @@ def add_emission_prices(n, emission_prices=None, exclude_co2=False):
 
 
 def set_line_s_max_pu(n):
-    n.lines['s_max_pu'] = snakemake.config['lines']['s_max_pu']
-    logger.info("N-1 security margin set to {}".format(snakemake.config['lines']['s_max_pu']))
+    s_max_pu = snakemake.config['lines']['s_max_pu']
+    n.lines['s_max_pu'] = s_max_pu
+    logger.info(f"N-1 security margin of lines set to {s_max_pu}")
 
 
 def set_transmission_limit(n, ll_type, factor, Nyears=1):


### PR DESCRIPTION
##  Changes proposed in this Pull Request

N-1 security margin used to interpolate between 0.5 (37 nodes) and 0.7 (200 nodes). Should be fixed at 0.7, but value is subject to configuration.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `environment.yaml` and `environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.