### PR TITLE
switch from CORINE to LUISA land use

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -53,7 +53,7 @@ datafiles = ['ch_cantons.csv', 'je-e-21.03.02.xls',
             'eez/World_EEZ_v8_2014.shp', 'EIA_hydro_generation_2000_2014.csv', 
             'hydro_capacities.csv', 'naturalearth/ne_10m_admin_0_countries.shp', 
             'NUTS_2013_60M_SH/data/NUTS_RG_60M_2013.shp', 'nama_10r_3popgdp.tsv.gz', 
-            'nama_10r_3gdp.tsv.gz', 'corine/g250_clc06_V18_5.tif']
+            'nama_10r_3gdp.tsv.gz']
 
 
 if not config.get('tutorial', False):
@@ -65,6 +65,12 @@ if config['enable'].get('retrieve_databundle', True):
         output: expand('data/bundle/{file}', file=datafiles)
         log: "logs/retrieve_databundle.log"
         script: 'scripts/retrieve_databundle.py'
+
+
+rule retrieve_landcover_data:
+    input: HTTP.remote("jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/LUISA/EUROPE/Basemaps/LandUse/2018/LATEST/LUISA_basemap_020321_50m.tif", static=True)
+    output: "data/landcover/LUISA_basemap_020321_50m.tif"
+    run: move(input[0], output[0])
 
 
 rule retrieve_load_data:
@@ -185,7 +191,7 @@ if config['enable'].get('retrieve_natura_raster', True):
 rule build_renewable_profiles:
     input:
         base_network="networks/base.nc",
-        corine="data/bundle/corine/g250_clc06_V18_5.tif",
+        luisa="data/landcover/LUISA_basemap_020321_50m.tif",
         natura="resources/natura.tiff",
         gebco=lambda w: ("data/bundle/GEBCO_2014_2D.nc"
                          if "max_depth" in config["renewable"][w.technology].keys()

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -96,13 +96,14 @@ renewable:
       turbine: Vestas_V112_3MW
     capacity_per_sqkm: 3 # ScholzPhd Tab 4.3.1: 10MW/km^2
     # correction_factor: 0.93
-    corine:
+    luisa:
       # Scholz, Y. (2012). Renewable energy based electricity supply at low costs:
       #  development of the REMix model and application for Europe. ( p.42 / p.28)
-      grid_codes: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
-                   24, 25, 26, 27, 28, 29, 31, 32]
+      grid_codes: [2110, 2120, 2130, 2210, 2220, 2230, 2310, 2410, 2420, 2430, 2440, 
+                   3110, 3120, 3130, 3210, 3220, 3230, 3240, 3310, 3320, 3330,]
       distance: 1000
-      distance_grid_codes: [1, 2, 3, 4, 5, 6]
+      distance_grid_codes: [1111, 1121, 1122, 1123, 1130, 1210,
+                            1221, 1222, 1230, 1241, 1242]
     natura: true
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
@@ -116,7 +117,7 @@ renewable:
     # proxy for wake losses
     # from 10.1016/j.energy.2018.08.153
     # until done more rigorously in #153
-    corine: [44, 255]
+    luisa: [0, 5230]
     natura: true
     max_depth: 50
     max_shore_distance: 30000
@@ -133,7 +134,7 @@ renewable:
     # proxy for wake losses
     # from 10.1016/j.energy.2018.08.153
     # until done more rigorously in #153
-    corine: [44, 255]
+    luisa: [0, 5230]
     natura: true
     max_depth: 50
     min_shore_distance: 30000
@@ -156,8 +157,9 @@ renewable:
     # This correction factor of 0.854337 may be in order if using reanalysis data.
     # for discussion refer to https://github.com/PyPSA/pypsa-eur/pull/304
     # correction_factor: 0.854337
-    corine: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
-             14, 15, 16, 17, 18, 19, 20, 26, 31, 32]
+    luisa: [1111, 1121, 1122, 1123, 1130, 1210, 1221, 1222, 1230, 1241, 1242,
+            1310, 1320, 1330, 1410, 1421, 1422, 2110, 2120, 2130, 2210, 2220, 2230,
+            2310, 2410, 2420, 3210, 3320, 3330]
     natura: true
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -72,13 +72,14 @@ renewable:
       turbine: Vestas_V112_3MW
     capacity_per_sqkm: 3 # ScholzPhd Tab 4.3.1: 10MW/km^2
     # correction_factor: 0.93
-    corine:
+    luisa:
       # Scholz, Y. (2012). Renewable energy based electricity supply at low costs:
       #  development of the REMix model and application for Europe. ( p.42 / p.28)
