### PR TITLE
Update load processing

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -65,7 +65,7 @@ if config['enable'].get('retrieve_databundle', True):
         log: "logs/retrieve_databundle.log"
         script: 'scripts/retrieve_databundle.py'
 
-if config['enable'].get('build_load', False):
+if config['enable'].get('build_load_data', False):
     rule build_load_data:
         output: "resources/time_series_60min_singleindex_filtered.csv"
         log: "logs/build_load_data.log"

--- a/Snakefile
+++ b/Snakefile
@@ -53,8 +53,7 @@ datafiles = ['ch_cantons.csv', 'je-e-21.03.02.xls',
             'eez/World_EEZ_v8_2014.shp', 'EIA_hydro_generation_2000_2014.csv', 
             'hydro_capacities.csv', 'naturalearth/ne_10m_admin_0_countries.shp', 
             'NUTS_2013_60M_SH/data/NUTS_RG_60M_2013.shp', 'nama_10r_3popgdp.tsv.gz', 
-            'nama_10r_3gdp.tsv.gz', 'time_series_60min_singleindex_filtered.csv', 
-            'corine/g250_clc06_V18_5.tif']
+            'nama_10r_3gdp.tsv.gz', 'corine/g250_clc06_V18_5.tif']
 
 if not config.get('tutorial', False):
     datafiles.extend(["natura/Natura2000_end2015.shp", "GEBCO_2014_2D.nc"])
@@ -65,11 +64,10 @@ if config['enable'].get('retrieve_databundle', True):
         log: "logs/retrieve_databundle.log"
         script: 'scripts/retrieve_databundle.py'
 
-if config['enable'].get('build_load_data', False):
-    rule build_load_data:
-        output: "resources/time_series_60min_singleindex_filtered.csv"
-        log: "logs/build_load_data.log"
-        script: 'scripts/build_load_data.py'
+rule build_load_data:
+    output: "resources/load.csv"
+    log: "logs/build_load_data.log"
+    script: 'scripts/build_load_data.py'
     
 rule build_powerplants:
     input:
@@ -210,7 +208,7 @@ rule add_electricity:
         powerplants='resources/powerplants.csv',
         hydro_capacities='data/bundle/hydro_capacities.csv',
         geth_hydro_capacities='data/geth2015_hydro_capacities.csv',
-        load='resources/time_series_60min_singleindex_filtered.csv',
+        load='resources/load.csv',
         nuts3_shapes='resources/nuts3_shapes.geojson',
         **{'profile_' + t: "resources/profile_" + t + ".nc"
            for t in config['renewable']}

--- a/Snakefile
+++ b/Snakefile
@@ -65,10 +65,11 @@ if config['enable'].get('retrieve_databundle', True):
         log: "logs/retrieve_databundle.log"
         script: 'scripts/retrieve_databundle.py'
 
-rule build_load_data:
-    output: "resources/opsd_load.csv"
-    log: "logs/build_load_data.log"
-    script: 'scripts/build_load_data.py'
+if config['enable'].get('build_load', False):
+    rule build_load_data:
+        output: "resources/time_series_60min_singleindex_filtered.csv"
+        log: "logs/build_load_data.log"
+        script: 'scripts/build_load_data.py'
     
 rule build_powerplants:
     input:
@@ -209,7 +210,7 @@ rule add_electricity:
         powerplants='resources/powerplants.csv',
         hydro_capacities='data/bundle/hydro_capacities.csv',
         geth_hydro_capacities='data/geth2015_hydro_capacities.csv',
-        load='resources/opsd_load.csv',
+        load='resources/time_series_60min_singleindex_filtered.csv',
         nuts3_shapes='resources/nuts3_shapes.geojson',
         **{'profile_' + t: "resources/profile_" + t + ".nc"
            for t in config['renewable']}

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -169,10 +169,9 @@ transformers:
 
 load:
   url: https://data.open-power-system-data.org/time_series/latest/time_series_60min_singleindex.csv
-  source: ENTSOE_power_statistics #ENTSOE_transparency
-  gap_filling_threshold: 3 # Threshold for the automatic filling of gaps in hours.
-  adjust_gaps_manuel: true # false
-  scaling_factor: 1.0
+  interpolate_limit: 3 # data gaps up until this size are interpolated linearly
+  time_shift_for_large_gaps: 1w # data gaps up until this size are copied by copying from 
+  manual_adjustments: true # false
 
 costs:
   year: 2030

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -30,6 +30,7 @@ enable:
   retrieve_databundle: true
   build_cutout: false
   retrieve_cutout: true
