### PR TITLE
hot fix for snakemake bug

### DIFF
--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -240,7 +240,7 @@ def mock_snakemake(rulename, **wildcards):
         if os.path.exists(p):
             snakefile = p
             break
-    workflow = sm.Workflow(snakefile)
+    workflow = sm.Workflow(snakefile, overwrite_configfiles=[])
     workflow.include(snakefile)
     workflow.global_resources = {}
     rule = workflow.get_rule(rulename)


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
The given change avoids the error caused by the current version of the snakemake package. In the current snakemake Workflow object the attribute overwrite_configfiles gets the default value None. This causes an error when the method list(overwrite_configfiles) is called.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
