### PR TITLE
Snakefile: fix memory function for clusters == 'all'

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -313,6 +313,8 @@ def memory(w):
             break
     if w.clusters.endswith('m'):
         return int(factor * (18000 + 180 * int(w.clusters[:-1])))
+    elif w.clusters == "all":
+        return int(factor * (18000 + 180 * 4000))
     else:
         return int(factor * (10000 + 195 * int(w.clusters)))
 

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -343,6 +343,9 @@ if __name__ == "__main__":
     if snakemake.wildcards.clusters.endswith('m'):
         n_clusters = int(snakemake.wildcards.clusters[:-1])
         aggregate_carriers = pd.Index(n.generators.carrier.unique()).difference(renewable_carriers)
+    elif snakemake.wildcards.clusters == 'all':
+        n_clusters = len(n.buses)
+        aggregate_carriers = None # All
     else:
         n_clusters = int(snakemake.wildcards.clusters)
         aggregate_carriers = None # All


### PR DESCRIPTION
## Changes proposed in this Pull Request

When setting the cluster wildcard to 'all' the memory function raises an error as no number is passed to `int()`. The fix hard-codes the memory limit to the resources needed for a full `pypsa-eur` network with all nodes. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