+  build_load: false
   build_natura_raster: false
   retrieve_natura_raster: true
 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -173,6 +173,7 @@ load:
   interpolate_limit: 3 # data gaps up until this size are interpolated linearly
   time_shift_for_large_gaps: 1w # data gaps up until this size are copied by copying from 
   manual_adjustments: true # false
+  scaling_factor: 1.0
 
 costs:
   year: 2030

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-version: 0.2.1
+version: 0.2.0
 tutorial: false
 
 logging:
@@ -30,7 +30,6 @@ enable:
   retrieve_databundle: true
   build_cutout: false
   retrieve_cutout: true
-  build_load_data: false
   build_natura_raster: false
   retrieve_natura_raster: true
 
@@ -169,7 +168,8 @@ transformers:
   type: ''
 
 load:
-  url: https://data.open-power-system-data.org/time_series/latest/time_series_60min_singleindex.csv
+  url: https://data.open-power-system-data.org/time_series/2019-06-05/time_series_60min_singleindex.csv
+  power_statistics: True # only for files from <2019; set false in order to get ENTSOE transparency data 
   interpolate_limit: 3 # data gaps up until this size are interpolated linearly
   time_shift_for_large_gaps: 1w # data gaps up until this size are copied by copying from 
   manual_adjustments: true # false

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -30,7 +30,7 @@ enable:
   retrieve_databundle: true
   build_cutout: false
   retrieve_cutout: true
-  build_load: false
+  build_load_data: false
   build_natura_raster: false
   retrieve_natura_raster: true
 

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -146,10 +146,11 @@ transformers:
   type: ''
 
 load:
-  url: https://data.open-power-system-data.org/time_series/latest/time_series_60min_singleindex.csv
-  source: ENTSOE_power_statistics #ENTSOE_transparency
-  gap_filling_threshold: 3 # Threshold for the automatic filling of gaps in hours.
-  adjust_gaps_manuel: false # true
+  url: https://data.open-power-system-data.org/time_series/2019-06-05/time_series_60min_singleindex.csv
+  power_statistics: True # only for files from <2019; set false in order to get ENTSOE transparency data 
+  interpolate_limit: 3 # data gaps up until this size are interpolated linearly
+  time_shift_for_large_gaps: 1w # data gaps up until this size are copied by copying from 
+  manual_adjustments: true # false
   scaling_factor: 1.0
 
 costs:

--- a/doc/configtables/load.csv
+++ b/doc/configtables/load.csv
@@ -1,4 +1,5 @@
 ,Unit,Values,Description
-url,--,"https://data.open-power-system-data.org/time_series/latest/time_series_60min_singleindex.csv","Link to open power system data time series data"
-source,--,"One of {'ENTSOE_power_statistics': set source to 'ENTSOE_power_statistics', 'ENTSOE_transparency': set source to 'ENTSOE_transparency'}"
-scaling_factor,--,float,"Global correction factor for the load time series."
+url,--,string,"Link to open power system data time series data."
+interpolate_limit,hours,integer,"Maximum gap size (consecutive nans) which interpolated linearly."
+time_shift_for_large_gaps,string,string,"Periods which are used for copying time-slices in order to fill large gaps of nans. Have to be valid ``pandas`` period strings."
+manual_adjustments,bool,"{true, false}","Whether to adjust the load data manually according to the function in :func:`manual_adjustment`."

--- a/doc/configtables/load.csv
+++ b/doc/configtables/load.csv
@@ -1,5 +1,7 @@
 ,Unit,Values,Description
 url,--,string,"Link to open power system data time series data."
+power_statistics,bool,"{true, false}",Whether to load the electricity consumption data of the ENTSOE power statistics (only for files from 2019 and before) or from the ENTSOE transparency data (only has load data from 2015 onwards). 
 interpolate_limit,hours,integer,"Maximum gap size (consecutive nans) which interpolated linearly."
 time_shift_for_large_gaps,string,string,"Periods which are used for copying time-slices in order to fill large gaps of nans. Have to be valid ``pandas`` period strings."
 manual_adjustments,bool,"{true, false}","Whether to adjust the load data manually according to the function in :func:`manual_adjustment`."
+scaling_factor,--,float,"Global correction factor for the load time series."

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -218,7 +218,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 170-171
+   :lines: 170-174
 
 .. csv-table::
    :header-rows: 1
@@ -232,7 +232,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 173-185
+   :lines: 175-188
 
 .. csv-table::
    :header-rows: 1
