### PR TITLE
Adapt to new snapshot weightings

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -24,6 +24,7 @@ Upcoming Release
 * The ``focus_weights`` are now also considered when pre-clustering in the :mod:`simplify_network` rule [`#241 <https://github.com/PyPSA/pypsa-eur/pull/241>`_].
 * Continuous integration testing switches to Github Actions from Travis CI [`#252 <https://github.com/PyPSA/pypsa-eur/pull/252>`_].
 * Bugfix in :mod:`build_renewable_profile` where offshore wind profiles could no longer be created [`#249 <https://github.com/PyPSA/pypsa-eur/pull/249>`_].
+* Implements changes to ``n.snapshot_weightings`` in upcoming PyPSA version (cf. `PyPSA/PyPSA/#227 <https://github.com/PyPSA/PyPSA/pull/227>`_) [`#259 <https://github.com/PyPSA/pypsa-eur/pull/259>`_].
 
 PyPSA-Eur 0.3.0 (7th December 2020)
 ==================================

--- a/envs/environment.docs.yaml
+++ b/envs/environment.docs.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python<=3.7
   - pip
-  - pypsa>=0.17.1
+  #- pypsa>=0.17.1
   - atlite>=0.2.2
   - dask<=2021.3.1 # until https://github.com/dask/dask/issues/7583 is solved
   - pre-commit
@@ -27,6 +27,7 @@ dependencies:
   - descartes
 
   - pip:
+    - git+https://github.com/pypsa/pypsa.git#egg=pypsa
     - vresutils==0.3.1
     - sphinx
     - sphinx_rtd_theme

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
   - pip
   - mamba # esp for windows build
 
-  - pypsa>=0.17.1 
+  #- pypsa>=0.17.1 
   - atlite>=0.2.2
   - dask<=2021.3.1 # until https://github.com/dask/dask/issues/7583 is solved
 
@@ -39,5 +39,6 @@ dependencies:
   - descartes
 
   - pip:
+    - git+https://github.com/pypsa/pypsa.git#egg=pypsa
     - vresutils==0.3.1
     - tsam>=1.1.0

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -119,7 +119,7 @@ def load_network_for_plots(fn, tech_costs, config, combine_hydro_ps=True):
     # bus_carrier = n.storage_units.bus.map(n.buses.carrier)
     # n.storage_units.loc[bus_carrier == "heat","carrier"] = "water tanks"
 
-    Nyears = n.snapshot_weightings.generators.sum() / 8760.
+    Nyears = n.snapshot_weightings.objective.sum() / 8760.
     costs = load_costs(Nyears, tech_costs, config['costs'], config['electricity'])
     update_transmission_costs(n, costs)
 

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -119,7 +119,7 @@ def load_network_for_plots(fn, tech_costs, config, combine_hydro_ps=True):
     # bus_carrier = n.storage_units.bus.map(n.buses.carrier)
     # n.storage_units.loc[bus_carrier == "heat","carrier"] = "water tanks"
 
-    Nyears = n.snapshot_weightings.sum() / 8760.
+    Nyears = n.snapshot_weightings.generators.sum() / 8760.
     costs = load_costs(Nyears, tech_costs, config['costs'], config['electricity'])
     update_transmission_costs(n, costs)
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -559,7 +559,7 @@ if __name__ == "__main__":
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.base_network)
-    Nyears = n.snapshot_weightings.generators.sum() / 8760.
+    Nyears = n.snapshot_weightings.objective.sum() / 8760.
 
     costs = load_costs(Nyears)
     ppl = load_powerplants()

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -559,7 +559,7 @@ if __name__ == "__main__":
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.base_network)
-    Nyears = n.snapshot_weightings.sum() / 8760.
+    Nyears = n.snapshot_weightings.generators.sum() / 8760.
 
     costs = load_costs(Nyears)
     ppl = load_powerplants()

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -197,7 +197,7 @@ if __name__ == "__main__":
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)
-    Nyears = n.snapshot_weightings.sum() / 8760.
+    Nyears = n.snapshot_weightings.generators.sum() / 8760.
     costs = load_costs(Nyears, tech_costs=snakemake.input.tech_costs,
                        config=snakemake.config['costs'],
                        elec_config=snakemake.config['electricity'])

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -197,7 +197,7 @@ if __name__ == "__main__":
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)
-    Nyears = n.snapshot_weightings.generators.sum() / 8760.
+    Nyears = n.snapshot_weightings.objective.sum() / 8760.
     costs = load_costs(Nyears, tech_costs=snakemake.input.tech_costs,
                        config=snakemake.config['costs'],
                        elec_config=snakemake.config['electricity'])

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -357,7 +357,8 @@ if __name__ == "__main__":
         clustering = pypsa.networkclustering.Clustering(n, busmap, linemap, linemap, pd.Series(dtype='O'))
     else:
         line_length_factor = snakemake.config['lines']['length_factor']
