### PR TITLE
Fix load variable in reserve constraint

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,6 +12,8 @@ Upcoming Release
 
 * Carriers of generators can now be excluded from aggregation in clustering network and simplify network.
 
+* Bugfix in the reserve constraint will increase demand related reserve requirements
+
 PyPSA-Eur 0.6.1 (20th September 2022)
 =====================================
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -278,7 +278,7 @@ def add_operational_reserve_margin_constraint(n, config):
         ).sum(1)
 
     # Total demand at t
-    demand = n.loads_t.p.sum(1)
+    demand = n.loads_t.p_set.sum(1)
 
     # VRES potential of non extendable generators
     capacity_factor = n.generators_t.p_max_pu[vres_i.difference(ext_i)]


### PR DESCRIPTION
## Changes proposed in this Pull Request
There is a reserve constraint set which considers the total demand per snapshot.
The total demand per snapshot was assigned as: `demand = n.loads_t.p.sum(1)`
However, this will always result in `0`

My suggestions would be: `demand = n.loads_t.p_set.sum(1)`

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of the previous release notes.