### PR TITLE
Fix clustering of p_nom_max values with pandas version > 1.4

### DIFF
--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -263,9 +263,9 @@ def clustering_for_n_clusters(n, n_clusters, custom_busmap=False, aggregate_carr
                               algorithm="kmeans", extended_link_costs=0, focus_weights=None):
 
     if potential_mode == 'simple':
-        p_nom_max_strategy = np.sum
+        p_nom_max_strategy = pd.Series.sum
     elif potential_mode == 'conservative':
-        p_nom_max_strategy = np.min
+        p_nom_max_strategy = pd.Series.min
     else:
         raise AttributeError(f"potential_mode should be one of 'simple' or 'conservative' but is '{potential_mode}'")
 
@@ -281,7 +281,7 @@ def clustering_for_n_clusters(n, n_clusters, custom_busmap=False, aggregate_carr
         aggregate_generators_carriers=aggregate_carriers,
         aggregate_one_ports=["Load", "StorageUnit"],
         line_length_factor=line_length_factor,
-        generator_strategies={'p_nom_max': p_nom_max_strategy, 'p_nom_min': np.sum},
+        generator_strategies={'p_nom_max': p_nom_max_strategy, 'p_nom_min': pd.Series.sum},
         scale_link_capital_costs=False)
 
     if not n.links.empty:


### PR DESCRIPTION
This PR fixes the current clustering implementation (mainly resulting in a infeasible network solving for open-source solvers) with pandas version > 1.4. 

The original error resulted from an incompatibility of numpy aggregation functions with the pandas groupby process in the presence of `np.inf` values.  The issue is circumvented by using `pd.Series.sum` and `pd.Series.min` as aggregation functions. 

Likely this was also the reason for the CI failings. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] ~Code and workflow changes are sufficiently documented.~
- [ ] ~Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.~
- [ ] ~Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.~
- [ ] ~Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.~
- [ ] ~A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.~