### PR TITLE
update TYNDP links which are already built

### DIFF
--- a/data/links_tyndp.csv
+++ b/data/links_tyndp.csv
@@ -2,14 +2,13 @@ Name,Converterstation 1,Converterstation 2,Length (given) (km),Length (distance*
 Biscay Gulf,Gatica (ES),Cubnezais (FR),370,,2200,in permitting,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/16,-2.867,43.367,-0.408943,45.074191
 Italy-France,Piossasco (IT),Grand Ile (FR),190,,1000,under construction,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/21,7.468,44.9898,6.045,45.472
 IFA2,Tourbe (FR),Chilling (GB),,247.2,1000,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/25,-0.172042,49.083593,-1.277269,50.839338
-Italy-Montenegro Phase 1,Villanova (IT),Latsva (MT),445,,600,built,Link.14539,https://tyndp.entsoe.eu/tyndp2018/projects/projects/28,14.125,42.3947222222222,18.7947222222222,42.3175
-Italy-Montenegro Phase 2,Villanova (IT),Latsva (MT),445,,600,under construction,Link.14539,https://tyndp.entsoe.eu/tyndp2018/projects/projects/28,14.125,42.3947222222222,18.7947222222222,42.3175
-NordLink,Tonstad (NO),Wilster (DE),514,,1400,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/37,6.716948,58.662631,9.373979,53.922479
-COBRA cable,Endrup (DK),Eemshaven (NL),325,,700,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/71,8.718392,55.523115,6.835494,53.438589
+Italy-Montenegro,Villanova (IT),Latsva (MT),445,,1200,built,Link.14802,https://tyndp.entsoe.eu/tyndp2018/projects/projects/28,14.125,42.3947222222222,18.7947222222222,42.3175
+NordLink,Tonstad (NO),Wilster (DE),514,,1400,built,Link.14848,https://tyndp.entsoe.eu/tyndp2018/projects/projects/37,6.716948,58.662631,9.373979,53.922479
+COBRA cable,Endrup (DK),Eemshaven (NL),325,,700,built,Link.14803,https://tyndp.entsoe.eu/tyndp2018/projects/projects/71,8.718392,55.523115,6.835494,53.438589
 Thames Estuary Cluster (NEMO-Link),Richborough (GB),Gezelle (BE),140,,1000,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/74,1.324854,51.295891,3.23043,51.24902
-Anglo-Scottish-1,Hunterston (UK),Deeside (UK),422,,2400,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/77,-4.898329,55.723331,-3.032972,53.199735
-ALEGrO,Lixhe (BE),Oberzier (DE),100,,1000,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/92,5.67933,50.7567965,6.474704,50.867532
-North Sea Link,Kvilldal (NO),Blythe (GB),720,,1400,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/110,6.637527,59.515096,-1.510277,55.126957
+Anglo-Scottish-1,Hunterston (UK),Deeside (UK),422,,2400,built,Link.8009,https://tyndp.entsoe.eu/tyndp2018/projects/projects/77,-4.898329,55.723331,-3.032972,53.199735
+ALEGrO,Lixhe (BE),Oberzier (DE),100,,1000,built,Link.14801,https://tyndp.entsoe.eu/tyndp2018/projects/projects/92,5.67933,50.7567965,6.474704,50.867532
+North Sea Link,Kvilldal (NO),Blythe (GB),720,,1400,built,Link.14804,https://tyndp.entsoe.eu/tyndp2018/projects/projects/110,6.637527,59.515096,-1.510277,55.126957
 HVDC SuedOstLink,Wolmirstedt (DE),Isar (DE),,557,2000,in permitting,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/130,11.629014,52.252137,12.091596,48.080837
 HVDC Line A-North,Emden East (DE),Osterath (DE),,284,2000,in permitting,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/132,7.206009,53.359403,6.619451,51.272935
 France-Alderney-Britain,Exeter (UK),Menuel (FR),220,,1400,in permitting,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/153,-3.533899,50.718412,-1.469216,49.509594
@@ -24,4 +23,4 @@ HVDC Ultranet,Osterath (DE),Philippsburg (DE),,314,600,in permitting,,https://ty
 Gridlink,Kingsnorth (UK),Warande (FR),160,,1400,in permitting,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/285,0.596111111111111,51.41972,2.376776,51.034368
 NeuConnect,Grain (UK),Fedderwarden (DE),680,,1400,in permitting,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/309,0.716666666666667,51.44,8.046524,53.562763
 NordBalt,Klaipeda (LT),Nybro (SE),450,,700,built,,https://en.wikipedia.org/wiki/NordBalt,21.256667,55.681667,15.854167,56.767778
-Estlink 1,Harku (EE),Espoo (FI),105,,350,built,,https://en.wikipedia.org/wiki/Estlink,24.560278,59.384722,24.551667,60.203889
+Estlink 1,Harku (EE),Espoo (FI),105,,350,built,Link.14807,https://en.wikipedia.org/wiki/Estlink,24.560278,59.384722,24.551667,60.203889

--- a/data/links_tyndp.csv
+++ b/data/links_tyndp.csv
@@ -1,14 +1,15 @@
 Name,Converterstation 1,Converterstation 2,Length (given) (km),Length (distance*1.2) (km),Power (MW),status,replaces,Ref,x1,y1,x2,y2
 Biscay Gulf,Gatica (ES),Cubnezais (FR),370,,2200,in permitting,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/16,-2.867,43.367,-0.408943,45.074191
 Italy-France,Piossasco (IT),Grand Ile (FR),190,,1000,under construction,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/21,7.468,44.9898,6.045,45.472
-IFA2,Tourbe (FR),Chilling (GB),,247.2,1000,under construction,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/25,-0.172042,49.083593,-1.277269,50.839338
-Italy-Montenegro,Villanova (IT),Latsva (MT),445,,1200,under construction,Link.14539,https://tyndp.entsoe.eu/tyndp2018/projects/projects/28,14.125,42.3947222222222,18.7947222222222,42.3175
-NordLink,Tonstad (NO),Wilster (DE),514,,1400,under construction,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/37,6.716948,58.662631,9.373979,53.922479
-COBRA cable,Endrup (DK),Eemshaven (NL),325,,700,under construction,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/71,8.718392,55.523115,6.835494,53.438589
-Thames Estuary Cluster (NEMO-Link),Richborough (GB),Gezelle (BE),140,,1000,under construction,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/74,1.324854,51.295891,3.23043,51.24902
-Anglo-Scottish -1,Hunterston (UK),Deeside (UK),422,,2400,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/77,-4.898329,55.723331,-3.032972,53.199735
+IFA2,Tourbe (FR),Chilling (GB),,247.2,1000,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/25,-0.172042,49.083593,-1.277269,50.839338
+Italy-Montenegro Phase 1,Villanova (IT),Latsva (MT),445,,600,built,Link.14539,https://tyndp.entsoe.eu/tyndp2018/projects/projects/28,14.125,42.3947222222222,18.7947222222222,42.3175
+Italy-Montenegro Phase 2,Villanova (IT),Latsva (MT),445,,600,under construction,Link.14539,https://tyndp.entsoe.eu/tyndp2018/projects/projects/28,14.125,42.3947222222222,18.7947222222222,42.3175
+NordLink,Tonstad (NO),Wilster (DE),514,,1400,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/37,6.716948,58.662631,9.373979,53.922479
+COBRA cable,Endrup (DK),Eemshaven (NL),325,,700,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/71,8.718392,55.523115,6.835494,53.438589
+Thames Estuary Cluster (NEMO-Link),Richborough (GB),Gezelle (BE),140,,1000,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/74,1.324854,51.295891,3.23043,51.24902
+Anglo-Scottish-1,Hunterston (UK),Deeside (UK),422,,2400,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/77,-4.898329,55.723331,-3.032972,53.199735
 ALEGrO,Lixhe (BE),Oberzier (DE),100,,1000,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/92,5.67933,50.7567965,6.474704,50.867532
-North Sea Link,Kvilldal (NO),Blythe (GB),720,,1400,under construction,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/110,6.637527,59.515096,-1.510277,55.126957
+North Sea Link,Kvilldal (NO),Blythe (GB),720,,1400,built,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/110,6.637527,59.515096,-1.510277,55.126957
 HVDC SuedOstLink,Wolmirstedt (DE),Isar (DE),,557,2000,in permitting,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/130,11.629014,52.252137,12.091596,48.080837
 HVDC Line A-North,Emden East (DE),Osterath (DE),,284,2000,in permitting,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/132,7.206009,53.359403,6.619451,51.272935
 France-Alderney-Britain,Exeter (UK),Menuel (FR),220,,1400,in permitting,,https://tyndp.entsoe.eu/tyndp2018/projects/projects/153,-3.533899,50.718412,-1.469216,49.509594

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -236,7 +236,7 @@ def _add_links_from_tyndp(buses, links, links_tyndp, europe_shape):
         carrier='DC',
         p_nom=links_tyndp["Power (MW)"],
         length=links_tyndp["Length (given) (km)"].fillna(links_tyndp["Length (distance*1.2) (km)"]),
-        under_construction=True,
+        under_construction=~(links_tyndp.status == 'built'),
         underground=False,
         geometry=(links_tyndp[["x1", "y1", "x2", "y2"]]
                   .apply(lambda s: str(LineString([[s.x1, s.y1], [s.x2, s.y2]])), axis=1)),

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -196,14 +196,15 @@ def _add_links_from_tyndp(buses, links, links_tyndp, europe_shape):
             return buses, links
 
     has_replaces_b = links_tyndp.replaces.notnull()
-    oids = dict(Bus=_get_oid(buses), Link=_get_oid(links))
+    logger.info("TYNDP links replacing links in dataset (overwriting): " + ", ".join(links_tyndp.loc[has_replaces_b, "Name"]))
+    ids = dict(Bus=buses.index, Link=links.index)
     keep_b = dict(Bus=pd.Series(True, index=buses.index),
                   Link=pd.Series(True, index=links.index))
     for reps in links_tyndp.loc[has_replaces_b, 'replaces']:
         for comps in reps.split(':'):
-            oids_to_remove = comps.split('.')
-            c = oids_to_remove.pop(0)
-            keep_b[c] &= ~oids[c].isin(oids_to_remove)
+            ids_to_remove = comps.split('.')
+            c = ids_to_remove.pop(0)
+            keep_b[c] &= ~ids[c].isin(ids_to_remove)
     buses = buses.loc[keep_b['Bus']]
     links = links.loc[keep_b['Link']]
 
@@ -211,7 +212,7 @@ def _add_links_from_tyndp(buses, links, links_tyndp, europe_shape):
     # Corresponds approximately to 20km tolerances
 
     if links_tyndp["j"].notnull().any():
-        logger.info("TYNDP links already in the dataset (skipping): " + ", ".join(links_tyndp.loc[links_tyndp["j"].notnull(), "Name"]))
+        logger.info("Additional TYNDP links already in the dataset (skipping): " + ", ".join(links_tyndp.loc[links_tyndp["j"].notnull(), "Name"]))
         links_tyndp = links_tyndp.loc[links_tyndp["j"].isnull()]
         if links_tyndp.empty: return buses, links
 


### PR DESCRIPTION
- [x] Update `data/links_tyndp.csv` with data on which links are already in operation.
- [x] Problem: If link is already in dataset, capacity data from TYNDP is ignored. Fix this by finding the right `replaces` to add to `data/links_tyndp.csv`!

```
INFO:__main__:TYNDP links already in the dataset (skipping): Italy-Montenegro Phase 1, Italy-Montenegro Phase 2, NordLink, COBRA cable, Anglo-Scottish-1, ALEGrO, North Sea Link, ElecLink, Estlink 1
```