### PR TITLE
Keep links to store components when using ATK wildcard

### DIFF
--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -205,9 +205,7 @@ def enforce_autarky(n, only_crossborder=False):
                     ].index
     else:
         lines_rm = n.lines.index
-        for i in n.links.index:
-            if n.links.loc[i,'carrier'] == 'DC':
-                links_rm.append(i)
+        links_rm = n.links.loc[n.links.carrier=="DC"].index
     n.mremove("Line", lines_rm)
     n.mremove("Link", links_rm)
 

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -193,7 +193,6 @@ def apply_time_segmentation(n, segments):
     return n
 
 def enforce_autarky(n, only_crossborder=False):
-    links_rm = []
     if only_crossborder:
         lines_rm = n.lines.loc[
                         n.lines.bus0.map(n.buses.country) !=


### PR DESCRIPTION
The new ATK wildcard removes all lines + links without further distinction; however, since storage options are now modeled as store components, the links to and from the the storage units for (dis)charge are eliminated as well. Thus, the storage options drop out of the optimisation.
Especially when only allowing renewables as generation sources, optimisation may become infeasible for a high temporal resolution (capacity factors = 0 for certain hours; no further options to serve the load).
This issue does not arise with the ATKc wildcard, since bus0 and bus1 of the (dis)charge links share the same country code.

The proposed change is a very quick fix in the enforce_autarky function, solely removing DC links.

Closes # (if applicable).

## Changes proposed in this Pull Request

enforce_autarky() in prepare_network.py

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
