### PR TITLE
Enable parallel computing with new dask version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ gurobi.log
 /data
 /data/links_p_nom.csv
 /cutouts
+/dask-worker-space
 
 doc/_build
 


### PR DESCRIPTION
Apparently, in the new dask version the argument `num_workers` is ignored and falls back to 1. This extremely slows down the whole workflow. For the moment I cannot come up with something better than this. Upside: Every thing is parallel and fast again, downside: One does not see the progressbar anymore (I cannot say why...) 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
