### PR TITLE
Adding marginal cost for storage

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -185,7 +185,10 @@ costs:
     offwind: 0.015
     hydro: 0.
     H2: 0.
+    electrolysis: 0.
+    fuel cell: 0.
     battery: 0.
+    battery inverter: 0.
   emission_prices: # in currency per tonne emission, only used with the option Ep
     co2: 0.
 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -179,7 +179,7 @@ costs:
   year: 2030
   discountrate: 0.07 # From a Lion Hirth paper, also reflects average of Noothout et al 2016
   USD2013_to_EUR2013: 0.7532 # [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html
-  marginal_cost:
+  marginal_cost: # EUR/MWh
     solar: 0.01
     onwind: 0.015
     offwind: 0.015

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -155,7 +155,7 @@ def attach_stores(n, costs):
                efficiency=costs.at['battery inverter','efficiency'],
                capital_cost=costs.at['battery inverter', 'capital_cost'],
                p_nom_extendable=True,
-               marginal_cost=costs.at["battery inverter", "marginal_cost"]))
+               marginal_cost=costs.at["battery inverter", "marginal_cost"])
 
 
 def attach_hydrogen_pipelines(n, costs):

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -114,7 +114,8 @@ def attach_stores(n, costs):
                carrier='H2 electrolysis',
                p_nom_extendable=True,
                efficiency=costs.at["electrolysis", "efficiency"],
-               capital_cost=costs.at["electrolysis", "capital_cost"])
+               capital_cost=costs.at["electrolysis", "capital_cost"],
+               marginal_cost=snakemake.config['costs']['marginal_cost'].get('H2'))
 
         n.madd("Link", h2_buses_i + " Fuel Cell",
                bus0=h2_buses_i,
@@ -123,7 +124,8 @@ def attach_stores(n, costs):
                p_nom_extendable=True,
                efficiency=costs.at["fuel cell", "efficiency"],
                #NB: fixed cost is per MWel
-               capital_cost=costs.at["fuel cell", "capital_cost"] * costs.at["fuel cell", "efficiency"])
+               capital_cost=costs.at["fuel cell", "capital_cost"] * costs.at["fuel cell", "efficiency"],
+               marginal_cost=snakemake.config['costs']['marginal_cost'].get('H2'))
 
     if 'battery' in carriers:
         b_buses_i = n.madd("Bus", buses_i + " battery", carrier="battery", **bus_sub_dict)
@@ -141,7 +143,8 @@ def attach_stores(n, costs):
                carrier='battery charger',
                efficiency=costs.at['battery inverter', 'efficiency'],
                capital_cost=costs.at['battery inverter', 'capital_cost'],
-               p_nom_extendable=True)
+               p_nom_extendable=True,
+               marginal_cost=snakemake.config['costs']['marginal_cost'].get('battery')))
 
         n.madd("Link", b_buses_i + " discharger",
                bus0=b_buses_i,
@@ -149,7 +152,8 @@ def attach_stores(n, costs):
                carrier='battery discharger',
                efficiency=costs.at['battery inverter','efficiency'],
                capital_cost=costs.at['battery inverter', 'capital_cost'],
-               p_nom_extendable=True)
+               p_nom_extendable=True,
+               marginal_cost=snakemake.config['costs']['marginal_cost'].get('battery')))
 
 
 def attach_hydrogen_pipelines(n, costs):

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -115,7 +115,7 @@ def attach_stores(n, costs):
                p_nom_extendable=True,
                efficiency=costs.at["electrolysis", "efficiency"],
                capital_cost=costs.at["electrolysis", "capital_cost"],
-               marginal_cost=snakemake.config['costs']['marginal_cost'].get('H2'))
+               marginal_cost=costs.at["electrolysis", "marginal_cost"])
 
         n.madd("Link", h2_buses_i + " Fuel Cell",
                bus0=h2_buses_i,

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -106,7 +106,8 @@ def attach_stores(n, costs):
                carrier='H2',
                e_nom_extendable=True,
                e_cyclic=True,
-               capital_cost=costs.at["hydrogen storage", "capital_cost"])
+               capital_cost=costs.at["hydrogen storage", "capital_cost"],
+               marginal_cost=costs.at["H2", "marginal_cost"])
 
         n.madd("Link", h2_buses_i + " Electrolysis",
                bus0=buses_i,
@@ -125,7 +126,7 @@ def attach_stores(n, costs):
                efficiency=costs.at["fuel cell", "efficiency"],
                #NB: fixed cost is per MWel
                capital_cost=costs.at["fuel cell", "capital_cost"] * costs.at["fuel cell", "efficiency"],
-               marginal_cost=snakemake.config['costs']['marginal_cost'].get('H2'))
+               marginal_cost=costs.at["fuel cell", "marginal_cost"])
 
     if 'battery' in carriers:
         b_buses_i = n.madd("Bus", buses_i + " battery", carrier="battery", **bus_sub_dict)
@@ -135,7 +136,8 @@ def attach_stores(n, costs):
                carrier='battery',
                e_cyclic=True,
                e_nom_extendable=True,
-               capital_cost=costs.at['battery storage', 'capital_cost'])
+               capital_cost=costs.at['battery storage', 'capital_cost'],
+               marginal_cost=costs.at["battery", "marginal_cost"])
 
         n.madd("Link", b_buses_i + " charger",
                bus0=buses_i,
@@ -144,7 +146,7 @@ def attach_stores(n, costs):
                efficiency=costs.at['battery inverter', 'efficiency'],
                capital_cost=costs.at['battery inverter', 'capital_cost'],
                p_nom_extendable=True,
-               marginal_cost=snakemake.config['costs']['marginal_cost'].get('battery')))
+               marginal_cost=costs.at["battery inverter", "marginal_cost"])
 
         n.madd("Link", b_buses_i + " discharger",
                bus0=b_buses_i,
@@ -153,7 +155,7 @@ def attach_stores(n, costs):
                efficiency=costs.at['battery inverter','efficiency'],
                capital_cost=costs.at['battery inverter', 'capital_cost'],
                p_nom_extendable=True,
-               marginal_cost=snakemake.config['costs']['marginal_cost'].get('battery')))
+               marginal_cost=costs.at["battery inverter", "marginal_cost"]))
 
 
 def attach_hydrogen_pipelines(n, costs):


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
The current config.yaml contains marginal cost inputs. Though, only the input for solar and wind had an effect on the optimization (tested). This PR fixes the bug, allowing to add marginal cost for energy storage components in the config.yaml file. For instance, changing the marginal cost of H2 to 0.01 would add to the electrolyser and fuel cell marginal cost of 0.01 EUR/MWh.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