@@ -254,7 +254,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 187-197
+   :lines: 190-200
 
 .. csv-table::
    :header-rows: 1
@@ -266,7 +266,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 187,198-214
+   :lines: 190,201-217
 
 .. csv-table::
    :header-rows: 1
@@ -280,7 +280,7 @@ Specifies the temporal range to build an energy system model for as arguments to
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml
-   :lines: 216-355
+   :lines: 219-358
 
 .. csv-table::
    :header-rows: 1

--- a/doc/preparation.rst
+++ b/doc/preparation.rst
@@ -39,6 +39,7 @@ together into a detailed PyPSA network stored in ``networks/elec.nc``.
 
    preparation/retrieve
    preparation/build_shapes
+   preparation/build_load_data
    preparation/build_cutout
    preparation/build_natura_raster
    preparation/prepare_links_p_nom

--- a/doc/preparation/build_load_data.rst
+++ b/doc/preparation/build_load_data.rst
@@ -1,0 +1,12 @@
+..
+  SPDX-FileCopyrightText: 2020-2021 The PyPSA-Eur Authors
+
+  SPDX-License-Identifier: CC-BY-4.0
+
+.. _load_data:
+
+Rule ``build_load_data``
+=============================
+
+
+.. automodule:: build_load_data

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -46,7 +46,7 @@ Upcoming Release
 
 * Modelling hydrogen and battery storage with Store and Link components is now the default, rather than using StorageUnit components with fixed power-to-energy ratio (`#205 <https://github.com/PyPSA/pypsa-eur/pull/205>`_).
 
-* Electricity consumption data can now be retrieved from the `OPSD website <https://data.open-power-system-data.org/time_series/2020-10-06>`_ using the rule ``build_load_data``. Enable it setting ``build_load_data`` to ``True``. 
+* Electricity consumption data is now directly retrieved from the `OPSD website <https://data.open-power-system-data.org/time_series/2019-06-05>`_ using the rule ``build_load_data``. The user can decide whether to take the ENTSOE power statistics data (defaul) or the ENTSOE transparency data.   
 
 
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -46,6 +46,9 @@ Upcoming Release
 
 * Modelling hydrogen and battery storage with Store and Link components is now the default, rather than using StorageUnit components with fixed power-to-energy ratio (`#205 <https://github.com/PyPSA/pypsa-eur/pull/205>`_).
 
+* Electricity consumption data can now be retrieved from the `OPSD website <https://data.open-power-system-data.org/time_series/2020-10-06>`_ using the rule ``build_load_data``. Enable it setting ``build_load_data`` to ``True``. 
+
+
 
 PyPSA-Eur 0.2.0 (8th June 2020)
 ==================================

--- a/scripts/build_load_data.py
+++ b/scripts/build_load_data.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """
 
-This rule downloads the load data from `Open Power System Data Time series <https://data.open-power-system-data.org/time_series/>` and interpolate the date to fill gaps. The resulting data saved as ``.csv`` file. The user can choose between two different data sources ("ENTSOE_transparency" or "ENTSOE_power_statistics"). 
+This rule downloads the load data from `Open Power System Data Time series <https://data.open-power-system-data.org/time_series/>`. For all countries in the network, the per country load timeseries with suffix ``_load_actual_entsoe_transparency`` are extracted from the dataset. After filling small gaps linearly and large gaps by copying time-slice of a given period, the load data is exported to a ``.csv`` file.
 
 Relevant Settings
 -----------------
@@ -12,7 +12,10 @@ Relevant Settings
 
     load:
         url:
-        source:
+        interpolate_limit:
+        time_shift_for_large_gaps:
+        manual_adjustments: true
+
 
 .. seealso::
     Documentation of the configuration file ``config.yaml`` at
@@ -28,12 +31,6 @@ Outputs
 - ``resource/load.csv``:
 
 
-Description
------------
-
-The configuration options ``load: source:`` can be used to control which load data should be used in the model "ENTSOE_transparency" or "ENTSOE_power_statistics".
-
-
 """
 
 import logging
@@ -41,67 +38,60 @@ logger = logging.getLogger(__name__)
 from _helpers import configure_logging
 
 import pandas as pd
