### PR TITLE
Weather year and investment years as wildcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # PyPSA-Eur: An Open Optimisation Model of the European Transmission System
 
-Test
 PyPSA-Eur is an open model dataset of the European power system at the
 transmission network level that covers the full ENTSO-E area.
 The model is suitable both for operational studies and generation and transmission expansion planning studies.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # PyPSA-Eur: An Open Optimisation Model of the European Transmission System
 
-
+Test
 PyPSA-Eur is an open model dataset of the European power system at the
 transmission network level that covers the full ENTSO-E area.
 The model is suitable both for operational studies and generation and transmission expansion planning studies.

--- a/Snakefile
+++ b/Snakefile
@@ -19,7 +19,7 @@ ATLITE_NPROCESSES = config['atlite'].get('nprocesses', 4)
 
 wildcard_constraints:
     simpl="[a-zA-Z0-9]*|all",
-    weather_year="[0-9]*|all",
+    weather_year="[0-9]*",
     clusters="[0-9]+m?|all",
     ll="(v|c)([0-9\.]+|opt|all)|all",
     opts="[-+a-zA-Z0-9\.]*"

--- a/Snakefile
+++ b/Snakefile
@@ -206,7 +206,7 @@ rule build_renewable_profiles:
         regions=lambda w: ("resources/regions_onshore.geojson"
                            if w.technology in ('onwind', 'solar')
                            else "resources/regions_offshore.geojson"),
-        cutout=lambda w: "cutouts/" + config["renewable"][w.technology]['cutout'] + ".nc"
+        cutout="cutouts/europe-{weatheryear}-era5.nc" #lambda w: "cutouts/" + config["renewable"][w.technology]['cutout'] + ".nc"
     output:
         profile="resources/profile{weather_year}_{technology}.nc",
     log: "logs/build_renewable_profile{weather_year}_{technology}.log"
@@ -221,7 +221,7 @@ if 'hydro' in config['renewable'].keys():
         input:
             country_shapes='resources/country_shapes.geojson',
             eia_hydro_generation='data/bundle/EIA_hydro_generation_2000_2014.csv',
-            cutout="cutouts/" + config["renewable"]['hydro']['cutout'] + ".nc"
+            cutout= "cutouts/europe-{weatheryear}-era5.nc" # "cutouts/" + config["renewable"]['hydro']['cutout'] + ".nc"
         output: 'resources/profile{weather_year}_hydro.nc'
         log: "logs/build_hydro_profile{weather_year}.log"
         resources: mem=5000

--- a/Snakefile
+++ b/Snakefile
@@ -19,7 +19,7 @@ ATLITE_NPROCESSES = config['atlite'].get('nprocesses', 4)
 
 wildcard_constraints:
     simpl="[a-zA-Z0-9]*|all",
-    weather_year="[0-9]*",
+    weather_year="[0-9]*|all",
     clusters="[0-9]+m?|all",
     ll="(v|c)([0-9\.]+|opt|all)|all",
     opts="[-+a-zA-Z0-9\.]*"

--- a/Snakefile
+++ b/Snakefile
@@ -64,12 +64,15 @@ if config['enable'].get('retrieve_databundle', True):
     rule retrieve_databundle:
         output: expand('data/bundle/{file}', file=datafiles)
         log: "logs/retrieve_databundle.log"
+        resources: mem_mb=1000
         script: 'scripts/retrieve_databundle.py'
 
 
 rule retrieve_load_data:
     input: HTTP.remote("data.open-power-system-data.org/time_series/2019-06-05/time_series_60min_singleindex.csv", keep_local=True, static=True)
     output: "data/load_raw.csv"
+    log: "logs/retrieve_load_data.log"
+    resources: mem_mb=5000
     shell: "mv {input} {output}"
 
 
@@ -77,6 +80,7 @@ rule build_load_data:
     input: "data/load_raw.csv"
     output: "resources/load.csv"
     log: "logs/build_load_data.log"
