### PR TITLE
Bug fix crs 4236 to 4326

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -70,6 +70,8 @@ Upcoming Release
 
 * Use updated SARAH-2 and ERA5 cutouts with slightly wider scope to east and additional variables.
 
+* Fix crs bug. Change crs 4236 to 4326.
+
 
 PyPSA-Eur 0.4.0 (22th September 2021)
 =====================================

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -240,7 +240,7 @@ if __name__ == '__main__':
         # use named function np.greater with partially frozen argument instead
         # and exclude areas where: -max_depth > grid cell depth
         func = functools.partial(np.greater,-config['max_depth'])
-        excluder.add_raster(snakemake.input.gebco, codes=func, crs=4236, nodata=-1000)
+        excluder.add_raster(snakemake.input.gebco, codes=func, crs=4326, nodata=-1000)
 
     if 'min_shore_distance' in config:
         buffer = config['min_shore_distance']


### PR DESCRIPTION
## Changes proposed in this Pull Request
- EPSG: 4326 is the standard crs system used around the world: https://epsg.io/4326 Scope: Horizontal component of 3D system. Used by the GPS satellite navigation system and for NATO military geodetic surveying. 
- EPSG: 4236 is the crs system for Taiwan, Republic of China [EPSG:4236 - Hu Tzu Shan 1950](https://epsg.io/4236)
## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