+import numpy as np
 
 
-def load_timeseries_opsd(years=None, fn=None, countries=None, source="ENTSOE_power_statistics"):
+def load_timeseries(fn, years, countries):
     """
-    Read load data from OPSD time-series package version 2019-06-05.
+    Read load data from OPSD time-series package version 2020-10-06.
 
     Parameters
     ----------
     years : None or slice()
         Years for which to read load data (defaults to
         slice("2018","2019"))
-        
-    fn : file name or url location (file format .csv)
-    
-    countries : Countries for which to read load data.
-        
-    source : "ENTSOE_transparency" or "ENTSOE_power_statistics"
+    fn : str
+        File name or url location (file format .csv)
+    countries : listlike
+        Countries for which to read load data.
 
     Returns
     -------
     load : pd.DataFrame
         Load time-series with UTC timestamps x ISO-2 countries
     """
-
-    if countries is None:
-        countries = snakemake.config['countries']
-        
     logger.info(f"Retrieving load data from '{fn}'.")
-     
-    if source == 'ENTSOE_transparency':
-        load = (pd.read_csv(fn, index_col=0, parse_dates=True)
-                .filter(like='_load_actual_entsoe_transparency')
-                .rename(columns=lambda s: s[:-len('_load_actual_entsoe_transparency')])
-                .dropna(how="all", axis=0))
-        
-    elif source == 'ENTSOE_power_statistics':
-        load = (pd.read_csv(fn, index_col=0, parse_dates=True)
-            .filter(like='_load_actual_entsoe_power_statistics')
-            .rename(columns=lambda s: s[:-len('_load_actual_entsoe_power_statistics')])
-            .dropna(how="all", axis=0))
-    else:
-        raise NotImplementedError(f"Data for source `{source}` not available.")
-    
-    
-    load = load.rename(columns={'GB_UKM' : 'GB'}).filter(items=countries)
 
-    if years is not None:
-        load = load.loc[years]
-        
-    
-    return load
+    rename = lambda s: s[:-len('_load_actual_entsoe_transparency')]
+    return (pd.read_csv(fn, index_col=0, parse_dates=True)
+            .filter(like='_load_actual_entsoe_transparency')
+            .rename(columns=rename)
+            .dropna(how="all", axis=0)
+            .rename(columns={'GB_UKM' : 'GB'})
+            .filter(items=countries)
+            .loc[years])
+
 
 def consecutive_nans(ds):
     return (ds.isnull().astype(int)
             .groupby(ds.notnull().astype(int).cumsum()[ds.isnull()])
             .transform('sum').fillna(0))
 
-def fill_large_gaps(ds, lower_bound=3, upper_bound=168):
-    """Fill up large gaps (longer than 3 hours and up to one week (168 hours)) with load data from the previous week."""
-    week_shift = pd.Series(ds.values, ds.index + pd.Timedelta('1w'))
-    return ds.where((consecutive_nans(ds) < lower_bound) | (consecutive_nans(ds) > upper_bound), week_shift.reindex_like(ds))
+
+def fill_large_gaps(ds, shift):
+    """
+    Fill up large gaps with load data from the previous week.
+
+    This function fills gaps ragning from 3 to 168 hours (one week).
+    """
+    shift = pd.Timedelta(shift)
+    nhours = shift / np.timedelta64(1, 'h')
+    if (consecutive_nans(ds) > nhours).any():
+        logger.warning('There exist gaps larger then the time shift used for '
+                       'copying time slices.')
+    time_shift = pd.Series(ds.values, ds.index + shift)
+    return ds.where(ds.notnull(), time_shift.reindex_like(ds))
+
 
 def nan_statistics(df):
     def max_consecutive_nans(ds):
@@ -115,69 +105,46 @@ def nan_statistics(df):
                  keys=['total', 'consecutive', 'max_total_per_month'], axis=1)
 
 
+def copy_timeslice(load, cntry, start, stop, delta):
+    start = pd.Timestamp(start)
+    stop = pd.Timestamp(stop)
+    if start in load.index and stop in load.index:
+        load.loc[start:stop, cntry] = load.loc[start-delta:stop-delta, cntry].values
+    return load
+
+
 def manual_adjustment(load, source="ENTSOE_power_statistics"):
     """
     Adjust gaps manual for load data from OPSD time-series package.
+
+
+    Albania and Macedonia do not exist in the data set. Both get the same load
+    curve as Montenegro,  scaled by correspoding ratio of total energy
+    consumptions reported by  <IEA Data browser `https://www.iea.org/data-and-statistics?country=WORLD&fuel=Electricity%20and%20heat&indicator=TotElecCons>`_ for the
+    year 2016.
+
 
     Parameters
     ----------
     load : pd.DataFrame
         Load time-series with UTC timestamps x ISO-2 countries
-        
-    source : "ENTSOE_transparency" or "ENTSOE_power_statistics"
 
     Returns
     -------
     load : pd.DataFrame
-        Manual adjusted and interpolated load time-series with UTC timestamps x ISO-2 countries
+        Manual adjusted and interpolated load time-series with UTC
+        timestamps x ISO-2 countries
     """
