### PR TITLE
Fix CI due to fiona

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -37,6 +37,7 @@ dependencies:
   - pyomo
   - matplotlib
   - proj
+  - fiona <= 1.18.20  # Till issue https://github.com/Toblerity/Fiona/issues/1085 is not solved
 
   # Keep in conda environment when calling ipython
   - ipython


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
With PyPSA-Africa, we noticed that the CI was breaking and the fix was to limit the fiona package to the previous version.
This fix may be in handy.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
