### PR TITLE
retrieve: update cutouts and downloads

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -150,8 +150,8 @@ if config['enable'].get('build_cutout', False):
 
 if config['enable'].get('retrieve_cutout', True):
     rule retrieve_cutout:
-        output: expand("cutouts/{cutouts}.nc", **config['atlite'])
-        log: "logs/retrieve_cutout.log"
+        output: "cutouts/{cutout}.nc"
+        log: "logs/retrieve_cutout_{cutout}.log"
         script: 'scripts/retrieve_cutout.py'
 
 

--- a/scripts/retrieve_cutout.py
+++ b/scripts/retrieve_cutout.py
@@ -42,7 +42,6 @@ The :ref:`tutorial` uses smaller `cutouts <https://zenodo.org/record/3518020/fil
 import logging
 logger = logging.getLogger(__name__)
 
-from pathlib import Path
 from _helpers import progress_retrieve, configure_logging
 
 if __name__ == "__main__":

--- a/scripts/retrieve_cutout.py
+++ b/scripts/retrieve_cutout.py
@@ -43,7 +43,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 from pathlib import Path
-import tarfile
 from _helpers import progress_retrieve, configure_logging
 
 if __name__ == "__main__":
@@ -56,20 +55,12 @@ if __name__ == "__main__":
 
     configure_logging(snakemake) # TODO Make logging compatible with progressbar (see PR #102)
 
-    if snakemake.config['tutorial']:
-        url = "https://zenodo.org/record/3518020/files/pypsa-eur-tutorial-cutouts.tar.xz"
-    else:
-        url = "https://zenodo.org/record/3517949/files/pypsa-eur-cutouts.tar.xz"
+    cutout = snakemake.wildcards.cutout
 
-    # Save location
-    tarball_fn = Path(f"{rootpath}/cutouts.tar.xz")
+    # url = f"https://zenodo.org/record/3517949/files/{cutout}.nc"
+    url = f"https://sandbox.zenodo.org/record/795060/files/{cutout}.nc"
 
-    logger.info(f"Downloading cutouts from '{url}'.")
-    progress_retrieve(url, tarball_fn)
+    logger.info(f"Downloading cutout '{cutout}' from '{url}'.")
+    progress_retrieve(url, snakemake.output[0])
 
-    logger.info(f"Extracting cutouts.")
-    tarfile.open(tarball_fn).extractall(path=rootpath)
-
-    tarball_fn.unlink()
-
-    logger.info(f"Cutouts available in '{Path(tarball_fn.stem).stem}'.")
+    logger.info(f"Cutout '{cutout}' available as '{snakemake.output[0]}'.")


### PR DESCRIPTION
Suggestion to update the cutout download scripts.
I think it's worth doing this in unison with the update to the new `atlite` version.

+ no tarballs, extraction
+ analogous to `retrieve_natura` rule
+ only one zenodo repository for both tutorial and main cutouts to maintain
+ on clusters, download can be done in parallel (minor point)
+ with @euronion's changed handling of tutorial cutout, relatively insignificant code changes needed

To test, I currently link to a sandbox zenodo repository which includes the tutorial cutout.

If you are happy with this implementation, I would proceed with the bulk upload of the cutouts.