### PR TITLE
fix tutorial config links

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -61,14 +61,16 @@ It is also possible to allow less or more carbon-dioxide emissions. Here, we lim
 
 .. literalinclude:: ../config.tutorial.yaml
    :language: yaml
-   :lines: 35,37
+   :start-at: electricity:
+   :end-before: exentable_carriers:
 
 PyPSA-Eur also includes a database of existing conventional powerplants.
 We can select which types of powerplants we like to be included:
 
 .. literalinclude:: ../config.tutorial.yaml
    :language: yaml
-   :lines: 35,51
+   :start-at: extendable_carriers:
+   :end-before: max_hours:
 
 To accurately model the temporal and spatial availability of renewables such as wind and solar energy, we rely on historical weather data.
 It is advisable to adapt the required range of coordinates to the selection of countries.
@@ -83,14 +85,21 @@ For example, we may want to use the ERA-5 dataset for solar and not the default 
 
 .. literalinclude:: ../config.tutorial.yaml
    :language: yaml
-   :lines: 63,106,107
+   :start-at: be-03-2013-era5:
+   :end-at: module:
+
+.. literalinclude:: ../config.tutorial.yaml
+   :language: yaml
+   :start-at: solar:
+   :end-at: cutout:
 
 Finally, it is possible to pick a solver. For instance, this tutorial uses the open-source solvers CBC and Ipopt and does not rely
 on the commercial solvers Gurobi or CPLEX (for which free academic licenses are available).
 
 .. literalinclude:: ../config.tutorial.yaml
    :language: yaml
-   :lines: 188,198,199
+   :start-at: solver:
+   :end-before: plotting:
 
 .. note::
 


### PR DESCRIPTION
Closes #436 

## Changes proposed in this Pull Request
Fix in the tutorial.rst the reference to the config.yaml.
I now avoid the line references and use only config objects e.g. `start-at: cutout:`
This should be more stable in long-term.

Here are the results:
![Screenshot from 2022-11-01 10-40-22](https://user-images.githubusercontent.com/61968949/199215775-5f9b63f7-6531-4b8d-81d9-5e7f8a86527d.png)

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes. --- Guess no release note required for this minor change
