### PR TITLE
helpers: check snakemake version for bug fix

### DIFF
--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -241,7 +241,7 @@ def mock_snakemake(rulename, **wildcards):
         if os.path.exists(p):
             snakefile = p
             break
-    kwargs=dict(rerun_triggers=[]) if parse(sm.__version__) > Version("7.7.0") else {}
+    kwargs = dict(rerun_triggers=[]) if parse(sm.__version__) > Version("7.7.0") else {}
     workflow = sm.Workflow(snakefile, overwrite_configfiles=[], **kwargs)
     workflow.include(snakefile)
     workflow.global_resources = {}

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -231,6 +231,7 @@ def mock_snakemake(rulename, **wildcards):
     import os
     from pypsa.descriptors import Dict
     from snakemake.script import Snakemake
+    from packaging.version import Version, parse
 
     script_dir = Path(__file__).parent.resolve()
     assert Path.cwd().resolve() == script_dir, \
@@ -240,7 +241,8 @@ def mock_snakemake(rulename, **wildcards):
         if os.path.exists(p):
             snakefile = p
             break
-    workflow = sm.Workflow(snakefile, overwrite_configfiles=[], rerun_triggers=[])
+    kwargs=dict(rerun_triggers=[]) if parse(sm.__version__) > Version("7.7.0") else {}
+    workflow = sm.Workflow(snakefile, overwrite_configfiles=[], **kwargs)
     workflow.include(snakefile)
     workflow.global_resources = {}
     rule = workflow.get_rule(rulename)


### PR DESCRIPTION
## Changes proposed in this Pull Request
By introducing the bug fix from #378, older snakemake versions (v7.7.0 and older) throw an error. This PR uses keyword arguments dependent on the snakemake version.

