### PR TITLE
Mark datasets from Zenodo as static

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -153,7 +153,7 @@ if config['enable'].get('build_cutout', False):
 
 if config['enable'].get('retrieve_cutout', True):
     rule retrieve_cutout:
-        input: HTTP.remote("zenodo.org/record/4709858/files/{cutout}.nc", keep_local=True)
+        input: HTTP.remote("zenodo.org/record/4709858/files/{cutout}.nc", keep_local=True, static=True)
         output: "cutouts/{cutout}.nc"
         shell: "mv {input} {output}"
 
@@ -170,7 +170,7 @@ if config['enable'].get('build_natura_raster', False):
 
 if config['enable'].get('retrieve_natura_raster', True):
     rule retrieve_natura_raster:
-        input: HTTP.remote("zenodo.org/record/4706686/files/natura.tiff", keep_local=True)
+        input: HTTP.remote("zenodo.org/record/4706686/files/natura.tiff", keep_local=True, static=True)
         output: "resources/natura.tiff"
         shell: "mv {input} {output}"
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

When retrieving a remote file over HTTP, Snakemake uses the "last-modified" property in HTTP header as a proxy for `mtime` of the remote file. If this time is more recent than the `mtime` of the output of the retrieve rule, the rule is triggered and the remote file is retrieved again (since it was apparently updated).

However, Zenodo periodically updates the "last-modified" property of records retrieved over HTTP even if those records have not been updated. This causes Snakemake to false assume that the records have to downloaded again.

Run for example `curl -I https://zenodo.org/record/4709858/files/europe-2013-era5.nc` so see the HTTP header with the "last-modified" time.

By setting `static=True` for datasets we know don't actually change, we avoid this problem.

Another way to change this would be change how we retrieve data from Zenodo. Zenodo offers an API which is probably more reliable with respect to these things, but then it looks like you need to generate an API access token, which is undesirable. Or maybe there is a different kind of HTTP request which returns a sensible "last-modified" time? I haven't been able to figure that out.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.

I'm not sure if this is worth menioning in the release notes, but I can add a note if desired.