+    resources: mem_mb=5000
     script: 'scripts/build_load_data.py'
     
 
@@ -162,6 +166,8 @@ if config['enable'].get('retrieve_cutout', True):
     rule retrieve_cutout:
         input: HTTP.remote("zenodo.org/record/4709858/files/{cutout}.nc", keep_local=True, static=True)
         output: "cutouts/{cutout}.nc"
+        log: "logs/retrieve_cutout_{cutout}.log"
+        resources: mem_mb=5000
         shell: "mv {input} {output}"
 
 
@@ -171,6 +177,7 @@ if config['enable'].get('build_natura_raster', False):
             natura="data/bundle/natura/Natura2000_end2015.shp",
             cutouts=expand("cutouts/{cutouts}.nc", **config['atlite'])
         output: "resources/natura.tiff"
+        resources: mem_mb=5000
         log: "logs/build_natura_raster.log"
         script: "scripts/build_natura_raster.py"
 
@@ -179,6 +186,8 @@ if config['enable'].get('retrieve_natura_raster', True):
     rule retrieve_natura_raster:
         input: HTTP.remote("zenodo.org/record/4706686/files/natura.tiff", keep_local=True, static=True)
         output: "resources/natura.tiff"
+        log: "logs/retrieve_natura_raster.log"
+        resources: mem_mb=5000
         shell: "mv {input} {output}"
 
 
@@ -377,6 +386,7 @@ rule make_summary:
     input: input_make_summary
     output: directory("results/summaries/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{country}")
     log: "logs/make_summary/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{country}.log",
+    resources: mem_mb=500
     script: "scripts/make_summary.py"
 
 
@@ -384,6 +394,7 @@ rule plot_summary:
     input: "results/summaries/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{country}"
     output: "results/plots/summary_{summary}_elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{country}.{ext}"
     log: "logs/plot_summary/{summary}_elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{country}_{ext}.log"
+    resources: mem_mb=500
     script: "scripts/plot_summary.py"
 
 
@@ -397,5 +408,6 @@ rule plot_p_nom_max:
     input: input_plot_p_nom_max
     output: "results/plots/elec_s{simpl}_cum_p_nom_max_{clusts}_{techs}_{country}.{ext}"
     log: "logs/plot_p_nom_max/elec_s{simpl}_{clusts}_{techs}_{country}_{ext}.log"
+    resources: mem_mb=500
     script: "scripts/plot_p_nom_max.py"
 

--- a/Snakefile
+++ b/Snakefile
@@ -19,7 +19,7 @@ ATLITE_NPROCESSES = config['atlite'].get('nprocesses', 4)
 
 wildcard_constraints:
     simpl="[a-zA-Z0-9]*|all",
-    weather_year="[0-9]*", #"[a-zA-Z0-9]*", # "[0-9]+m?",
+    weather_year="[0-9]*",
     clusters="[0-9]+m?|all",
     ll="(v|c)([0-9\.]+|opt|all)|all",
     opts="[-+a-zA-Z0-9\.]*"
@@ -151,17 +151,17 @@ rule build_bus_regions:
     script: "scripts/build_bus_regions.py"
 
 
