### PR TITLE
clustering strategies moved to configurables

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -22,6 +22,10 @@ countries: ['AL', 'AT', 'BA', 'BE', 'BG', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'F
 clustering:
   simplify:
     to_substations: false # network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)
+  aggregation_strategies:
+    generators:
+      p_nom_max: "sum" # use "min" for more conservative assumptions
+      p_nom_min: "sum"
 
 snapshots:
   start: "2013-01-01"

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -22,6 +22,10 @@ countries: ['BE']
 clustering:
   simplify:
     to_substations: false # network is simplified to nodes with positive or negative power injection (i.e. substations or offwind connections)
+  aggregation_strategies:
+    generators:
+      p_nom_max: "sum" # use "min" for more conservative assumptions
+      p_nom_min: "sum"
 
 snapshots:
   start: "2013-03-01"


### PR DESCRIPTION
Closes # (if applicable).
#375 

## Changes proposed in this Pull Request
all clustering strategies appearing in `cluster_network` or `simplify_network` now moved to configurables.
very recent changes from #379 missing again, but need to be placed in the config now, instead of in any of the scripts. (also, #379 forgot to make the adaptations in `simplify_network`)

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
