### PR TITLE
Fix snakemake CLA in GH action.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,5 +43,5 @@ jobs:
       run: |
         conda list
         cp test/config.test1.yaml config.yaml
-        snakemake -j all solve_all_networks
+        snakemake -c all solve_all_networks
         rm -rf resources/*.nc resources/*.geojson resources/*.h5 networks results

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,5 +43,5 @@ jobs:
       run: |
         conda list
         cp test/config.test1.yaml config.yaml
-        snakemake -c all solve_all_networks
+        snakemake --cores all solve_all_networks
         rm -rf resources/*.nc resources/*.geojson resources/*.h5 networks results


### PR DESCRIPTION
`snakemake` broke `-j all` with the latest update. Now has to be `-c all` for local execution.

## Changes proposed in this Pull Request

Replace a `j` with a `c `.

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
