### PR TITLE
Delete capital costs at battery discharge link

### DIFF
--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -152,7 +152,6 @@ def attach_stores(n, costs):
                bus1=buses_i,
                carrier='battery discharger',
                efficiency=costs.at['battery inverter','efficiency'],
-               capital_cost=costs.at['battery inverter', 'capital_cost'],
                p_nom_extendable=True,
                marginal_cost=costs.at["battery inverter", "marginal_cost"])
 


### PR DESCRIPTION
Hey guys,
please correct me if I'm wrong, but I think pricing both the charge and discharge of the battery store component with the inverter's capital costs results in duplicating costs since a bi-directional inverter is considered (I checked the source of the cost assumption, Budischak 2013). 
Before working with PyPSA-EUR, I have worked with the toy model WHOBS where only the charging-link of the battery store component is priced with its capital costs (cf. https://github.com/PyPSA/WHOBS/blob/master/run_single_simulation.ipynb). The proposed change in code is equivalent.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
