### PR TITLE
Use `geomap=True` for plotting existing lines

### DIFF
--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -123,7 +123,7 @@ def plot_map(n, opts, ax=None, attribute='p_nom'):
            link_colors=link_colors_with_alpha,
            bus_sizes=0,
            boundaries=map_boundaries,
-           color_geomap=True, geomap=False,
+           color_geomap=True, geomap=True,
            ax=ax)
     ax.set_aspect('equal')
     ax.axis('off')


### PR DESCRIPTION
Since https://github.com/PyPSA/PyPSA/commit/e754928e#diff-1ffb543f39b9a9c1d00adfc3fb2c1a89c905c56e00b9ede9178787a8148dc0eeR210 PyPSA raises an exception for plots that have geo axes but use `geomap=False`.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
