### PR TITLE
base: add escape if all TYNDP links already in network

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -19,6 +19,7 @@ Upcoming Release
 * Fix: Value for ``co2base`` in ``config.yaml`` adjusted to 1.487e9 t CO2-eq (from 3.1e9 t CO2-eq). The new value represents emissions related to the electricity sector for EU+UK. The old value was ~2x too high and used when the emissions wildcard in ``{opts}`` was used.
 * Add option to include marginal costs of links representing fuel cells, electrolysis, and battery inverters 
   [`#232 <https://github.com/PyPSA/pypsa-eur/pull/232>`_].
+* Fix: Add escape in :mod:`base_network` if all TYNDP links are already contained in the network [`#246 <https://github.com/PyPSA/pypsa-eur/pull/246>`_].
 
 PyPSA-Eur 0.3.0 (7th December 2020)
 ==================================

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -213,6 +213,7 @@ def _add_links_from_tyndp(buses, links):
     if links_tyndp["j"].notnull().any():
         logger.info("TYNDP links already in the dataset (skipping): " + ", ".join(links_tyndp.loc[links_tyndp["j"].notnull(), "Name"]))
         links_tyndp = links_tyndp.loc[links_tyndp["j"].isnull()]
+        if links_tyndp.empty: return buses, links
 
     tree = sp.spatial.KDTree(buses[['x', 'y']])
     _, ind0 = tree.query(links_tyndp[["x1", "y1"]])


### PR DESCRIPTION
Closes #231.

## Changes proposed in this Pull Request

In `base_network` add an escape if all TYNDP links are already contained in the network.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- ~[ ] Code and workflow changes are sufficiently documented.~
- ~[ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.~
- ~[ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.~
- ~[ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.~
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
