### PR TITLE
specify when to run CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,15 @@
 
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+  schedule:
+    - cron: "0 5 * * TUE"
 
 jobs:
   build:


### PR DESCRIPTION
Run CI only for:

- direct pushes on master branch
- pull requests to merge into master branch
- every Tuesday of the week at 5AM UTC
