### PR TITLE
Parameter corrections for East-Western and Anglo-Scottish interconnection

### DIFF
--- a/data/links_tyndp.csv
+++ b/data/links_tyndp.csv
@@ -6,7 +6,7 @@ Italy-Montenegro,Villanova (IT),Latsva (MT),445,,1200,under construction,Link.14
 NordLink,Tonstad (NO),Wilster (DE),514,,1400,under construction,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/37,6.716948,58.662631,9.373979,53.922479
 COBRA cable,Endrup (DK),Eemshaven (NL),325,,700,under construction,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/71,8.718392,55.523115,6.835494,53.438589
 Thames Estuary Cluster (NEMO-Link),Richborough (GB),Gezelle (BE),140,,1000,under construction,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/74,1.324854,51.295891,3.23043,51.24902
-Anglo-Scottish -1,Hunterston (UK),Deeside (UK),422,,2400,under construction,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/77,-4.898329,55.723331,-3.032972,53.199735
+Anglo-Scottish -1,Hunterston (UK),Deeside (UK),422,,2400,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/77,-4.898329,55.723331,-3.032972,53.199735
 ALEGrO,Lixhe (BE),Oberzier (DE),100,,1000,in permitting,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/92,5.67933,50.7567965,6.474704,50.867532
 North Sea Link,Kvilldal (NO),Blythe (GB),720,,1400,under construction,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/110,6.637527,59.515096,-1.510277,55.126957
 HVDC SuedOstLink,Wolmirstedt (DE),Isar (DE),,557,2000,in permitting,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/130,11.629014,52.252137,12.091596,48.080837

--- a/data/parameter_corrections.yaml
+++ b/data/parameter_corrections.yaml
@@ -33,12 +33,13 @@ Link:
       "14559": "6240" # fix wrong bus allocation from 6241
       "12998": "1333" # combine link 12998 + 12997 in 12998
       "5627": '2309' # combine link 5627 + 5628 in 5627
+      "8068": "5819" # fix GB location of Anglo-Scottish interconnector
   length: 
     index:
       "12998": 409.0 
       "5627": 26.39
   bus0: 
     index: 
-      # set bus0 == bus1 for removing the link in remove_unconnected_components
-      "5628": "7276" 
-      "12997": "7276"
+      "14552": "5819" # fix GB location of GB-IE interconnector
+      "5628": "7276" # bus0 == bus1 to remove link in remove_unconnected_components
+      "12997": "7276" # bus0 == bus1 to remove link in remove_unconnected_components

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -39,6 +39,8 @@ Upcoming Release
 
 * The mappings for clustered lines and buses produced by the ``simplify_network`` and ``cluster_network`` rules changed from Hierarchical Data Format (.h5) to Comma-Separated Values format (.csv) (`#198 <https://github.com/PyPSA/pypsa-eur/pull/198>`_)
 
+* Parameter corrections for East-Western and Anglo-Scottish interconnectors (`#206 <https://github.com/PyPSA/pypsa-eur/pull/206>`_)
+
 
 PyPSA-Eur 0.2.0 (8th June 2020)
 ==================================

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -201,8 +201,8 @@ def _add_links_from_tyndp(buses, links):
     buses = buses.loc[keep_b['Bus']]
     links = links.loc[keep_b['Link']]
 
-    links_tyndp["j"] = _find_closest_links(links, links_tyndp, distance_upper_bound=0.15)
-    # Corresponds approximately to 15km tolerances
+    links_tyndp["j"] = _find_closest_links(links, links_tyndp, distance_upper_bound=0.20)
+    # Corresponds approximately to 20km tolerances
 
     if links_tyndp["j"].notnull().any():
         logger.info("TYNDP links already in the dataset (skipping): " + ", ".join(links_tyndp.loc[links_tyndp["j"].notnull(), "Name"]))


### PR DESCRIPTION
The buses in England were partially allocated to isolated buses.

As a result East-Western interconnector was wrongly removed in `simplify_network`.

Also the distance tolerance for checking duplicate link entries by merging TYNDP projects into the ENTSO-E extract was too low and resulted in a duplicate Anglo-Scottish interconnector.

These are now fixed.