-# if config['enable'].get('build_cutout', False):
-#         rule build_cutout:
-#             input: 
-#                 regions_onshore="resources/regions_onshore.geojson",
-#                 regions_offshore="resources/regions_offshore.geojson"
-#             output: "cutouts/europe-{weather_year}-" + "{}.nc".format(config['cutout'].split('-')[1])
-#             log: "logs/build_cutout/europe-{weather_year}-" + "{}.log".format(config['cutout'].split('-')[1])
-#             benchmark: "benchmarks/build_cutout_europe-{weather_year}-" + "{}".format(config['cutout'].split('-')[1])
-#             threads: ATLITE_NPROCESSES
-#             resources: mem_mb=ATLITE_NPROCESSES * 1000
-#             script: "scripts/build_cutout.py"
+if config['enable'].get('build_cutout', False):
+    rule build_cutout:
+        input: 
+            regions_onshore="resources/regions_onshore.geojson",
+            regions_offshore="resources/regions_offshore.geojson"
+        output: "cutouts/europe-{weather_year}-" + "{}.nc".format(config['cutout'].split('-')[1])
+        log: "logs/build_cutout/europe-{weather_year}-" + "{}.log".format(config['cutout'].split('-')[1])
+        benchmark: "benchmarks/build_cutout_europe-{weather_year}-" + "{}".format(config['cutout'].split('-')[1])
+        threads: ATLITE_NPROCESSES
+        resources: mem_mb=ATLITE_NPROCESSES * 1000
+        script: "scripts/build_cutout.py"
 
 
 if config['enable'].get('retrieve_cutout', True):

--- a/Snakefile
+++ b/Snakefile
@@ -19,7 +19,7 @@ ATLITE_NPROCESSES = config['atlite'].get('nprocesses', 4)
 
 wildcard_constraints:
     simpl="[a-zA-Z0-9]*|all",
-    weather_year="[0-9]+m?",
+    weather_year="[0-9]*", #"[a-zA-Z0-9]*", # "[0-9]+m?",
     clusters="[0-9]+m?|all",
     ll="(v|c)([0-9\.]+|opt|all)|all",
     opts="[-+a-zA-Z0-9\.]*"
@@ -151,17 +151,17 @@ rule build_bus_regions:
     script: "scripts/build_bus_regions.py"
 
 
-if config['enable'].get('build_cutout', False):
-    rule build_cutout:
-        input: 
-            regions_onshore="resources/regions_onshore.geojson",
-            regions_offshore="resources/regions_offshore.geojson"
-        output: "cutouts/europe-{weather_year}-era5.nc" # {cutout}")
-        log: "logs/build_cutout/europe-{weather_year}-era5.log"
-        benchmark: "benchmarks/build_cutout_europe-{weather_year}-era5"
-        threads: ATLITE_NPROCESSES
-        resources: mem_mb=ATLITE_NPROCESSES * 1000
-        script: "scripts/build_cutout.py"
+# if config['enable'].get('build_cutout', False):
+#         rule build_cutout:
+#             input: 
+#                 regions_onshore="resources/regions_onshore.geojson",
+#                 regions_offshore="resources/regions_offshore.geojson"
+#             output: "cutouts/europe-{weather_year}-" + "{}.nc".format(config['cutout'].split('-')[1])
+#             log: "logs/build_cutout/europe-{weather_year}-" + "{}.log".format(config['cutout'].split('-')[1])
+#             benchmark: "benchmarks/build_cutout_europe-{weather_year}-" + "{}".format(config['cutout'].split('-')[1])
+#             threads: ATLITE_NPROCESSES
+#             resources: mem_mb=ATLITE_NPROCESSES * 1000
+#             script: "scripts/build_cutout.py"
 
 
 if config['enable'].get('retrieve_cutout', True):
@@ -207,7 +207,8 @@ rule build_renewable_profiles:
         regions=lambda w: ("resources/regions_onshore.geojson"
                            if w.technology in ('onwind', 'solar')
                            else "resources/regions_offshore.geojson"),
-        cutout="cutouts/europe-{weather_year}-era5.nc" #lambda w: "cutouts/" + config["renewable"][w.technology]['cutout'] + ".nc"
+                
+        cutout="cutouts/europe-{weather_year}-" + "{}.nc".format(config['cutout'].split('-')[1])
     output:
         profile="resources/profile{weather_year}_{technology}.nc",
     log: "logs/build_renewable_profile{weather_year}_{technology}.log"
@@ -222,7 +223,7 @@ if 'hydro' in config['renewable'].keys():
         input:
             country_shapes='resources/country_shapes.geojson',
             eia_hydro_generation='data/bundle/EIA_hydro_generation_2000_2014.csv',
