### PR TITLE
Fix distribute clustering with cbc/glpk/ipopt

### DIFF
--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -218,7 +218,7 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name=None):
     results = opt.solve(m)
     assert results['Solver'][0]['Status'] == 'ok', f"Solver returned non-optimally: {results}"
 
-    return pd.Series(m.n.get_values(), index=L.index).astype(int)
+    return pd.Series(m.n.get_values(), index=L.index).round().astype(int)
 
 
 def busmap_for_n_clusters(n, n_clusters, solver_name, focus_weights=None, algorithm="kmeans", **algorithm_kwds):


### PR DESCRIPTION
In PyPSA-Africa an error appeared while clustering two countries:
`OverflowError: cannot convert float infinity to integer`
(CI in PyPSA-Eur only considers 1 country). This PR fixes the issue.

Assume you have 10 nodes that need to be distributed between 2 countries.
What can happen with some of the open-source solvers is that one country
gets assigned to 9.01 (float) nodes, and the other one to 0.99.

Now using .astype(int) would lead to a node distribution of 0 and 9, as
the `astype(int)` function round down by default (0.99 -> 0). This assigned
zero value breaks the code in case open source solvers are used.

Gurobi somehow does deal with it. Therefore the error was not detected previously.

Closes #

## Changes proposed in this Pull Request
add `.round()`

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.