-      grid_codes: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
-                   24, 25, 26, 27, 28, 29, 31, 32]
+      grid_codes: [2110, 2120, 2130, 2210, 2220, 2230, 2310, 2410, 2420, 2430, 2440, 
+                   3110, 3120, 3130, 3210, 3220, 3230, 3240, 3310, 3320, 3330,]
       distance: 1000
-      distance_grid_codes: [1, 2, 3, 4, 5, 6]
+      distance_grid_codes: [1111, 1121, 1122, 1123, 1130, 1210,
+                            1221, 1222, 1230, 1241, 1242]
     natura: true
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
@@ -89,7 +90,7 @@ renewable:
       turbine: NREL_ReferenceTurbine_5MW_offshore
     capacity_per_sqkm: 3
     # correction_factor: 0.93
-    corine: [44, 255]
+    luisa: [0, 5230]
     natura: true
     max_shore_distance: 30000
     potential: simple # or conservative
@@ -102,7 +103,7 @@ renewable:
     # ScholzPhd Tab 4.3.1: 10MW/km^2
     capacity_per_sqkm: 3
     # correction_factor: 0.93
-    corine: [44, 255]
+    luisa: [0, 5230]
     natura: true
     min_shore_distance: 30000
     potential: simple # or conservative
@@ -123,8 +124,9 @@ renewable:
     # power." Applied Energy 135 (2014): 704-720.
     # This correction factor of 0.854337 may be in order if using reanalysis data.
     # correction_factor: 0.854337
-    corine: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
-             14, 15, 16, 17, 18, 19, 20, 26, 31, 32]
+    luisa: [1111, 1121, 1122, 1123, 1130, 1210, 1221, 1222, 1230, 1241, 1242,
+            1310, 1320, 1330, 1410, 1421, 1422, 2110, 2120, 2130, 2210, 2220, 2230,
+            2310, 2410, 2420, 3210, 3320, 3330]
     natura: true
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -26,7 +26,7 @@ Relevant settings
     renewable:
         {technology}:
             cutout:
-            corine:
+            luisa:
             grid_codes:
             distance:
             natura:
@@ -47,10 +47,7 @@ Relevant settings
 Inputs
 ------
 
-- ``data/bundle/corine/g250_clc06_V18_5.tif``: `CORINE Land Cover (CLC) <https://land.copernicus.eu/pan-european/corine-land-cover>`_ inventory on `44 classes <https://wiki.openstreetmap.org/wiki/Corine_Land_Cover#Tagging>`_ of land use (e.g. forests, arable land, industrial, urban areas).
-
-    .. image:: ../img/corine.png
-        :scale: 33 %
+- ``data/landcover/LUISA_basemap_020321_50m.tif``: TODO
 
 - ``data/bundle/GEBCO_2014_2D.nc``: A `bathymetric <https://en.wikipedia.org/wiki/Bathymetry>`_ data set with a global terrain model for ocean and land at 15 arc-second intervals by the `General Bathymetric Chart of the Oceans (GEBCO) <https://www.gebco.net/data_and_products/gridded_bathymetry_data/>`_.
 
@@ -134,8 +131,7 @@ taking account of a combination of the available land at each grid cell and the
 capacity factor there.
 
 First the script computes how much of the technology can be installed at each
-cutout grid cell and each node using the `GLAES
-<https://github.com/FZJ-IEK3-VSA/glaes>`_ library. This uses the CORINE land use data,
+cutout grid cell and each node using the atlite library. This uses the LUISA land use data,
 Natura2000 nature reserves and GEBCO bathymetry data.
 
 .. image:: ../img/eligibility.png
@@ -210,8 +206,8 @@ if __name__ == '__main__':
     capacity_per_sqkm = config['capacity_per_sqkm']
     p_nom_max_meth = config.get('potential', 'conservative')
 
-    if isinstance(config.get("corine", {}), list):
-        config['corine'] = {'grid_codes': config['corine']}
+    if isinstance(config.get("luisa", {}), list):
+        config['luisa'] = {'grid_codes': config['luisa']}
 
     if correction_factor != 1.:
         logger.info(f'correction_factor is set as {correction_factor}')
@@ -226,14 +222,14 @@ if __name__ == '__main__':
     if config['natura']:
         excluder.add_raster(snakemake.input.natura, nodata=0, allow_no_overlap=True)
 
