### PR TITLE
Changed doc info in retrieve_databundle.py

### DIFF
--- a/scripts/retrieve_databundle.py
+++ b/scripts/retrieve_databundle.py
@@ -28,7 +28,7 @@ The :ref:`tutorial` uses a smaller `data bundle <https://zenodo.org/record/35179
 
 **Outputs**
 
-- ``cutouts/bundle``: input data collected from various sources
+- ``data/bundle``: input data collected from various sources
 
 """
 


### PR DESCRIPTION
Simply changed the text regarding the output directory. It said 'cutouts/bundle' but I think it should be 'data/bundle'. It only affects the documentation.

Closes # (if applicable).

## Changes proposed in this Pull Request
Corrected what I think was an error in the documentation. Output directory should be data/bundle (not cutouts/bundle). The documentation reads this text from this script, but note that I'm not changing any code line, thus, I'm not filling the checklist below.

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
