### PR TITLE
config: reduce default deployment density for offshore wind

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -111,7 +111,7 @@ renewable:
     resource:
       method: wind
       turbine: NREL_ReferenceTurbine_5MW_offshore
-    capacity_per_sqkm: 3
+    capacity_per_sqkm: 2
     correction_factor: 0.8855
     # proxy for wake losses
     # from 10.1016/j.energy.2018.08.153
@@ -128,7 +128,7 @@ renewable:
       method: wind
       turbine: NREL_ReferenceTurbine_5MW_offshore
     # ScholzPhd Tab 4.3.1: 10MW/km^2
-    capacity_per_sqkm: 3
+    capacity_per_sqkm: 2
     correction_factor: 0.8855
     # proxy for wake losses
     # from 10.1016/j.energy.2018.08.153

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -15,6 +15,9 @@ Upcoming Release
   as a proxy for wake losses. More rigorous modelling is `planned <https://github.com/PyPSA/pypsa-eur/issues/153>`_
   [`#277 <https://github.com/PyPSA/pypsa-eur/pull/277>`_].
 
+* The default deployment density of AC- and DC-connected offshore wind capacity is reduced from 3 MW/sqkm
+  to a more conservative estimate of 2 MW/sqkm [`#280 <https://github.com/PyPSA/pypsa-eur/pull/280>`_].
+
 
 PyPSA-Eur 0.4.0 (22th September 2021)
 =====================================


### PR DESCRIPTION
## Changes proposed in this Pull Request

The default deployment density of AC- and DC-connected offshore wind capacity is reduced from 3 MW/km² to a more conservative estimate of 2 MW/km².

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- ~[ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.~
- ~[ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.~
- ~[ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.~
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