-    def copy_timeslice(load, cntry, start, stop, delta):
-        start = pd.Timestamp(start)
-        stop = pd.Timestamp(stop)
-        if start in load.index and stop in load.index:
-            load.loc[start:stop, cntry] = load.loc[start-delta:stop-delta, cntry].values
-        return load
-    
-    # Kosovo (KV) and Albania (AL) do not exist in the data set 
-    
-    # Kosovo gets the same load curve as Serbia
-    # scale parameter selected by energy consumption ratio from IEA Data browser
-    # IEA 2012 -> scaling parameter = 4.8 / 27.
-    # IEA 2017 -> scaling parameter = 5. / 33.
-    # source https://www.iea.org/data-and-statistics?country=KOSOVO&fuel=Electricity%20and%20heat&indicator=Electricity%20final%20consumption
-    
-    if 'RS' in load.columns:
-        if 'KV' not in load.columns or load.KV.isnull().values.all():
-            load['KV'] = load['RS'] * (4.8 / 27.)
-    
-    # Albania gets the same load curve as Macedonia
-    # scale parameter selected by energy consumption ratio from IEA Data browser
-    # IEA 2012 -> scaling parameter = 4.1 / 7.4
-    # IEA 2017 -> scaling parameter = 6.0 / 7.0
-    # source https://www.iea.org/data-and-statistics?country=ALBANIA&fuel=Electricity%20and%20heat&indicator=Electricity%20final%20consumption
 
-    if 'MK' in load.columns:
-        if 'AL' not in load.columns or load.AL.isnull().values.all():
-            load['AL'] = load['MK'] * (4.1 / 7.4)
+    if 'ME' in load:
+        if 'AL' not in load and 'AL' in countries:
+            load['AL'] = load.ME * (5.7/2.9)
+        if 'MK' not in load and 'MK' in countries:
+            load['MK'] = load.ME * (6.7/2.9)
 
-    
-    if source == 'ENTSOE_power_statistics':
-
-        # To fill periods of load-gaps, we copy a period before into it
-        load = copy_timeslice(load, 'GR', '2015-08-11 21:00', '2015-08-15 20:00', pd.Timedelta(weeks=1))
-        load = copy_timeslice(load, 'AT', '2018-12-31 22:00', '2019-01-01 22:00', pd.Timedelta(days=2))
-        load = copy_timeslice(load, 'CH', '2010-01-19 07:00', '2010-01-19 22:00', pd.Timedelta(days=1))
-        load = copy_timeslice(load, 'CH', '2010-03-28 00:00', '2010-03-28 21:00', pd.Timedelta(days=1))
-        load = copy_timeslice(load, 'CH', '2010-10-08 13:00', '2010-10-10 21:00', pd.Timedelta(weeks=1)) #is a WE, so take WE before
-        load = copy_timeslice(load, 'CH', '2010-11-04 04:00', '2010-11-04 22:00', pd.Timedelta(days=1))
-        load = copy_timeslice(load, 'NO', '2010-12-09 11:00', '2010-12-09 18:00', pd.Timedelta(days=1))
-        load = copy_timeslice(load, 'GB', '2009-12-31 23:00', '2010-01-31 23:00', pd.Timedelta(days=-364)) #whole january missing
-        
-
-    if source == 'ENTSOE_transparency':
-        
-        # To fill periods of load-gaps, we copy a period before into it
-        load = copy_timeslice(load, 'BG', '2018-10-27 21:00', '2018-10-28 22:00', pd.Timedelta(weeks=1))
+    if 'BG' in load:
+        load = copy_timeslice(load, 'BG', '2018-10-27 21:00', '2018-10-28 22:00',
+                              pd.Timedelta(weeks=1))
 
     return load
 
@@ -187,48 +154,33 @@ if __name__ == "__main__":
     if 'snakemake' not in globals():
         from _helpers import mock_snakemake
         snakemake = mock_snakemake('build_load_data')
-        rootpath = '..'
-    else:
-        rootpath = '.'
-    
+
     configure_logging(snakemake)
-    
-    url = snakemake.config['load']['url']
-    
-    opsd_load = (load_timeseries_opsd(years = slice(*pd.date_range(freq='y', **snakemake.config['snapshots'])[[0,-1]].year.astype(str)),
-                                 fn=url,
-                                 countries = snakemake.config['countries'],
-                                 source = snakemake.config['load']['source']))
 