-        hvac_overhead_cost = (load_costs(n.snapshot_weightings.generators.sum()/8760,
+        Nyears = n.snapshot_weightings.objective.sum()/8760
+        hvac_overhead_cost = (load_costs(Nyears,
                                    tech_costs=snakemake.input.tech_costs,
                                    config=snakemake.config['costs'],
                                    elec_config=snakemake.config['electricity'])

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -357,7 +357,7 @@ if __name__ == "__main__":
         clustering = pypsa.networkclustering.Clustering(n, busmap, linemap, linemap, pd.Series(dtype='O'))
     else:
         line_length_factor = snakemake.config['lines']['length_factor']
-        hvac_overhead_cost = (load_costs(n.snapshot_weightings.sum()/8760,
+        hvac_overhead_cost = (load_costs(n.snapshot_weightings.generators.sum()/8760,
                                    tech_costs=snakemake.input.tech_costs,
                                    config=snakemake.config['costs'],
                                    elec_config=snakemake.config['electricity'])

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -400,7 +400,7 @@ def make_summaries(networks_dict, country='all'):
         if country != 'all':
             n = n[n.buses.country == country]
 
-        Nyears = n.snapshot_weightings.generators.sum() / 8760.
+        Nyears = n.snapshot_weightings.objective.sum() / 8760.
         costs = load_costs(Nyears, snakemake.input[0],
                            snakemake.config['costs'], snakemake.config['electricity'])
         update_transmission_costs(n, costs, simple_hvdc_costs=False)

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -111,15 +111,15 @@ def calculate_costs(n, label, costs):
         costs.loc[idx[raw_index],label] = capital_costs_grouped.values
 
         if c.name == "Link":
-            p = c.pnl.p0.multiply(n.snapshot_weightings,axis=0).sum()
+            p = c.pnl.p0.multiply(n.snapshot_weightings.generators,axis=0).sum()
         elif c.name == "Line":
             continue
         elif c.name == "StorageUnit":
-            p_all = c.pnl.p.multiply(n.snapshot_weightings,axis=0)
+            p_all = c.pnl.p.multiply(n.snapshot_weightings.generators,axis=0)
             p_all[p_all < 0.] = 0.
             p = p_all.sum()
         else:
-            p = c.pnl.p.multiply(n.snapshot_weightings,axis=0).sum()
+            p = c.pnl.p.multiply(n.snapshot_weightings.generators,axis=0).sum()
 
         marginal_costs = p*c.df.marginal_cost
 
@@ -145,9 +145,9 @@ def calculate_energy(n, label, energy):
     for c in n.iterate_components(n.one_port_components|n.branch_components):
 
         if c.name in n.one_port_components:
-            c_energies = c.pnl.p.multiply(n.snapshot_weightings,axis=0).sum().multiply(c.df.sign).groupby(c.df.carrier).sum()
+            c_energies = c.pnl.p.multiply(n.snapshot_weightings.generators,axis=0).sum().multiply(c.df.sign).groupby(c.df.carrier).sum()
         else:
-            c_energies = (-c.pnl.p1.multiply(n.snapshot_weightings,axis=0).sum() - c.pnl.p0.multiply(n.snapshot_weightings,axis=0).sum()).groupby(c.df.carrier).sum()
+            c_energies = (-c.pnl.p1.multiply(n.snapshot_weightings.generators,axis=0).sum() - c.pnl.p0.multiply(n.snapshot_weightings.generators,axis=0).sum()).groupby(c.df.carrier).sum()
 
         energy = include_in_summary(energy, [c.list_name], label, c_energies)
 
@@ -400,7 +400,7 @@ def make_summaries(networks_dict, country='all'):
         if country != 'all':
             n = n[n.buses.country == country]
 
-        Nyears = n.snapshot_weightings.sum() / 8760.
+        Nyears = n.snapshot_weightings.generators.sum() / 8760.
         costs = load_costs(Nyears, snakemake.input[0],
                            snakemake.config['costs'], snakemake.config['electricity'])
         update_transmission_costs(n, costs, simple_hvdc_costs=False)

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -144,8 +144,10 @@ def calculate_energy(n, label, energy):
 
     for c in n.iterate_components(n.one_port_components|n.branch_components):
 
-        if c.name in n.one_port_components:
+        if c.name in {'Generator', 'Load', 'ShuntImpedance'}:
             c_energies = c.pnl.p.multiply(n.snapshot_weightings.generators,axis=0).sum().multiply(c.df.sign).groupby(c.df.carrier).sum()
+        elif c.name in {'StorageUnit', 'Store'}:
+            c_energies = c.pnl.p.multiply(n.snapshot_weightings.stores,axis=0).sum().multiply(c.df.sign).groupby(c.df.carrier).sum()
         else:
             c_energies = (-c.pnl.p1.multiply(n.snapshot_weightings.generators,axis=0).sum() - c.pnl.p0.multiply(n.snapshot_weightings.generators,axis=0).sum()).groupby(c.df.carrier).sum()
 

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -196,7 +196,7 @@ def plot_total_energy_pie(n, ax=None):
 def plot_total_cost_bar(n, ax=None):
     if ax is None: ax = plt.gca()
 
-    total_load = (n.snapshot_weightings * n.loads_t.p.sum(axis=1)).sum()
+    total_load = (n.snapshot_weightings.generators * n.loads_t.p.sum(axis=1)).sum()
     tech_colors = opts['tech_colors']
 
     def split_costs(n):

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -150,6 +150,7 @@ def average_every_nhours(n, offset):
 
     return m
 
+
 def apply_time_segmentation(n, segments):
     logger.info(f"Aggregating time series to {segments} segments.")
     try:
@@ -223,7 +224,7 @@ if __name__ == "__main__":
     opts = snakemake.wildcards.opts.split('-')
 
     n = pypsa.Network(snakemake.input[0])
-    Nyears = n.snapshot_weightings.generators.sum() / 8760.
+    Nyears = n.snapshot_weightings.objective.sum() / 8760.
 
     set_line_s_max_pu(n)
 

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -223,7 +223,7 @@ if __name__ == "__main__":
     opts = snakemake.wildcards.opts.split('-')
 
     n = pypsa.Network(snakemake.input[0])
-    Nyears = n.snapshot_weightings.sum() / 8760.
+    Nyears = n.snapshot_weightings.generators.sum() / 8760.
 
     set_line_s_max_pu(n)
 

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -141,7 +141,7 @@ def simplify_network_to_380(n):
 def _prepare_connection_costs_per_link(n):
     if n.links.empty: return {}
 
-    costs = load_costs(n.snapshot_weightings.sum() / 8760, snakemake.input.tech_costs,
+    costs = load_costs(n.snapshot_weightings.generators.sum() / 8760, snakemake.input.tech_costs,
                        snakemake.config['costs'], snakemake.config['electricity'])
 
     connection_costs_per_link = {}

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -141,7 +141,8 @@ def simplify_network_to_380(n):
 def _prepare_connection_costs_per_link(n):
     if n.links.empty: return {}
 
-    costs = load_costs(n.snapshot_weightings.generators.sum() / 8760, snakemake.input.tech_costs,
+    Nyears = n.snapshot_weightings.objective.sum() / 8760
+    costs = load_costs(Nyears, snakemake.input.tech_costs,
                        snakemake.config['costs'], snakemake.config['electricity'])
 
     connection_costs_per_link = {}

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -176,14 +176,14 @@ def add_EQ_constraints(n, o, scaling=1e-1):
         sgrouper = n.storage_units.bus
     load = n.snapshot_weightings.generators @ \
            n.loads_t.p_set.groupby(lgrouper, axis=1).sum()
-    inflow = n.snapshot_weightings.generators @ \
+    inflow = n.snapshot_weightings.stores @ \
              n.storage_units_t.inflow.groupby(sgrouper, axis=1).sum()
     inflow = inflow.reindex(load.index).fillna(0.)
     rhs = scaling * ( level * load - inflow )
     lhs_gen = linexpr((n.snapshot_weightings.generators * scaling,
                        get_var(n, "Generator", "p").T)
               ).T.groupby(ggrouper, axis=1).apply(join_exprs)
-    lhs_spill = linexpr((-n.snapshot_weightings.generators * scaling,
+    lhs_spill = linexpr((-n.snapshot_weightings.stores * scaling,
                          get_var(n, "StorageUnit", "spill").T)
                 ).T.groupby(sgrouper, axis=1).apply(join_exprs)
     lhs_spill = lhs_spill.reindex(lhs_gen.index).fillna("")

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -174,16 +174,16 @@ def add_EQ_constraints(n, o, scaling=1e-1):
         ggrouper = n.generators.bus
         lgrouper = n.loads.bus
         sgrouper = n.storage_units.bus
-    load = n.snapshot_weightings @ \
+    load = n.snapshot_weightings.generators @ \
            n.loads_t.p_set.groupby(lgrouper, axis=1).sum()
-    inflow = n.snapshot_weightings @ \
+    inflow = n.snapshot_weightings.generators @ \
              n.storage_units_t.inflow.groupby(sgrouper, axis=1).sum()
     inflow = inflow.reindex(load.index).fillna(0.)
     rhs = scaling * ( level * load - inflow )
-    lhs_gen = linexpr((n.snapshot_weightings * scaling,
+    lhs_gen = linexpr((n.snapshot_weightings.generators * scaling,
                        get_var(n, "Generator", "p").T)
               ).T.groupby(ggrouper, axis=1).apply(join_exprs)
-    lhs_spill = linexpr((-n.snapshot_weightings * scaling,
+    lhs_spill = linexpr((-n.snapshot_weightings.generators * scaling,
                          get_var(n, "StorageUnit", "spill").T)
                 ).T.groupby(sgrouper, axis=1).apply(join_exprs)
     lhs_spill = lhs_spill.reindex(lhs_gen.index).fillna("")

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -127,7 +127,7 @@ def prepare_network(n, solve_opts):
     if solve_opts.get('nhours'):
         nhours = solve_opts['nhours']
         n.set_snapshots(n.snapshots[:nhours])
-        n.snapshot_weightings[:] = 8760./nhours
+        n.snapshot_weightings[:] = 8760. / nhours
 
     return n
 


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

Use `n.snapshot_weightings.generators` or `n.snapshot_weightings.objective`  as substitute for `n.snapshot_weightings`.

@lisazeyen is the use of generators and objective semantically correct?

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