-            cutout= "cutouts/europe-{weather_year}-era5.nc" # "cutouts/" + config["renewable"]['hydro']['cutout'] + ".nc"
+            cutout="cutouts/europe-{weather_year}-" + "{}.nc".format(config['cutout'].split('-')[1])
         output: 'resources/profile{weather_year}_hydro.nc'
         log: "logs/build_hydro_profile{weather_year}.log"
         resources: mem_mb=5000

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -24,11 +24,6 @@ clustering:
   simplify:
     to_substations: false # network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)
 
-#snapshots: # Not used # Maybe use this instead for "load/year" in base_network.py to allow studies for more than one year
- # start: "2011-01-01"
- # end: "2012-01-01"
- # closed: 'left' # end is not inclusive
-
 enable:
   prepare_links_p_nom: false
   retrieve_databundle: true
@@ -64,7 +59,7 @@ electricity:
   #   Wind: [onwind, offwind-ac, offwind-dc]
   #   Solar: [solar]
 
-cutout: 'europe-era5' # Cutout used. Currently, we can only use era5 for multiyear-purpose.
+cutout: 'europe-era5' # Cutout used for renewable potentials. Currently, we can only use era5 for multiyear-purpose.
 
 atlite:
   nprocesses: 4
@@ -91,7 +86,7 @@ atlite:
       
 renewable:
   onwind:
-    #cutout: europe-2013-era5
+    #cutout: europe-era5
     resource:
       method: wind
       turbine: Vestas_V112_3MW
@@ -108,7 +103,7 @@ renewable:
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   offwind-ac:
-    #cutout: europe-2013-era5
+    #cutout: europe-era5
     resource:
       method: wind
       turbine: NREL_ReferenceTurbine_5MW_offshore
@@ -124,7 +119,7 @@ renewable:
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   offwind-dc:
-    #cutout: europe-2013-era5
+    #cutout: europe-era5
     resource:
       method: wind
       turbine: NREL_ReferenceTurbine_5MW_offshore
@@ -141,7 +136,7 @@ renewable:
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   solar:
-    #cutout: europe-2013-sarah
+    #cutout: europe-sarah # Currently, sarah dataset has not been acquired for other years than 2013
     resource:
       method: pv
       panel: CSi
@@ -163,12 +158,12 @@ renewable:
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   hydro:
-    # cutout: europe-2013-era5
+    # cutout: europe-era5
     carriers: [ror, PHS, hydro]
     PHS_max_hours: 6
     hydro_max_hours: "energy_capacity_totals_by_country" # one of energy_capacity_totals_by_country, estimate_by_large_installations or a float
     clip_min_inflow: 1.0
-    normyear: 2013 # Hydro production year used for normalization of computed inflow. 
+    normyear: 2013 # Hydro production year used for normalization of computed inflow. [2000,2014]
 
 lines:
   types:
@@ -192,7 +187,7 @@ transformers:
   type: ''
 
 load:
-  year: 2013
+  year: 2013 # [2005, 2018]
   power_statistics: True # only for files from <2019; set false in order to get ENTSOE transparency data 
   interpolate_limit: 3 # data gaps up until this size are interpolated linearly
   time_shift_for_large_gaps: 1w # data gaps up until this size are copied by copying from 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -12,7 +12,7 @@ logging:
 summary_dir: results
 
 scenario:
-  weather_year: [''] # for backwards compatibility
+  weather_year: ['2011']
   simpl: ['']
   ll: ['copt']
   clusters: [37, 128, 256, 512, 1024]
@@ -24,16 +24,16 @@ clustering:
   simplify:
     to_substations: false # network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)
 
