### PR TITLE
make resolution of exclusion calculation a configurable option

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -120,6 +120,7 @@ renewable:
       distance: 1000
       distance_grid_codes: [1, 2, 3, 4, 5, 6]
     natura: true
+    excluder_resolution: 100
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   offwind-ac:
@@ -136,6 +137,7 @@ renewable:
     natura: true
     max_depth: 50
     max_shore_distance: 30000
+    excluder_resolution: 200
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   offwind-dc:
@@ -153,6 +155,7 @@ renewable:
     natura: true
     max_depth: 50
     min_shore_distance: 30000
+    excluder_resolution: 200
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   solar:
@@ -175,6 +178,7 @@ renewable:
     corine: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
              14, 15, 16, 17, 18, 19, 20, 26, 31, 32]
     natura: true
+    excluder_resolution: 100
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   hydro:

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -76,6 +76,7 @@ renewable:
       distance: 1000
       distance_grid_codes: [1, 2, 3, 4, 5, 6]
     natura: true
+    excluder_resolution: 200
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   offwind-ac:
@@ -88,6 +89,7 @@ renewable:
     corine: [44, 255]
     natura: true
     max_shore_distance: 30000
+    excluder_resolution: 200
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   offwind-dc:
@@ -101,6 +103,7 @@ renewable:
     corine: [44, 255]
     natura: true
     min_shore_distance: 30000
+    excluder_resolution: 200
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   solar:
@@ -122,6 +125,7 @@ renewable:
     corine: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
              14, 15, 16, 17, 18, 19, 20, 26, 31, 32]
     natura: true
+    excluder_resolution: 200
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
 

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -228,7 +228,8 @@ if __name__ == '__main__':
     regions = regions.set_index('name').rename_axis('bus')
     buses = regions.index
 
-    excluder = atlite.ExclusionContainer(crs=3035, res=100)
+    res = config.get("excluder_resolution", 100)
+    excluder = atlite.ExclusionContainer(crs=3035, res=res)
 
     if config['natura']:
         excluder.add_raster(snakemake.input.natura, nodata=0, allow_no_overlap=True)

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -75,6 +75,7 @@ renewable:
       distance: 1000
       distance_grid_codes: [1, 2, 3, 4, 5, 6]
     natura: true
+    excluder_resolution: 200
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   offwind-ac:
@@ -87,6 +88,7 @@ renewable:
     corine: [44, 255]
     natura: true
     max_shore_distance: 30000
+    excluder_resolution: 200
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   offwind-dc:
@@ -100,6 +102,7 @@ renewable:
     corine: [44, 255]
     natura: true
     min_shore_distance: 30000
+    excluder_resolution: 200
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
   solar:
@@ -120,6 +123,7 @@ renewable:
     corine: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
              14, 15, 16, 17, 18, 19, 20, 26, 31, 32]
     natura: true
+    excluder_resolution: 200
     potential: simple # or conservative
     clip_p_max_pu: 1.e-2
 


### PR DESCRIPTION
This will speed up build_renewable_profiles, esp in Github CI.

Could argue that for offshore wind 100m resolution is not necessary.