### PR TITLE
solve_network: move extra_functionality to args

### DIFF
--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -392,7 +392,6 @@ def solve_network(n, config, opts="", **kwargs):
             n,
             solver_name=solver_name,
             solver_options=solver_options,
-            extra_functionality=extra_functionality,
             **kwargs
         )
     else:
@@ -403,7 +402,6 @@ def solve_network(n, config, opts="", **kwargs):
             track_iterations=track_iterations,
             min_iterations=min_iterations,
             max_iterations=max_iterations,
-            extra_functionality=extra_functionality,
             **kwargs
         )
     return n
@@ -432,6 +430,7 @@ if __name__ == "__main__":
             n,
             snakemake.config,
             opts,
+            extra_functionality=extra_functionality,
             solver_dir=tmpdir,
             solver_logfile=snakemake.log.solver,
         )

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -389,10 +389,7 @@ def solve_network(n, config, opts="", **kwargs):
 
     if skip_iterations:
         network_lopf(
-            n,
-            solver_name=solver_name,
-            solver_options=solver_options,
-            **kwargs
+            n, solver_name=solver_name, solver_options=solver_options, **kwargs
         )
     else:
         ilopf(


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
Currently if solve_network is used outside pypsa-eur (for example via import), no additional extra_functionality can be passed as kwarg. If it is removed from the function and only passed as kwarg instead, this problem is resolved.

associated error: `TypeError: pypsa.linopf.network_lopf() got multiple values for keyword argument 'extra_functionality'`

Thoughts?

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
