### PR TITLE
List first-order dependencies and add pypsa-eur-sec specialties

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -13,7 +13,7 @@ dependencies:
   - mamba # esp for windows build
 
   - pypsa>=0.17.1 
-  - atlite>=0.2.5
+  - atlite>=0.2.4
   - dask<=2021.3.1 # until https://github.com/dask/dask/issues/7583 is solved
 
   # Dependencies of the workflow itself
@@ -27,7 +27,7 @@ dependencies:
   - pytables
   - lxml
   - powerplantmatching>=0.4.8
-  - numpy<=0.19.0 # until new PyPSA after 27-06-21
+  - numpy<=1.19 # until new PyPSA after 27-06-21
   - pandas
   - geopandas
   - xarray

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -13,7 +13,7 @@ dependencies:
   - mamba # esp for windows build
 
   - pypsa>=0.17.1 
-  - atlite>=0.2.2
+  - atlite>=0.2.5
   - dask<=2021.3.1 # until https://github.com/dask/dask/issues/7583 is solved
 
   # Dependencies of the workflow itself
@@ -27,7 +27,7 @@ dependencies:
   - pytables
   - lxml
   - powerplantmatching>=0.4.8
-  - numpy
+  - numpy<=0.19.0 # until new PyPSA after 27-06-21
   - pandas
   - geopandas
   - xarray

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -19,7 +19,6 @@ dependencies:
   # Dependencies of the workflow itself
   - xlrd
   - openpyxl
-  - scikit-learn
   - pycountry
   - seaborn
   - snakemake-minimal
@@ -28,8 +27,17 @@ dependencies:
   - pytables
   - lxml
   - powerplantmatching>=0.4.8
-  - numpy<=1.19.0 # otherwise macos fails
-
+  - numpy
+  - pandas
+  - geopandas
+  - xarray
+  - netcdf4
+  - networkx
+  - scipy
+  - shapely
+  - progressbar2
+  - pyomo
+  - matplotlib
 
   # Keep in conda environment when calling ipython
   - ipython
@@ -37,6 +45,12 @@ dependencies:
   # GIS dependencies:
   - cartopy
   - descartes
+  - rasterio
+
+  # PyPSA-Eur-Sec Dependencies
+  - geopy
+  - tqdm
+  - pytz
 
   - pip:
     - vresutils==0.3.1

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -51,6 +51,7 @@ dependencies:
   - geopy
   - tqdm
   - pytz
+  - country_converter
 
   - pip:
     - vresutils==0.3.1


### PR DESCRIPTION
Every package that is imported in the scripts and requires installation should be listed in the environment even though they are already dependencies of `pypsa` or `atlite`.

Also the revision of PyPSA-Eur-Sec requires three new packages (which are usually already installed). I thought it's best to add them here.