### PR TITLE
Adding focus_weights to pre-clustering

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -19,6 +19,7 @@ Upcoming Release
 * Fix: Value for ``co2base`` in ``config.yaml`` adjusted to 1.487e9 t CO2-eq (from 3.1e9 t CO2-eq). The new value represents emissions related to the electricity sector for EU+UK. The old value was ~2x too high and used when the emissions wildcard in ``{opts}`` was used.
 * Add option to include marginal costs of links representing fuel cells, electrolysis, and battery inverters 
   [`#232 <https://github.com/PyPSA/pypsa-eur/pull/232>`_].
+* The ``focus_weights`` are now also considered when pre-clustering in the :mod:`simplify_network` rule [`#241 <https://github.com/PyPSA/pypsa-eur/pull/241>`_].
 
 PyPSA-Eur 0.3.0 (7th December 2020)
 ==================================

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -324,6 +324,8 @@ def remove_stubs(n):
 def cluster(n, n_clusters):
     logger.info(f"Clustering to {n_clusters} buses")
 
+    focus_weights = snakemake.config.get('focus_weights', None)
+    
     renewable_carriers = pd.Index([tech
                                     for tech in n.generators.carrier.unique()
                                     if tech.split('-', 2)[0] in snakemake.config['renewable']])
@@ -337,7 +339,8 @@ def cluster(n, n_clusters):
                                             for tech in renewable_carriers]))
                         if len(renewable_carriers) > 0 else 'conservative')
     clustering = clustering_for_n_clusters(n, n_clusters, custom_busmap=False, potential_mode=potential_mode,
-                                           solver_name=snakemake.config['solving']['solver']['name'])
+                                           solver_name=snakemake.config['solving']['solver']['name'],
+                                           focus_weights=focus_weights)
 
     return clustering.network, clustering.busmap
 


### PR DESCRIPTION
Hey guys,
another quick fix since I noticed it wasn't implemented yet: When pre-clustering the network, the focus_weights have not yet been considered. This may distort clustering results when pre-clustering to a low resolution.

Closes # (if applicable).

## Changes proposed in this Pull Request
Adding focus_weights to the pre-clustering function in simplify_network

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- ~[ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.~
- ~[ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.~
- ~[ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.~
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
