### PR TITLE
config: co2base interpreted by snakemake as str without +

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -36,7 +36,7 @@ enable:
 electricity:
   voltages: [220., 300., 380.]
   co2limit: 7.75e+7 # 0.05 * 3.1e9*0.5
-  co2base: 1.487e9
+  co2base: 1.487e+9
   agg_p_nom_limits: data/agg_p_nom_minmax.csv
 
   extendable_carriers:


### PR DESCRIPTION
without the '+', co2base is interpreted as str. Causes an error when applied with a factor in 

https://github.com/PyPSA/pypsa-eur/blob/master/scripts/prepare_network.py#L76

namely:
```
    annual_emissions = factor*snakemake.config['electricity']['co2base']
TypeError: can't multiply sequence by non-int of type 'float'

```