### PR TITLE
Fix network directory path in make_summary

### DIFF
--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -556,9 +556,13 @@ if __name__ == "__main__":
             opts="Co2L-24H",
             country="all",
         )
-        network_dir = os.path.join("..", "results", "networks", snakemake.config["run"]["name"])
+        network_dir = os.path.join(
+            "..", "results", "networks", snakemake.config["run"]["name"]
+        )
     else:
-        network_dir = os.path.join("results", "networks", snakemake.config["run"]["name"])
+        network_dir = os.path.join(
+            "results", "networks", snakemake.config["run"]["name"]
+        )
     configure_logging(snakemake)
 
     config = snakemake.config

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -556,9 +556,9 @@ if __name__ == "__main__":
             opts="Co2L-24H",
             country="all",
         )
-        network_dir = os.path.join("..", "results", "networks")
+        network_dir = os.path.join("..", "results", "networks", snakemake.config["run"]["name"])
     else:
-        network_dir = os.path.join("results", "networks")
+        network_dir = os.path.join("results", "networks", snakemake.config["run"]["name"])
     configure_logging(snakemake)
 
     config = snakemake.config


### PR DESCRIPTION
This just fixes the network directory path in `make_summary.py` to comply with the recently introduced `name` property in the config file.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.

The rest of the checklist doesn't really apply as this is a minimal change.

- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
