### PR TITLE
Config: enable res installations per default

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -69,7 +69,7 @@ electricity:
   renewable_carriers: [solar, onwind, offwind-ac, offwind-dc, hydro]
 
   estimate_renewable_capacities:
-    enable: false
+    enable: true
     # Add capacities from OPSD data
     from_opsd: true
     # Renewable capacities are based on existing capacities reported by IRENA

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,7 +12,7 @@ Upcoming Release
 
 * Individual commits are now tested against pre-commit hooks. This includes black style formatting, sorting of package imports, Snakefile formatting and others. Installation instructions can for the pre-commit can be found `here <https://pre-commit.com/>`_.
 * Pre-commit CI is now part of the repository's CI.
-
+* The heuristic distribution of today's renewable installations is now enable per default.
 
 PyPSA-Eur 0.6.0 (10th September 2022)
 =====================================


### PR DESCRIPTION
This is helpful for other projects (as BE) to enable short-term scenarios. 

## Checklist

- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
