### PR TITLE
Fix random state for kmean clustering

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -24,6 +24,8 @@ Upcoming Release
 
 * Resource definitions for memory usage now follow [Snakemake standard resource definition](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#standard-resources) ```mem_mb`` rather than ``mem``.
 
+* Network building is made deterministic by supplying a fixed random state to network clustering routines.
+
 
 PyPSA-Eur 0.4.0 (22th September 2021)
 =====================================

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -226,6 +226,7 @@ def busmap_for_n_clusters(n, n_clusters, solver_name, focus_weights=None, algori
         algorithm_kwds.setdefault('n_init', 1000)
         algorithm_kwds.setdefault('max_iter', 30000)
         algorithm_kwds.setdefault('tol', 1e-6)
+        algorithm_kwds.setdefault('random_state', 0)
 
     n.determine_network_topology()
 


### PR DESCRIPTION
When the kmeans algorithm is used to cluster networks, this is not deterministic by default. The result is that repeated runs of the `simplify_network` and `cluster_network` rules can and usually do produce different results that vary randomly. This makes results less reproducible when given only a pypsa-eur configuration file.

## Changes proposed in this Pull Request

The fix is to supply a fixed random state to the k-means algorithm.

It might be considered if this should be done PyPSA itself, in the `busmap_by_kmeans` functions in `networkclustering.py`. That's an equally valid option, but maybe a bit opinionated.

I have not checked in a very rigorous way if there are any other sources of randomness in the network building process, but I don't think so.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] N/A Code and workflow changes are sufficiently documented.
- [ ] N/A Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] N/A Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] N/A Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
