### PR TITLE
solve_operations_network: include optimized stores to operation

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -26,6 +26,8 @@ Upcoming Release
 * Bugfix in :mod:`build_renewable_profile` where offshore wind profiles could no longer be created [`#249 <https://github.com/PyPSA/pypsa-eur/pull/249>`_].
 * Implements changes to ``n.snapshot_weightings`` in upcoming PyPSA version (cf. `PyPSA/PyPSA/#227 <https://github.com/PyPSA/PyPSA/pull/227>`_) [`#259 <https://github.com/PyPSA/pypsa-eur/pull/259>`_].
 * Bugfix: Lower expansion limit of extendable carriers is now set to the existing capacity, i.e. ``p_nom_min = p_nom`` (0 before). Simultaneously, the upper limit (``p_nom_max``) is now the maximum of the installed capacity (``p_nom``) and the previous estimate based on land availability (``p_nom_max``) [`#260 <https://github.com/PyPSA/pypsa-eur/pull/260>`_].
+* Bugfix: Solving an operations network now includes optimized stores as well. Before only lines, links, generators and storage units werde considered.
+* Bugfix: ``load_shedding: true`` in the solving options of ``config.yaml`` now excludes stores to be added as a load generator.
 
 PyPSA-Eur 0.3.0 (7th December 2020)
 ==================================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -27,7 +27,7 @@ Upcoming Release
 * Implements changes to ``n.snapshot_weightings`` in upcoming PyPSA version (cf. `PyPSA/PyPSA/#227 <https://github.com/PyPSA/PyPSA/pull/227>`_) [`#259 <https://github.com/PyPSA/pypsa-eur/pull/259>`_].
 * Bugfix: Lower expansion limit of extendable carriers is now set to the existing capacity, i.e. ``p_nom_min = p_nom`` (0 before). Simultaneously, the upper limit (``p_nom_max``) is now the maximum of the installed capacity (``p_nom``) and the previous estimate based on land availability (``p_nom_max``) [`#260 <https://github.com/PyPSA/pypsa-eur/pull/260>`_].
 * Bugfix: Solving an operations network now includes optimized stores as well. Before only lines, links, generators and storage units werde considered.
-* Bugfix: ``load_shedding: true`` in the solving options of ``config.yaml`` now excludes stores to be added as a load generator.
+* Bugfix: With ``load_shedding: true`` in the solving options of ``config.yaml`` load shedding generators are only added at the AC buses, excluding buses for H2 and battery stores.
 
 PyPSA-Eur 0.3.0 (7th December 2020)
 ==================================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -26,7 +26,7 @@ Upcoming Release
 * Bugfix in :mod:`build_renewable_profile` where offshore wind profiles could no longer be created [`#249 <https://github.com/PyPSA/pypsa-eur/pull/249>`_].
 * Implements changes to ``n.snapshot_weightings`` in upcoming PyPSA version (cf. `PyPSA/PyPSA/#227 <https://github.com/PyPSA/PyPSA/pull/227>`_) [`#259 <https://github.com/PyPSA/pypsa-eur/pull/259>`_].
 * Bugfix: Lower expansion limit of extendable carriers is now set to the existing capacity, i.e. ``p_nom_min = p_nom`` (0 before). Simultaneously, the upper limit (``p_nom_max``) is now the maximum of the installed capacity (``p_nom``) and the previous estimate based on land availability (``p_nom_max``) [`#260 <https://github.com/PyPSA/pypsa-eur/pull/260>`_].