-    # Convert to naive UTC (has to be explicit since pandas 0.24)
-    opsd_load.index = opsd_load.index.tz_localize(None)
-    
-    # check the number and lenght of gaps
-    nan_stats = nan_statistics(opsd_load)
-    
-    gap_filling_threshold = snakemake.config['load']['gap_filling_threshold']
-      
-    if nan_stats.consecutive.max() > gap_filling_threshold:        
-        logger.warning(f"Load data contains consecutive gaps of longer than '{gap_filling_threshold}' hours! Check dataset carefully!")
+    config = snakemake.config
+    url = config['load']['url']
+    interpolate_limit = config['load']['interpolate_limit']
+    countries = config['countries']
+    snapshots = pd.date_range(freq='h', **config['snapshots'])
+    years = slice(snapshots[0], snapshots[-1])
+    time_shift = config['load']['time_shift_for_large_gaps']
 
-    # adjust gaps manuel
-    if snakemake.config['load']['adjust_gaps_manuel']:
-        logger.info(f"Load data are adjusted manual. See adjustes in the manual_adjustment() function")
-        opsd_load = manual_adjustment(load=opsd_load, source=snakemake.config['load']['source'])
+    load = load_timeseries(url, years, countries)
 
-    # Adjust gaps and interpolate load data with predefined heuristics
-    logger.info(f"Gaps up to a length of one week and longer than {gap_filling_threshold} hours filled with data from previous week. Smaler gaps interpolated linearly.")
-    # Longer gaps filled with data from previous week lower_bound is gap_filling_threshold and upper bound is one week.
-    opsd_load = opsd_load.apply(fill_large_gaps, lower_bound=gap_filling_threshold)
-    # Interpolate over the data with filling limit of gap_filling_threshold
-    opsd_load = opsd_load.interpolate(method='linear', limit=gap_filling_threshold)
+    if config['load']['manual_adjustments']:
+        load = manual_adjustment(load)
 
-   
-    # check the number and lenght of gaps after adjustment and interpolating
-    nan_stats = nan_statistics(opsd_load)
-    
-    if nan_stats.consecutive.max() > 0:
-        raise NotImplementedError(f'Load data contains gaps after adjustments. Modify manual_adjustment() function for implementing the needed load data modifications!')
+    logger.info(f"Interpolate gaps of size {interpolate_limit} or less linearly.")
+    load = load.interpolate(method='linear', limit=interpolate_limit)
 
-    opsd_load.to_csv(snakemake.output[0])
-    
+    logger.info("Filling larger gaps by copying time-slices of period "
+                f"'{time_shift}'.")
+    load = load.apply(fill_large_gaps, shift=time_shift)
+
+    assert not load.isna().any().any(), (
+        'Load data contains nans. Adjust the parameters '
+        '`time_shift_for_large_gaps` or modify the `manual_adjustment` function '
+        'for implementing the needed load data modifications.')
+
+    load.to_csv(snakemake.output[0])
+

--- a/scripts/build_load_data.py
+++ b/scripts/build_load_data.py
@@ -28,7 +28,7 @@ Inputs
 Outputs
 -------
 
-- ``resource/load.csv``:
+- ``resource/time_series_60min_singleindex_filtered.csv``:
 
 
 """

--- a/scripts/build_load_data.py
+++ b/scripts/build_load_data.py
@@ -39,9 +39,11 @@ from _helpers import configure_logging
 
 import pandas as pd
 import numpy as np
+import dateutil
+from pandas import Timedelta as Delta
 
 
-def load_timeseries(fn, years, countries):
+def load_timeseries(fn, years, countries, powerstatistics=True):
     """
     Read load data from OPSD time-series package version 2020-10-06.
 
@@ -54,6 +56,10 @@ def load_timeseries(fn, years, countries):
         File name or url location (file format .csv)
     countries : listlike
         Countries for which to read load data.
+    powerstatistics: bool
+        Whether the electricity consumption data of the ENTSOE power
+        statistics (if true) or of the ENTSOE transparency map (if false)
+        should be parsed.
 
     Returns
     -------
