### PR TITLE
add_electricity: calculate marginal costs from plant efficiency

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,7 +12,7 @@ Upcoming Release
 
 * Individual commits are now tested against pre-commit hooks. This includes black style formatting, sorting of package imports, Snakefile formatting and others. Installation instructions can for the pre-commit can be found `here <https://pre-commit.com/>`_.
 * Pre-commit CI is now part of the repository's CI.
-
+* Marginal costs of conventional generators are now taking the plant-specific efficiency into account.
 
 PyPSA-Eur 0.6.0 (10th September 2022)
 =====================================

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -369,6 +369,9 @@ def attach_conventional_generators(
         .rename(index=lambda s: "C" + str(s))
     )
     ppl["efficiency"] = ppl.efficiency.fillna(ppl.efficiency_r)
+    ppl["marginal_cost"] = (
+        ppl.carrier.map(costs.VOM) + ppl.carrier.map(costs.fuel) / ppl.efficiency
+    )
 
     logger.info(
         "Adding {} generators with capacities [GW] \n{}".format(


### PR DESCRIPTION
Use the plant based efficiency instead of the technology efficiency to calculate marginal costs

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
