### PR TITLE
build_renewable_profiles: set show progress default to False

### DIFF
--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -203,7 +203,7 @@ if __name__ == '__main__':
     pgb.streams.wrap_stderr()
 
     nprocesses = int(snakemake.threads)
-    noprogress = not snakemake.config['atlite'].get('show_progress', True)
+    noprogress = not snakemake.config['atlite'].get('show_progress', False)
     config = snakemake.config['renewable'][snakemake.wildcards.technology]
     resource = config['resource'] # pv panel config / wind turbine config
     correction_factor = config.get('correction_factor', 1.)


### PR DESCRIPTION
Together with new `atlite` version fastens the landuse calculation by a factor of 4-5. So for whole of Europe, this takes around ~1 min with 6 cores.
Downside: One does not see the progressbar anymore, but I think it is a worthy trade-off.