### PR TITLE
fix the plot_network snakemake rule

### DIFF
--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -120,7 +120,7 @@ def load_network_for_plots(fn, tech_costs, config, combine_hydro_ps=True):
     # n.storage_units.loc[bus_carrier == "heat","carrier"] = "water tanks"
 
     Nyears = n.snapshot_weightings.objective.sum() / 8760.
-    costs = load_costs(Nyears, tech_costs, config['costs'], config['electricity'])
+    costs = load_costs(tech_costs, config['costs'], config['electricity'], Nyears)
     update_transmission_costs(n, costs)
 
     return n

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -20,8 +20,7 @@ Description
 """
 
 import logging
-from _helpers import (retrieve_snakemake_keys, load_network_for_plots,
-                      aggregate_p, aggregate_costs, configure_logging)
+from _helpers import (load_network_for_plots, aggregate_p, aggregate_costs, configure_logging)
 
 import pandas as pd
 import numpy as np
@@ -182,7 +181,7 @@ def plot_map(n, ax=None, attribute='p_nom', opts={}):
     return fig
 
 
-def plot_total_energy_pie(n, ax=None):
+def plot_total_energy_pie(n, ax=None, opts={}):
     if ax is None: ax = plt.gca()
 
     ax.set_title('Energy per technology', fontdict=dict(fontsize="medium"))
@@ -200,7 +199,7 @@ def plot_total_energy_pie(n, ax=None):
             t1.remove()
             t2.remove()
 
-def plot_total_cost_bar(n, ax=None):
+def plot_total_cost_bar(n, ax=None, opts={}):
     if ax is None: ax = plt.gca()
 
     total_load = (n.snapshot_weightings.generators * n.loads_t.p.sum(axis=1)).sum()
@@ -259,25 +258,31 @@ if __name__ == "__main__":
 
     set_plot_style()
 
-    paths, config, wildcards, logs, out = retrieve_snakemake_keys(snakemake)
+    paths, config, wildcards, logs, out = (
+        snakemake.input,
+        snakemake.config,
+        snakemake.wildcards,
+        snakemake.log,
+        snakemake.output,
+    )
 
-    map_figsize = config['map']['figsize']
-    map_boundaries = config['map']['boundaries']
+    map_figsize = config["plotting"]['map']['figsize']
+    map_boundaries = config["plotting"]['map']['boundaries']
 
     n = load_network_for_plots(paths.network, paths.tech_costs, config)
 
     scenario_opts = wildcards.opts.split('-')
 
     fig, ax = plt.subplots(figsize=map_figsize, subplot_kw={"projection": ccrs.PlateCarree()})
-    plot_map(n, ax, wildcards.attr, config)
+    plot_map(n, ax, wildcards.attr, config["plotting"])
 
     fig.savefig(out.only_map, dpi=150, bbox_inches='tight')
 
     ax1 = fig.add_axes([-0.115, 0.625, 0.2, 0.2])
-    plot_total_energy_pie(n, ax1)
+    plot_total_energy_pie(n, ax1, config["plotting"])
 
     ax2 = fig.add_axes([-0.075, 0.1, 0.1, 0.45])
-    plot_total_cost_bar(n, ax2)
+    plot_total_cost_bar(n, ax2, config["plotting"])
 
     ll = wildcards.ll
     ll_type = ll[0]


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request:

1. Removed the dependency of _helper.retrieve_snakemake_keys from plot_network (now uses snakemake.attr)
2. Fixed the reference to the config["plotting"] which was broken
3. Added opts as argument for the config["plotting"] dict tot the plotting functions.


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
