### PR TITLE
Constrain Snakefile rule build_renewable_profiles with wildcard_constraint

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -201,7 +201,7 @@ rule build_renewable_profiles:
     benchmark: "benchmarks/build_renewable_profiles_{technology}"
     threads: ATLITE_NPROCESSES
     resources: mem_mb=ATLITE_NPROCESSES * 5000
-    wildcard_constraints: technology="^(?!hydro).*$" # Any technology other than hydro
+    wildcard_constraints: technology="(?!hydro).*" # Any technology other than hydro
     script: "scripts/build_renewable_profiles.py"
 
 

--- a/Snakefile
+++ b/Snakefile
@@ -201,19 +201,19 @@ rule build_renewable_profiles:
     benchmark: "benchmarks/build_renewable_profiles_{technology}"
     threads: ATLITE_NPROCESSES
     resources: mem_mb=ATLITE_NPROCESSES * 5000
+    wildcard_constraints: technology="solar|onwind|offwind-ac|offwind-dc"
     script: "scripts/build_renewable_profiles.py"
 
 
-if 'hydro' in config['renewable'].keys():
-    rule build_hydro_profile:
-        input:
-            country_shapes='resources/country_shapes.geojson',
-            eia_hydro_generation='data/bundle/EIA_hydro_generation_2000_2014.csv',
-            cutout="cutouts/" + config["renewable"]['hydro']['cutout'] + ".nc"
-        output: 'resources/profile_hydro.nc'
-        log: "logs/build_hydro_profile.log"
-        resources: mem_mb=5000
-        script: 'scripts/build_hydro_profile.py'
+rule build_hydro_profile:
+    input:
+        country_shapes='resources/country_shapes.geojson',
+        eia_hydro_generation='data/bundle/EIA_hydro_generation_2000_2014.csv',
+        cutout="cutouts/" + config["renewable"]['hydro']['cutout'] + ".nc"
+    output: 'resources/profile_hydro.nc'
+    log: "logs/build_hydro_profile.log"
+    resources: mem_mb=5000
+    script: 'scripts/build_hydro_profile.py'
 
 
 rule add_electricity:

--- a/Snakefile
+++ b/Snakefile
@@ -209,7 +209,7 @@ rule build_hydro_profile:
     input:
         country_shapes='resources/country_shapes.geojson',
         eia_hydro_generation='data/bundle/EIA_hydro_generation_2000_2014.csv',
-        cutout="cutouts/" + config["renewable"]['hydro']['cutout'] + ".nc"
+        cutout=f"cutouts/{config['renewable']['hydro']['cutout']}.nc" if "hydro" in config["renewable"] else "config['renewable']['hydro']['cutout'] not configured",
     output: 'resources/profile_hydro.nc'
     log: "logs/build_hydro_profile.log"
     resources: mem_mb=5000

--- a/Snakefile
+++ b/Snakefile
@@ -201,7 +201,7 @@ rule build_renewable_profiles:
     benchmark: "benchmarks/build_renewable_profiles_{technology}"
     threads: ATLITE_NPROCESSES
     resources: mem_mb=ATLITE_NPROCESSES * 5000
-    wildcard_constraints: technology="solar|onwind|offwind-ac|offwind-dc"
+    wildcard_constraints: technology="^(?!hydro).*$" # Any technology other than hydro
     script: "scripts/build_renewable_profiles.py"
 
 


### PR DESCRIPTION
* Introduce a `wildcard_constraint` to limit `build_renewable_profiles` to certain technologies.
* Remove potential ambuitiy for `resources/profile_hydro.nc`
* Remove optional inclusion of `build_hydro_profile`: Unnecessary, as rule is only executed, if `add_electricity` wants it.

Side effect:
* Easier to understand `snakemake` errors when trying to run with an unsupported `technology` :

```
# before PR
$ snakemake -call -n resources/profile_hello.nc
Building DAG of jobs...
InputFunctionException in line 185 of .../pypsa-eur/Snakefile:
Error:
  KeyError: 'hello'
Wildcards:
  technology=hello
Traceback:
  File ".../Snakefile", line 191, in <lambda>

# after PR
$ snakemake -call -n resources/profile_hello.nc
Building DAG of jobs...
MissingRuleException:
No rule to produce resources/profile_hello.nc (if you use input functions make sure that they don't raise unexpected exceptions).

```

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