@@ -62,9 +68,12 @@ def load_timeseries(fn, years, countries):
     """
     logger.info(f"Retrieving load data from '{fn}'.")
 
-    rename = lambda s: s[:-len('_load_actual_entsoe_transparency')]
-    return (pd.read_csv(fn, index_col=0, parse_dates=True)
-            .filter(like='_load_actual_entsoe_transparency')
+    pattern = 'power_statistics' if powerstatistics else '_transparency'
+    pattern = f'_load_actual_entsoe_{pattern}'
+    rename = lambda s: s[:-len(pattern)]
+    date_parser = lambda x: dateutil.parser.parse(x, ignoretz=True)
+    return (pd.read_csv(fn, index_col=0, parse_dates=[0], date_parser=date_parser)
+            .filter(like=pattern)
             .rename(columns=rename)
             .dropna(how="all", axis=0)
             .rename(columns={'GB_UKM' : 'GB'})
@@ -84,7 +93,7 @@ def fill_large_gaps(ds, shift):
 
     This function fills gaps ragning from 3 to 168 hours (one week).
     """
-    shift = pd.Timedelta(shift)
+    shift = Delta(shift)
     nhours = shift / np.timedelta64(1, 'h')
     if (consecutive_nans(ds) > nhours).any():
         logger.warning('There exist gaps larger then the time shift used for '
@@ -108,26 +117,37 @@ def nan_statistics(df):
 def copy_timeslice(load, cntry, start, stop, delta):
     start = pd.Timestamp(start)
     stop = pd.Timestamp(stop)
-    if start in load.index and stop in load.index:
+    if start-delta in load.index and stop in load.index and cntry in load:
         load.loc[start:stop, cntry] = load.loc[start-delta:stop-delta, cntry].values
-    return load
 
 
-def manual_adjustment(load, source="ENTSOE_power_statistics"):
+def manual_adjustment(load, powerstatistics):
     """
     Adjust gaps manual for load data from OPSD time-series package.
 
+    1. For the ENTSOE power statistics load data (if powerstatistics is True)
 
-    Albania and Macedonia do not exist in the data set. Both get the same load
-    curve as Montenegro,  scaled by correspoding ratio of total energy
-    consumptions reported by  <IEA Data browser `https://www.iea.org/data-and-statistics?country=WORLD&fuel=Electricity%20and%20heat&indicator=TotElecCons>`_ for the
-    year 2016.
+    Kosovo (KV) and Albania (AL) do not exist in the data set. Kosovo gets the
+    same load curve as Serbia and Albania the same as Macdedonia, both scaled
+    by the corresponding ratio of total energy consumptions reported by
+    IEA Data browser [0] for the year 2013.
+
+    2. For the ENTSOE transparency load data (if powerstatistics is False)
+
+    Albania (AL) and Macedonia (MK) do not exist in the data set. Both get the
+    same load curve as Montenegro,  scaled by the corresponding ratio of total energy
+    consumptions reported by  IEA Data browser [0] for the year 2016.
+
+    [0] https://www.iea.org/data-and-statistics?country=WORLD&fuel=Electricity%20and%20heat&indicator=TotElecCons
 
 
     Parameters
     ----------
     load : pd.DataFrame
         Load time-series with UTC timestamps x ISO-2 countries
+    powerstatistics: bool
+        Whether argument load comprises the electricity consumption data of
+        the ENTSOE power statistics or of the ENTSOE transparency map
 
     Returns
     -------
@@ -136,15 +156,32 @@ def manual_adjustment(load, source="ENTSOE_power_statistics"):
         timestamps x ISO-2 countries
     """
 
-    if 'ME' in load:
-        if 'AL' not in load and 'AL' in countries:
-            load['AL'] = load.ME * (5.7/2.9)
-        if 'MK' not in load and 'MK' in countries:
-            load['MK'] = load.ME * (6.7/2.9)
+    if powerstatistics:
+        if 'MK' in load.columns:
+            if 'AL' not in load.columns or load.AL.isnull().values.all():
+                load['AL'] = load['MK'] * (4.1 / 7.4)
+        if 'RS' in load.columns:
+            if 'KV' not in load.columns or load.KV.isnull().values.all():
+                load['KV'] = load['RS'] * (4.8 / 27.)
 
-    if 'BG' in load:
-        load = copy_timeslice(load, 'BG', '2018-10-27 21:00', '2018-10-28 22:00',
-                              pd.Timedelta(weeks=1))
+        copy_timeslice(load, 'GR', '2015-08-11 21:00', '2015-08-15 20:00', Delta(weeks=1))
+        copy_timeslice(load, 'AT', '2018-12-31 22:00', '2019-01-01 22:00', Delta(days=2))
+        copy_timeslice(load, 'CH', '2010-01-19 07:00', '2010-01-19 22:00', Delta(days=1))
+        copy_timeslice(load, 'CH', '2010-03-28 00:00', '2010-03-28 21:00', Delta(days=1))
+        # is a WE, so take WE before
+        copy_timeslice(load, 'CH', '2010-10-08 13:00', '2010-10-10 21:00', Delta(weeks=1))
+        copy_timeslice(load, 'CH', '2010-11-04 04:00', '2010-11-04 22:00', Delta(days=1))
+        copy_timeslice(load, 'NO', '2010-12-09 11:00', '2010-12-09 18:00', Delta(days=1))
+        # whole january missing
+        copy_timeslice(load, 'GB', '2009-12-31 23:00', '2010-01-31 23:00', Delta(days=-364))
+
+    else:
+        if 'ME' in load:
+            if 'AL' not in load and 'AL' in countries:
+                load['AL'] = load.ME * (5.7/2.9)
+            if 'MK' not in load and 'MK' in countries:
+                load['MK'] = load.ME * (6.7/2.9)
+        copy_timeslice(load, 'BG', '2018-10-27 21:00', '2018-10-28 22:00', Delta(weeks=1))
 
     return load
 
@@ -158,6 +195,7 @@ if __name__ == "__main__":
     configure_logging(snakemake)
 
     config = snakemake.config
+    powerstatistics = config['load']['power_statistics']
     url = config['load']['url']
     interpolate_limit = config['load']['interpolate_limit']
     countries = config['countries']
@@ -165,12 +203,12 @@ if __name__ == "__main__":
     years = slice(snapshots[0], snapshots[-1])
     time_shift = config['load']['time_shift_for_large_gaps']
 
-    load = load_timeseries(url, years, countries)
+    load = load_timeseries(url, years, countries, powerstatistics)
 
     if config['load']['manual_adjustments']:
-        load = manual_adjustment(load)
+        load = manual_adjustment(load, powerstatistics)
 
-    logger.info(f"Interpolate gaps of size {interpolate_limit} or less linearly.")
+    logger.info(f"Linearly interpolate gaps of size {interpolate_limit} and less.")
     load = load.interpolate(method='linear', limit=interpolate_limit)
 
     logger.info("Filling larger gaps by copying time-slices of period "

--- a/scripts/build_load_data.py
+++ b/scripts/build_load_data.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """
 
-This rule downloads the load data from `Open Power System Data Time series <https://data.open-power-system-data.org/time_series/>`. For all countries in the network, the per country load timeseries with suffix ``_load_actual_entsoe_transparency`` are extracted from the dataset. After filling small gaps linearly and large gaps by copying time-slice of a given period, the load data is exported to a ``.csv`` file.
+This rule downloads the load data from `Open Power System Data Time series <https://data.open-power-system-data.org/time_series/>`_. For all countries in the network, the per country load timeseries with suffix ``_load_actual_entsoe_transparency`` are extracted from the dataset. After filling small gaps linearly and large gaps by copying time-slice of a given period, the load data is exported to a ``.csv`` file.
 
 Relevant Settings
 -----------------
@@ -19,7 +19,7 @@ Relevant Settings
 
 .. seealso::
     Documentation of the configuration file ``config.yaml`` at
-    :ref:`load`
+    :ref:`load_cf`
 
 Inputs
 ------

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -146,10 +146,11 @@ transformers:
   type: ''
 
 load:
-  url: https://data.open-power-system-data.org/time_series/latest/time_series_60min_singleindex.csv
-  source: ENTSOE_power_statistics #ENTSOE_transparency
-  gap_filling_threshold: 3 # Threshold for the automatic filling of gaps in hours.
-  adjust_gaps_manuel: false # true
+  url: https://data.open-power-system-data.org/time_series/2019-06-05/time_series_60min_singleindex.csv
+  power_statistics: True # only for files from <2019; set false in order to get ENTSOE transparency data 
+  interpolate_limit: 3 # data gaps up until this size are interpolated linearly
+  time_shift_for_large_gaps: 1w # data gaps up until this size are copied by copying from 
+  manual_adjustments: true # false
   scaling_factor: 1.0
 
 costs:


### PR DESCRIPTION
This PR supersedes and simplifies #170 . 

## General remarks (in comparison to #170):

The "power statistic" time-series are not supported in the latest data file by [OPSD](https://data.open-power-system-data.org/time_series/2020-10-06). We agreed on taking the older version from 2019 as a default. Therefore, both transparency and power statistics can be selected. 


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
~- [] Newly introduced dependencies are added to `environment.yaml` and `environment.docs.yaml`.~
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.