-snapshots:
-  start: "2011-01-01"
-  end: "2012-01-01"
-  closed: 'left' # end is not inclusive
+#snapshots: # Not used # Maybe use this instead for "load/year" in base_network.py to allow studies for more than one year
+ # start: "2011-01-01"
+ # end: "2012-01-01"
+ # closed: 'left' # end is not inclusive
 
 enable:
   prepare_links_p_nom: false
   retrieve_databundle: true
-  build_cutout: false
-  retrieve_cutout: true
+  build_cutout: true
+  retrieve_cutout: false
   build_natura_raster: false
   retrieve_natura_raster: true
   custom_busmap: false
@@ -64,26 +64,26 @@ electricity:
   #   Wind: [onwind, offwind-ac, offwind-dc]
   #   Solar: [solar]
 
+cutout: 'europe-era5' # Cutout used. Currently, we can only use era5 for multiyear-purpose.
+
 atlite:
   nprocesses: 4
   cutouts:
     # use 'base' to determine geographical bounds and time span from config
     # base: 
       # module: era5  
-    europe-2013-era5:
-      module: era5 # in priority order 
+    europe-era5:
+      module: era5
       x: [-12., 35.]
       y: [33., 72]
       dx: 0.3
       dy: 0.3
-      time: ['2013', '2013']
-    europe-2013-sarah:
-      module: [sarah, era5] # in priority order 
+    europe-sarah:
+      module: [sarah, era5]
       x: [-12., 45.]
       y: [33., 65]
       dx: 0.2
       dy: 0.2
-      time: ['2013', '2013']
       sarah_interpolate: false
       sarah_dir: 
       features: [influx, temperature]
@@ -91,7 +91,7 @@ atlite:
       
 renewable:
   onwind:
-    # cutout: europe-2013-era5
+    #cutout: europe-2013-era5
     resource:
       method: wind
       turbine: Vestas_V112_3MW
@@ -108,7 +108,7 @@ renewable:
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   offwind-ac:
-    # cutout: europe-2013-era5
+    #cutout: europe-2013-era5
     resource:
       method: wind
       turbine: NREL_ReferenceTurbine_5MW_offshore
@@ -124,7 +124,7 @@ renewable:
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   offwind-dc:
-    # cutout: europe-2013-era5
+    #cutout: europe-2013-era5
     resource:
       method: wind
       turbine: NREL_ReferenceTurbine_5MW_offshore
@@ -141,7 +141,7 @@ renewable:
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   solar:
-    # cutout: europe-2013-sarah
+    #cutout: europe-2013-sarah
     resource:
       method: pv
       panel: CSi
@@ -168,6 +168,7 @@ renewable:
     PHS_max_hours: 6
     hydro_max_hours: "energy_capacity_totals_by_country" # one of energy_capacity_totals_by_country, estimate_by_large_installations or a float
     clip_min_inflow: 1.0
+    normyear: 2013 # Hydro production year used for normalization of computed inflow. 
 
 lines:
   types:
@@ -191,6 +192,7 @@ transformers:
   type: ''
 
 load:
+  year: 2013
   power_statistics: True # only for files from <2019; set false in order to get ENTSOE transparency data 
   interpolate_limit: 3 # data gaps up until this size are interpolated linearly
   time_shift_for_large_gaps: 1w # data gaps up until this size are copied by copying from 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -12,6 +12,7 @@ logging:
 summary_dir: results
 
 scenario:
+  weather_year: [''] # for backwards compatibility
   simpl: ['']
   ll: ['copt']
   clusters: [37, 128, 256, 512, 1024]
@@ -24,8 +25,8 @@ clustering:
     to_substations: false # network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)
 
 snapshots:
-  start: "2013-01-01"
-  end: "2014-01-01"
+  start: "2011-01-01"
+  end: "2012-01-01"
   closed: 'left' # end is not inclusive
 
 enable:
@@ -90,7 +91,7 @@ atlite:
       
 renewable:
   onwind:
-    cutout: europe-2013-era5
+    # cutout: europe-2013-era5
     resource:
       method: wind
       turbine: Vestas_V112_3MW