-* Bugfix: Solving an operations network now includes optimized stores as well. Before only lines, links, generators and storage units werde considered.
+* Bugfix: Solving an operations network now includes optimized store capacities as well. Before only lines, links, generators and storage units werde considered.
 * Bugfix: With ``load_shedding: true`` in the solving options of ``config.yaml`` load shedding generators are only added at the AC buses, excluding buses for H2 and battery stores.
 
 PyPSA-Eur 0.3.0 (7th December 2020)

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -26,7 +26,7 @@ Upcoming Release
 * Bugfix in :mod:`build_renewable_profile` where offshore wind profiles could no longer be created [`#249 <https://github.com/PyPSA/pypsa-eur/pull/249>`_].
 * Implements changes to ``n.snapshot_weightings`` in upcoming PyPSA version (cf. `PyPSA/PyPSA/#227 <https://github.com/PyPSA/PyPSA/pull/227>`_) [`#259 <https://github.com/PyPSA/pypsa-eur/pull/259>`_].
 * Bugfix: Lower expansion limit of extendable carriers is now set to the existing capacity, i.e. ``p_nom_min = p_nom`` (0 before). Simultaneously, the upper limit (``p_nom_max``) is now the maximum of the installed capacity (``p_nom``) and the previous estimate based on land availability (``p_nom_max``) [`#260 <https://github.com/PyPSA/pypsa-eur/pull/260>`_].
-* Bugfix: Solving an operations network now includes optimized store capacities as well. Before only lines, links, generators and storage units werde considered.
+* Bugfix: Solving an operations network now includes optimized store capacities as well. Before only lines, links, generators and storage units were considered.
 * Bugfix: With ``load_shedding: true`` in the solving options of ``config.yaml`` load shedding generators are only added at the AC buses, excluding buses for H2 and battery stores.
 
 PyPSA-Eur 0.3.0 (7th December 2020)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -101,7 +101,7 @@ def prepare_network(n, solve_opts):
 
     if solve_opts.get('load_shedding'):
         n.add("Carrier", "Load")
-        buses_i = n.buses.query('carrier not in @n.stores.carrier.unique()').index
+        buses_i = n.buses.query("carrier == 'AC'").index
         n.madd("Generator", buses_i, " load",
                bus=buses_i,
                carrier='load',

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -101,8 +101,9 @@ def prepare_network(n, solve_opts):
 
     if solve_opts.get('load_shedding'):
         n.add("Carrier", "Load")
-        n.madd("Generator", n.buses.index, " load",
-               bus=n.buses.index,
+        buses_i = n.buses.query('carrier not in @n.stores.carrier.unique()').index
+        n.madd("Generator", buses_i, " load",
+               bus=buses_i,
                carrier='load',
                sign=1e-3, # Adjust sign to measure p and p_nom in kW instead of MW
                marginal_cost=1e2, # Eur/kWh

--- a/scripts/solve_operations_network.py
+++ b/scripts/solve_operations_network.py
@@ -81,10 +81,15 @@ def set_parameters_from_optimized(n, n_optim):
         n_optim.generators['p_nom_opt'].reindex(gen_extend_i, fill_value=0.)
     n.generators.loc[gen_extend_i, 'p_nom_extendable'] = False
 
-    stor_extend_i = n.storage_units.index[n.storage_units.p_nom_extendable]
-    n.storage_units.loc[stor_extend_i, 'p_nom'] = \
-        n_optim.storage_units['p_nom_opt'].reindex(stor_extend_i, fill_value=0.)
-    n.storage_units.loc[stor_extend_i, 'p_nom_extendable'] = False
+    stor_units_extend_i = n.storage_units.index[n.storage_units.p_nom_extendable]
+    n.storage_units.loc[stor_units_extend_i, 'p_nom'] = \
+        n_optim.storage_units['p_nom_opt'].reindex(stor_units_extend_i, fill_value=0.)
+    n.storage_units.loc[stor_units_extend_i, 'p_nom_extendable'] = False
+
+    stor_extend_i = n.stores.index[n.stores.e_nom_extendable]
+    n.stores.loc[stor_extend_i, 'e_nom'] = \
+        n_optim.stores['e_nom_opt'].reindex(stor_extend_i, fill_value=0.)
+    n.stores.loc[stor_extend_i, 'e_nom_extendable'] = False
 
     return n
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
If load_shedding is added to the network, including generators such as `battery load` or `H2 load` seems un-intuitive to me... in terms of feasibility it should be sufficient to include one generator per bus (i.e. not the store/battery buses). Please correct if I'm wrong!

Also, optimized store capacities were not included to the operations network. My guess is this build on #97

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
