### PR TITLE
Update version of powerplantmatching

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -24,7 +24,7 @@ dependencies:
   - yaml
   - pytables
   - lxml
-  - powerplantmatching>=0.4.8
+  - powerplantmatching==0.5.3
   - numpy
   - pandas
   - geopandas

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -24,7 +24,7 @@ dependencies:
   - yaml
   - pytables
   - lxml
-  - powerplantmatching==0.5.3
+  - powerplantmatching>=0.5.3
   - numpy
   - pandas
   - geopandas


### PR DESCRIPTION
Hi,

I recently became aware that I was using an older version (0.4.8) of the powerplantmatching. I tested my setup with the newer version (0.5.3), and it runs without any issues.

The following is a comment/question on the powerplantmatching dataset, which might be relevant to mention (mentioned here as well: https://github.com/FRESNA/powerplantmatching/issues/72#issue-1250822542):

With regard to pumped-hydro storage (PHS), the newest version of powerplantmatching shows an existing energy storage capacity of 4.3 TWh (Europe-aggregate, assuming 6-hours duration for plants that do not have duration specified). In the earlier version 0.4.8, this number was a bit higher (10 TWh). As comparison, Geth et al. (2015) showed a PHS energy capacity of 1.3 TWh (including Norway and Switzerland) using 2012-numbers. PHS power capacity has increased from roughly 50 to 55 GW from 2014 to 2020 (iha, 2015, 2021), so energy storage capacity most likely is increased as well. But is it fair to say that energy storage capacity has been almost quadrupled since 2012 (from 1.3 TWh to 4.3 TWh)? Or how can we interpret this discrepancy? 

Sources:
Geth et al., 2015, https://doi.org/10.1016/j.rser.2015.07.145 
iha, 2015, https://www.aler-renovaveis.org/contents/lerpublication/iha_2015_sept_hydropower-status-report.pdf
iha, 2021, https://assets-global.website-files.com/5f749e4b9399c80b5e421384/60c37321987070812596e26a_IHA20212405-status-report-02_LR.pdf

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
