### PR TITLE
restrict rasterio version

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -72,6 +72,8 @@ Upcoming Release
 
 * Fix crs bug. Change crs 4236 to 4326.
 
+* Update rasterio version to correctly calculate exclusion raster
+
 
 PyPSA-Eur 0.4.0 (22th September 2021)
 =====================================

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -37,7 +37,7 @@ dependencies:
   - pyomo
   - matplotlib
   - proj
-  - fiona <= 1.18.20  # Till issue https://github.com/Toblerity/Fiona/issues/1085 is not solved
+  - fiona<=1.18.20  # Till issue https://github.com/Toblerity/Fiona/issues/1085 is not solved
 
   # Keep in conda environment when calling ipython
   - ipython
@@ -45,7 +45,7 @@ dependencies:
   # GIS dependencies:
   - cartopy
   - descartes
-  - rasterio
+  - rasterio<=1.2.8  # 1.2.10 creates error https://github.com/PyPSA/atlite/issues/238
 
   # PyPSA-Eur-Sec Dependencies
   - geopy

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -45,7 +45,7 @@ dependencies:
   # GIS dependencies:
   - cartopy
   - descartes
-  - rasterio<=1.2.8  # 1.2.10 creates error https://github.com/PyPSA/atlite/issues/238
+  - rasterio<=1.2.9  # 1.2.10 creates error https://github.com/PyPSA/atlite/issues/238
 
   # PyPSA-Eur-Sec Dependencies
   - geopy


### PR DESCRIPTION
There is an issue in Atlite related to the rasterio version. The rasterio version 2.1.10 is causing troubles in the exclusion raster downsampling part: https://github.com/PyPSA/atlite/issues/238 . We solved this in Atlite already but need to wait for a new Atlite release. Until then the exclusion raster error can occur in PyPSA-Eur.

## Changes proposed in this Pull Request
Until we update the Atlite version we should change the environment and constrain the rasterio version

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
