### PR TITLE
Correct co2base in config.default.yaml .

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -36,7 +36,7 @@ enable:
 electricity:
   voltages: [220., 300., 380.]
   co2limit: 7.75e+7 # 0.05 * 3.1e9*0.5
-  co2base: 3.1e+9 # 1 * 3.1e9*0.5
+  co2base: 1.487e9
   agg_p_nom_limits: data/agg_p_nom_minmax.csv
 
   extendable_carriers:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,7 +11,7 @@ Release Notes
 Upcoming Release
 ================
 
-* Fix: Value for `co2base` in `config.yaml` adjusted to 1.487e9 t CO2-eq (from 3.1e9 t CO2-eq). The new value represents emissions related to the electricity sector for EU+UK. The old value was ~2x too high and used when the emissions wildcard was used.
+* Fix: Value for ``co2base`` in ``config.yaml`` adjusted to 1.487e9 t CO2-eq (from 3.1e9 t CO2-eq). The new value represents emissions related to the electricity sector for EU+UK. The old value was ~2x too high and used when the emissions wildcard in ``{opts}`` was used.
 
 
 PyPSA-Eur 0.3.0 (7th December 2020)

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,8 @@ Release Notes
 Upcoming Release
 ================
 
+* Fix: Value for `co2base` in `config.yaml` adjusted to 1.487e9 t CO2-eq (from 3.1e9 t CO2-eq). The new value represents emissions related to the electricity sector for EU+UK. The old value was ~2x too high and used when the emissions wildcard was used.
+
 
 PyPSA-Eur 0.3.0 (7th December 2020)
 ==================================


### PR DESCRIPTION
Based on PyPSA-EUR-SEC data.

~Closes # (if applicable).~

## Changes proposed in this Pull Request

Fix co2base value in config used for reduction targets via wildcard (EU27++)

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