@@ -107,7 +108,7 @@ renewable:
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   offwind-ac:
-    cutout: europe-2013-era5
+    # cutout: europe-2013-era5
     resource:
       method: wind
       turbine: NREL_ReferenceTurbine_5MW_offshore
@@ -123,7 +124,7 @@ renewable:
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   offwind-dc:
-    cutout: europe-2013-era5
+    # cutout: europe-2013-era5
     resource:
       method: wind
       turbine: NREL_ReferenceTurbine_5MW_offshore
@@ -140,7 +141,7 @@ renewable:
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   solar:
-    cutout: europe-2013-sarah
+    # cutout: europe-2013-sarah
     resource:
       method: pv
       panel: CSi
@@ -162,7 +163,7 @@ renewable:
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   hydro:
-    cutout: europe-2013-era5
+    # cutout: europe-2013-era5
     carriers: [ror, PHS, hydro]
     PHS_max_hours: 6
     hydro_max_hours: "energy_capacity_totals_by_country" # one of energy_capacity_totals_by_country, estimate_by_large_installations or a float

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -12,6 +12,7 @@ logging:
 summary_dir: results
 
 scenario:
+  weather_year: ['2011']
   simpl: ['']
   ll: ['copt']
   clusters: [5]
@@ -22,11 +23,6 @@ countries: ['DE']
 clustering:
   simplify:
     to_substations: false # network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)
-
-snapshots:
-  start: "2013-03-01"
-  end: "2013-04-01"
-  closed: 'left' # end is not inclusive
 
 enable:
   prepare_links_p_nom: false
@@ -55,18 +51,18 @@ electricity:
   custom_powerplants: false # use pandas query strings here, e.g. Country in ['Germany']
   conventional_carriers: [coal, CCGT] # [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
 
+cutout: 'tutorial-era5'
+
 atlite:
   nprocesses: 4
   cutouts:
-    europe-2013-era5-tutorial:
+    tutorial-era5:
       module: era5
       x: [4., 15.]
       y: [46., 56.]
-      time: ["2013-03", "2013-03"]
 
 renewable:
   onwind:
-    cutout: europe-2013-era5-tutorial
     resource:
       method: wind
       turbine: Vestas_V112_3MW
@@ -83,7 +79,6 @@ renewable:
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   offwind-ac:
-    cutout: europe-2013-era5-tutorial
     resource:
       method: wind
       turbine: NREL_ReferenceTurbine_5MW_offshore
@@ -95,7 +90,6 @@ renewable:
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   offwind-dc:
-    cutout: europe-2013-era5-tutorial
     resource:
       method: wind
       turbine: NREL_ReferenceTurbine_5MW_offshore
@@ -108,7 +102,6 @@ renewable:
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   solar:
-    cutout: europe-2013-era5-tutorial
     resource:
       method: pv
       panel: CSi
@@ -151,6 +144,7 @@ transformers:
   type: ''
 
 load:
+  year: 2013 # [2005, 2018]
   power_statistics: True # only for files from <2019; set false in order to get ENTSOE transparency data 
   interpolate_limit: 3 # data gaps up until this size are interpolated linearly
   time_shift_for_large_gaps: 1w # data gaps up until this size are copied by copying from 

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -559,8 +559,9 @@ def base_network(eg_buses, eg_converters, eg_transformers, eg_lines, eg_links,
     n = pypsa.Network()
     n.name = 'PyPSA-Eur'
 
-    n.set_snapshots(pd.date_range(freq='h', **config['snapshots']))
-
+    date_range = pd.date_range(str(snakemake.config['load']['year']) + '-01-01',str(int(snakemake.config['load']['year'])+1) + '-01-01',freq='h')[0:-1]
+    n.set_snapshots(date_range)
+    
     n.import_components_from_dataframe(buses, "Bus")
     n.import_components_from_dataframe(lines, "Line")
     n.import_components_from_dataframe(transformers, "Transformer")

--- a/scripts/build_cutout.py
+++ b/scripts/build_cutout.py
@@ -106,10 +106,15 @@ if __name__ == "__main__":
         snakemake = mock_snakemake('build_cutout', cutout='europe-2013-era5')
     configure_logging(snakemake)
 
-    cutout_params = snakemake.config['atlite']['cutouts'][snakemake.wildcards.cutout]
+    cutout_name = snakemake.config['cutout']
+    cutout_params = snakemake.config['atlite']['cutouts'][cutout_name]  
 
-    snapshots = pd.date_range(freq='h', **snakemake.config['snapshots'])
-    time = [snapshots[0], snapshots[-1]]
+    if len(snakemake.wildcards.weather_year) > 0:
+        weather_year = snakemake.wildcards.weather_year
+    else:
+        weather_year = snakemake.config['load']['year']
+
+    time = [str(int(weather_year)) + '-01-01',str(int(weather_year)) + '-12-31']
     cutout_params['time'] = slice(*cutout_params.get('time', time))
 
     if {'x', 'y', 'bounds'}.isdisjoint(cutout_params):

--- a/scripts/build_load_data.py
+++ b/scripts/build_load_data.py
@@ -200,7 +200,8 @@ if __name__ == "__main__":
     interpolate_limit = snakemake.config['load']['interpolate_limit']
     countries = snakemake.config['countries']
     snapshots = pd.date_range(freq='h', **snakemake.config['snapshots'])
-    years = slice(snapshots[0], snapshots[-1])
+    #years = slice(snapshots[0], snapshots[-1])
+    years = slice(str(snakemake.config['load']['year']) + '-01-01',str(snakemake.config['load']['year']+1) + '-01-01')
     time_shift = snakemake.config['load']['time_shift_for_large_gaps']
 
     load = load_timeseries(snakemake.input[0], years, countries, powerstatistics)


### PR DESCRIPTION
Related to the discussion in #177

## Changes proposed in this Pull Request

•	Weather year as wildcard {weather_year}
          o	Options to choose a weather year between 1979-2021
          o	The weather_year wildcard refers only to the datasets with direct weather dependence, i.e. renewable potential from wind and solar, and inflow for hydro, and e.g. year for historical electricity load, industry demand, etc., are not changed. Heat demand, solar thermal, and temperature profiles depend on weather data as well.
          o	**It is optional**. If not specified, it takes 2013 as weather year. 
          o	**Cutout is limited to ERA5** (I didn’t manage to retrieve Sarah for other years). However, some flexibility does exist if one should find a smart way to acquire sarah data (or other sources): Change config[‘cutout’] to e.g. ‘europe-sarah’ instead of ‘europe-era5’.
          o	**"snapshots" is substituted with config[‘loads’][‘year’]**. This might not be convenient if the optimization is based on a period of more than 1 year, i.e. perfect foresight for more than one year. An option could be to make configs[‘loads’][‘year’] a list of years or have it defined as a snapshot, as previously. The weather_year wildcard would then have to include two years, start and end year.

•	Investment year as wildcard {investment_year}
      o	The wildcard replaces {planning_horizons}
      o	For myopic optimization, {investment_year} acts as both the year of cost assumptions and as the year of planning
      o	For overnight optimization, {investment_year} only corresponds to the year of planning, where as config['cost']['year'] gives the year of cost cost assumptions

Things that I have not changed, but are no longer dependent on the “snapshots” which was earlier used to indicate period/year for data acquisition:
•	Electricity load year: 2013 (available from 2005 to 2018)  
•	Hydro production year: 2013 (available from 2000 to 2014)

Furthermore, the model relies on additional input years, which I have not altered:
•	Industry energy demand year: 2015 
•	Energy totals year: 2011
•	Eurostat report year 2016
•	Biomass: 2030

It might be convenient to argue why the different years have been selected.


## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
