### PR TITLE
build_load_data bug: removed underscore in pattern

### DIFF
--- a/scripts/build_load_data.py
+++ b/scripts/build_load_data.py
@@ -70,7 +70,7 @@ def load_timeseries(fn, years, countries, powerstatistics=True):
     """
     logger.info(f"Retrieving load data from '{fn}'.")
 
-    pattern = 'power_statistics' if powerstatistics else '_transparency'
+    pattern = 'power_statistics' if powerstatistics else 'transparency'
     pattern = f'_load_actual_entsoe_{pattern}'
     rename = lambda s: s[:-len(pattern)]
     date_parser = lambda x: dateutil.parser.parse(x, ignoretz=True)


### PR DESCRIPTION
When using the transparency option the pattern used as a filter is created with a double underscore -> removed underscore in '_transparency'

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
