### PR TITLE
Fix creation of renewable profiles for offshore wind.

### DIFF
--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -183,6 +183,7 @@ import progressbar as pgb
 import geopandas as gpd
 import xarray as xr
 import numpy as np
+import functools
 import atlite
 import logging
 from pypsa.geo import haversine
@@ -235,8 +236,11 @@ if __name__ == '__main__':
         excluder.add_raster(paths.corine, codes=codes, buffer=buffer, crs=3035)
 
     if "max_depth" in config:
-        func = lambda v: v <= -config['max_depth']
-        excluder.add_raster(paths.gebco, codes=func, crs=4236, nodata=-1000)
+        # lambda not supported for atlite + multiprocessing
+        # use named function np.greater with partially frozen argument instead
+        # to include only areas with depth > -max_depth
+        func = functools.partial(np.greater,-config['max_depth'])
+        excluder.add_raster(paths.gebco, codes=func, invert=True, crs=4236, nodata=-1000)
 
     if 'min_shore_distance' in config:
         buffer = config['min_shore_distance']


### PR DESCRIPTION
Closes #249 .

## Changes proposed in this Pull Request

This PR fixes the issue we encounter in the rule `build_renewable_profiles` for offshore wind, where areas with a depth lower than `config['max_depth']` should be exlucded via `atlite`'s exclusion calculator.

The issue arises due to the combination of how `atlite` implements the exclusion calculator and how `multiprocessing` spawns new processes. Anonymous functions - like `lambda`'s - are not supported.
We fix this by using `np.greater` instead of the `lambda` comparison.
Special considerations:
* `np.greater` expects two arguments, we freeze one (reference value `config['max_depth']` using `functools.partial`
* `np.greater` requires the first two arguments to be positional arguments, named arguments are not permitted. Therefore the implementation uses `np.greater` and `invert=True` in the exclusion caluculation ("include all areas with sea depth more shallow than the max depth") where the reference value can be used as the first positional argument.

We fix this issue here rather than in `atlite`, as supporting `lambda` in the exclusion calculator would by desgin require more complicated changes; instead we'll add a note to the documentation mentioning that `lambda` functions are not permitted. This way there is nothing broken, i.e. nothing needs fixing ;-)

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [n/a] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [n/a] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [n/a] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
