### PR TITLE
simplify: drop incorrect cols if they exist (avoid error)

### DIFF
--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -407,8 +407,11 @@ if __name__ == "__main__":
     if snakemake.wildcards.simpl:
         n, cluster_map = cluster(n, int(snakemake.wildcards.simpl))
         busmaps.append(cluster_map)
-    else:
-        n.buses = n.buses.drop(['symbol', 'tags', 'under_construction', 'substation_lv', 'substation_off'], axis=1)
+
+    # some entries in n.buses are not updated in previous functions, therefore can be wrong. as they are not needed
+    # and are lost when clustering (for example with the simpl wildcard), we remove them for consistency:
+    buses_c = {'symbol', 'tags', 'under_construction', 'substation_lv', 'substation_off'}.intersection(n.buses.columns)
+    n.buses = n.buses.drop(buses_c, axis=1)
 
     update_p_nom_max(n)
         


### PR DESCRIPTION
bug with drop columns in simplify_network, when previously a clustering method was applied. before, this was only the case when a simpl wildcard was applied. with #243 there are now two cases. here's a fix suggestion that is independent of which or how many clustering pre-processing steps are applied.
xref: https://groups.google.com/g/pypsa/c/QO8Rhy22_hI

i also added a short comment why we are doing this, because at the moment it seems rather random.

we could also make the stubs clustering optional...