### PR TITLE
build_bus_regions: move voronoi partition from `vresutils` to script

### DIFF
--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -71,8 +71,6 @@ def voronoi_partition_pts(points, outline):
     ----------
     points : Nx2 - ndarray[dtype=float]
     outline : Polygon
-    no_multipolygons : bool (default: False)
-        If true, replace each MultiPolygon by its largest component
     Returns
     -------
     polygons : N - ndarray[dtype=Polygon|MultiPolygon]

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -117,9 +117,7 @@ def voronoi_partition_pts(points, outline, no_multipolygons=False):
             return poly
         polygons = [demultipolygon(poly) for poly in polygons]
 
-    polygons_arr = np.empty((len(polygons),), 'object')
-    polygons_arr[:] = polygons
-    return polygons_arr
+    return np.array(polygons, dtype=object)
 
 
 if __name__ == "__main__":

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -107,15 +107,6 @@ def voronoi_partition_pts(points, outline, no_multipolygons=False):
 
             polygons.append(poly)
 
-    if no_multipolygons:
-        def demultipolygon(poly):
-            try:
-                # for a MultiPolygon pick the part with the largest area
-                poly = max(poly.geoms, key=lambda pg: pg.area)
-            except:
-                pass
-            return poly
-        polygons = [demultipolygon(poly) for poly in polygons]
 
     return np.array(polygons, dtype=object)
 

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -62,7 +62,7 @@ def save_to_geojson(s, fn):
     s.to_file(fn, driver='GeoJSON', schema=schema)
 
 
-def voronoi_partition_pts(points, outline, no_multipolygons=False):
+def voronoi_partition_pts(points, outline):
     """
     Compute the polygons of a voronoi partition of `points` within the
     polygon `outline`. Taken from


### PR DESCRIPTION
Up for discussion: This would be a step towards eliminating all `vresutils` dependencies.