### PR TITLE
Update CPLEX default parameters (and documentation)

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -238,8 +238,8 @@ solving:
   #   threads: 4
   #   lpmethod: 4 # barrier
   #   solutiontype: 2 # non basic solution, ie no crossover
-  #   barrier_convergetol: 1.e-5
-  #   feasopt_tolerance: 1.e-6
+  #   barrier.convergetol: 1.e-5
+  #   feasopt.tolerance: 1.e-6
 
 plotting:
   map:

--- a/doc/configtables/solving-solver.csv
+++ b/doc/configtables/solving-solver.csv
@@ -1,3 +1,3 @@
 ,Unit,Values,Description
 name,--,"One of {'gurobi', 'cplex', 'cbc', 'glpk', 'ipopt'}; potentially more possible","Solver to use for optimisation problems in the workflow; e.g. clustering and linear optimal power flow."
-opts,--,"Parameter list for `Gurobi <https://www.gurobi.com/documentation/8.1/refman/parameters.html>`_ and `CPLEX <https://www.ibm.com/support/knowledgecenter/SSSA5P_12.5.1/ilog.odms.cplex.help/CPLEX/Parameters/topics/introListAlpha.html>`_","Solver specific parameter settings."
+opts,--,"Parameter list for `Gurobi <https://www.gurobi.com/documentation/8.1/refman/parameters.html>`_ and `CPLEX <https://www.ibm.com/docs/en/icos/20.1.0?topic=cplex-topical-list-parameters>`_","Solver specific parameter settings."

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -195,8 +195,8 @@ solving:
   #   threads: 4
   #   lpmethod: 4 # barrier
   #   solutiontype: 2 # non basic solution, ie no crossover
-  #   barrier_convergetol: 1.e-5
-  #   feasopt_tolerance: 1.e-6
+  #   barrier.convergetol: 1.e-5
+  #   feasopt.tolerance: 1.e-6
 
 plotting:
   map:


### PR DESCRIPTION
For more recent versions of CPLEX and PyPSA, using dotted options works while the current default crashes a CPLEX solve with "AttributeError: 'RootParameterGroup' object has no attribute 'barrier_convergetol'". See https://github.com/PyPSA/PyPSA/pull/168.

## Changes proposed in this Pull Request

Exchange underscores for dots in default CPLEX configuration. Also update obsolete link to CPLEX parameter documentation.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [-] Code and workflow changes are sufficiently documented.
- [-] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
