### PR TITLE
build_natura_raster: fix out_shapes

### DIFF
--- a/scripts/build_natura_raster.py
+++ b/scripts/build_natura_raster.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
 
     # adjusted boundaries
     shapes = gpd.read_file(snakemake.input.natura).to_crs(3035)
-    raster = ~geometry_mask(shapes.geometry, out_shape[::-1], transform)
+    raster = ~geometry_mask(shapes.geometry, out_shape, transform)
     raster = raster.astype(rio.uint8)
 
     with rio.open(


### PR DESCRIPTION
Raised and fixed in https://github.com/pypsa-meets-earth/pypsa-earth/pull/454/files

This bug was harmless as the shape for our default cutout was quite quadratic. But this is important for other cutouts shapes.