### PR TITLE
update plot_network and make_summary to latest pypsa/-eur versions

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -361,7 +361,6 @@ def input_make_summary(w):
         ll = w.ll
     return ([COSTS] +
             expand("results/networks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc",
-                   network=w.network,
                    ll=ll,
                    **{k: config["scenario"][k] if getattr(w, k) == "all" else getattr(w, k)
                       for k in ["simpl", "clusters", "opts"]}))

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -444,7 +444,7 @@ if __name__ == "__main__":
         ll = [snakemake.wildcards.ll]
 
     networks_dict = {(simpl,clusters,l,opts) :
-        os.path.join(network_dir, f'{snakemake.wildcards.network}_s{simpl}_'
+        os.path.join(network_dir, f'elec_s{simpl}_'
                                   f'{clusters}_ec_l{l}_{opts}.nc')
                      for simpl in expand_from_wildcard("simpl")
                      for clusters in expand_from_wildcard("clusters")

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -88,36 +88,43 @@ def plot_map(n, ax=None, attribute='p_nom', opts={}):
         # bus_sizes = n.generators_t.p.sum().loc[n.generators.carrier == "load"].groupby(n.generators.bus).sum()
         bus_sizes = pd.concat((n.generators.query('carrier != "load"').groupby(['bus', 'carrier']).p_nom_opt.sum(),
                                n.storage_units.groupby(['bus', 'carrier']).p_nom_opt.sum()))
-        line_widths_exp = dict(Line=n.lines.s_nom_opt, Link=n.links.p_nom_opt)
-        line_widths_cur = dict(Line=n.lines.s_nom_min, Link=n.links.p_nom_min)
+        line_widths_exp = n.lines.s_nom_opt
+        line_widths_cur = n.lines.s_nom_min
+        link_widths_exp = n.links.p_nom_opt
+        link_widths_cur = n.links.p_nom_min
     else:
         raise 'plotting of {} has not been implemented yet'.format(attribute)
 
 
     line_colors_with_alpha = \
-    dict(Line=(line_widths_cur['Line'] / n.lines.s_nom > 1e-3)
-        .map({True: line_colors['cur'], False: to_rgba(line_colors['cur'], 0.)}),
-        Link=(line_widths_cur['Link'] / n.links.p_nom > 1e-3)
+        ((line_widths_cur / n.lines.s_nom > 1e-3)
+         .map({True: line_colors['cur'], False: to_rgba(line_colors['cur'], 0.)}))
+    link_colors_with_alpha = \
+        ((link_widths_cur / n.links.p_nom > 1e-3)
         .map({True: line_colors['cur'], False: to_rgba(line_colors['cur'], 0.)}))
+    
 
     ## FORMAT
     linewidth_factor = opts['map'][attribute]['linewidth_factor']
     bus_size_factor  = opts['map'][attribute]['bus_size_factor']
 
     ## PLOT
-    n.plot(line_widths=pd.concat(line_widths_exp)/linewidth_factor,
-           line_colors=dict(Line=line_colors['exp'], Link=line_colors['exp']),
+    n.plot(line_widths=line_widths_exp/linewidth_factor,
+           link_widths=link_widths_exp/linewidth_factor,
+           line_colors=line_colors['exp'],
+           link_colors=line_colors['exp'],
            bus_sizes=bus_sizes/bus_size_factor,
            bus_colors=tech_colors,
            boundaries=map_boundaries,
-           geomap=True,
+           color_geomap=True, geomap=True,
            ax=ax)
-    n.plot(line_widths=pd.concat(line_widths_cur)/linewidth_factor,
-           line_colors=pd.concat(line_colors_with_alpha),
+    n.plot(line_widths=line_widths_cur/linewidth_factor,
+           link_widths=link_widths_cur/linewidth_factor,
+           line_colors=line_colors_with_alpha,
+           link_colors=link_colors_with_alpha,
            bus_sizes=0,
-           bus_colors=tech_colors,
            boundaries=map_boundaries,
-           geomap=False,
+           color_geomap=True, geomap=False,
            ax=ax)
     ax.set_aspect('equal')
     ax.axis('off')
@@ -138,7 +145,7 @@ def plot_map(n, ax=None, attribute='p_nom', opts={}):
                      loc="upper left", bbox_to_anchor=(0.24, 1.01),
                      frameon=False,
                      labelspacing=0.8, handletextpad=1.5,
-                     title='Transmission Exist./Exp.             ')
+                     title='Transmission Exp./Exist.             ')
     ax.add_artist(l1_1)
 
     handles = []


### PR DESCRIPTION
Support previous updates in [PyPSA 166](https://github.com/PyPSA/PyPSA/pull/166), where `line_colors`, `link_colors`, `line_widths` and `link_widths` are now separate kwargs in the plotting functionality. Also, in #190 where the `network` wildcard was removed - but this change was forgotten to be adapted for `make_summary`.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