-    corine = config.get("corine", {})
-    if "grid_codes" in corine:
-        codes = corine["grid_codes"]
-        excluder.add_raster(snakemake.input.corine, codes=codes, invert=True, crs=3035)
-    if corine.get("distance", 0.) > 0.:
-        codes = corine["distance_grid_codes"]
-        buffer = corine["distance"]
-        excluder.add_raster(snakemake.input.corine, codes=codes, buffer=buffer, crs=3035)
+    luisa = config.get("luisa", {})
+    if "grid_codes" in luisa:
+        codes = luisa["grid_codes"]
+        excluder.add_raster(snakemake.input.luisa, codes=codes, invert=True, crs=3035, nodata=0)
+    if luisa.get("distance", 0.) > 0.:
+        codes = luisa["distance_grid_codes"]
+        buffer = luisa["distance"]
+        excluder.add_raster(snakemake.input.luisa, codes=codes, buffer=buffer, crs=3035, nodata=0)
 
     if "max_depth" in config:
         # lambda not supported for atlite + multiprocessing

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -71,13 +71,14 @@ renewable:
       turbine: Vestas_V112_3MW
     capacity_per_sqkm: 3 # ScholzPhd Tab 4.3.1: 10MW/km^2
     # correction_factor: 0.93
-    corine:
+    luisa:
       # Scholz, Y. (2012). Renewable energy based electricity supply at low costs:
       #  development of the REMix model and application for Europe. ( p.42 / p.28)
-      grid_codes: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
-                   24, 25, 26, 27, 28, 29, 31, 32]
+      grid_codes: [2110, 2120, 2130, 2210, 2220, 2230, 2310, 2410, 2420, 2430, 2440, 
+                   3110, 3120, 3130, 3210, 3220, 3230, 3240, 3310, 3320, 3330,]
       distance: 1000
-      distance_grid_codes: [1, 2, 3, 4, 5, 6]
+      distance_grid_codes: [1111, 1121, 1122, 1123, 1130, 1210,
+                            1221, 1222, 1230, 1241, 1242]
     natura: true
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
@@ -88,7 +89,7 @@ renewable:
       turbine: NREL_ReferenceTurbine_5MW_offshore
     capacity_per_sqkm: 3
     # correction_factor: 0.93
-    corine: [44, 255]
+    luisa: [0, 5230]
     natura: true
     max_shore_distance: 30000
     potential: simple # or conservative
@@ -101,7 +102,7 @@ renewable:
     # ScholzPhd Tab 4.3.1: 10MW/km^2
     capacity_per_sqkm: 3
     # correction_factor: 0.93
-    corine: [44, 255]
+    luisa: [0, 5230]
     natura: true
     min_shore_distance: 30000
     potential: simple # or conservative
@@ -121,8 +122,9 @@ renewable:
     # sector: The economic potential of photovoltaics and concentrating solar
     # power." Applied Energy 135 (2014): 704-720.
     correction_factor: 0.854337
-    corine: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
-             14, 15, 16, 17, 18, 19, 20, 26, 31, 32]
+    luisa: [1111, 1121, 1122, 1123, 1130, 1210, 1221, 1222, 1230, 1241, 1242,
+            1310, 1320, 1330, 1410, 1421, 1422, 2110, 2120, 2130, 2210, 2220, 2230,
+            2310, 2410, 2420, 3210, 3320, 3330]
     natura: true
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2


### PR DESCRIPTION
Closes #297

## Changes proposed in this Pull Request

Replace CORINE with LUISA dataset as outlined in #297.

- [x] adapt documentation for switch from CORINE to LUISA
- [x] check for performance degression (LUISA has more fields and 50m resolution compared to 100m resolution)
- [x] investigate how to leverage higher resolution
- [x] compare to Agora Flächenrechner https://www.agora-energiewende.de/service/pv-und-windflaechenrechner/

For codes in relation to CORINE land cover, see Annex 1:

https://publications.jrc.ec.europa.eu/repository/bitstream/JRC124621/technical_report_luisa_basemap_2018_v7_final.pdf

## Comparison for Belgium

Solar CORINE:

![solar-corine](https://user-images.githubusercontent.com/29101152/159996929-bf174163-f6f7-4a98-af94-b6e3eeef6fe7.png)

Solar LUISA:

![solar-luisa](https://user-images.githubusercontent.com/29101152/159996941-c61f5080-aff4-45eb-8727-aa1d746bb1fa.png)

Onshore Wind CORINE:

![onwind-corine](https://user-images.githubusercontent.com/29101152/159996951-7c1d3cad-2e01-4cc1-adbf-600aba7c9036.png)

Onshore Wind LUISA:

![onwind-luisa](https://user-images.githubusercontent.com/29101152/159996962-472c9a25-337d-42ec-a808-1bc9260e412a.png)

Offshore Wind CORINE:

![offshore-corine](https://user-images.githubusercontent.com/29101152/159996974-6d63b6b4-b413-4455-b8cf-431623663a31.png)

Offshore Wind LUISA:

![offshore-luisa](https://user-images.githubusercontent.com/29101152/159996978-9e4c7312-8121-4289-9e09-b2ccbdd0bc5b.png)

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
