### PR TITLE
Add country-specific EAF restriction for NPPs.

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -64,7 +64,30 @@ electricity:
   powerplants_filter: (DateOut >= 2021 or DateOut != DateOut)
   # use pandas query strings here, e.g. Country in ['Germany']
   custom_powerplants: false 
-  conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
+  conventional_carriers:
+    technologies: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
+    # Limit energy availability from these sources -> p_max_pu
+    # syntax:
+    # <technology name>: <fixed value> or <country>: <value>
+    energy_availability_factors:
+      # From IAEA
+      # https://pris.iaea.org/PRIS/WorldStatistics/ThreeYrsEnergyAvailabilityFactor.aspx (2022-04-08)
+      nuclear:
+        BE: 0.65
+        BG: 0.89
+        CZ: 0.82
+        FI: 0.92
+        FR: 0.70
+        DE: 0.88
+        HU: 0.90
+        NL: 0.86
+        RO: 0.92
+        SK: 0.89
+        SI: 0.94
+        ES: 0.89
+        SE: 0.82
+        CH: 0.86
+        GB: 0.67
   renewable_capacities_from_OPSD: [] # onwind, offwind, solar
 
   estimate_renewable_capacities:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -25,7 +25,10 @@ Energy Security Release (April 2022)
 * Add operational reserve margin constraint analogous to `GenX implementation <https://genxproject.github.io/GenX/dev/core/#Reserves>`_.
   Can be activated with config setting ``electricity: operational_reserve:``.
 
-* Add function to add global constraint on use of gas in :mod:`prepare_network`. This can be activated with `electricity: gaslimit:` given in MWh. 
+* Add function to add global constraint on use of gas in :mod:`prepare_network`. This can be activated with `electricity: gaslimit:` given in MWh.
+
+* Add configuration option to implement Energy Availability Factors (EAFs) for conventional generation technologies.
+* Implement country-specific EAFs for nuclear power plants based on IAEA 2018-2020 reported country averages.
 
 * The powerplants that have been shut down before 2021 are filtered out. 
 


### PR DESCRIPTION
Based on historic figures from IAEA.

## Checklist

- [yep. once. It seemed to work] I tested my contribution locally and it seems to work fine.
- [nope ] Code and workflow changes are sufficiently documented.
- [none] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [nope, only in the default config] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [naaah] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [do I need to? I guess so....] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
