### PR TITLE
Fix EQ constraint in case no hydro exist

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,6 +12,8 @@ Upcoming Release
 
 * Carriers of generators can now be excluded from aggregation in clustering network and simplify network.
 
+* Fix EQ constraint for the case no hydro inflow is available
+
 PyPSA-Eur 0.6.1 (20th September 2022)
 =====================================
 

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -395,8 +395,10 @@ def simplify_links(n, costs, config, output, aggregation_strategies=dict()):
 def remove_stubs(n, costs, config, output, aggregation_strategies=dict()):
     logger.info("Removing stubs")
 
-    across_borders = config["clustering"]["simplify_network"].get("remove_stubs_across_borders", True)
-    matching_attrs = [] if across_borders else ['country']
+    across_borders = config["clustering"]["simplify_network"].get(
+        "remove_stubs_across_borders", True
+    )
+    matching_attrs = [] if across_borders else ["country"]
     busmap = busmap_by_stubs(n, matching_attrs)
 
     connection_costs_to_bus = _compute_connection_costs_to_bus(n, busmap, costs, config)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -216,18 +216,21 @@ def add_EQ_constraints(n, o, scaling=1e-1):
         .T.groupby(ggrouper, axis=1)
         .apply(join_exprs)
     )
-    lhs_spill = (
-        linexpr(
-            (
-                -n.snapshot_weightings.stores * scaling,
-                get_var(n, "StorageUnit", "spill").T,
+    if not n.storage_units_t.inflow.empty:
+        lhs_spill = (
+            linexpr(
+                (
+                    -n.snapshot_weightings.stores * scaling,
+                    get_var(n, "StorageUnit", "spill").T,
+                )
             )
+            .T.groupby(sgrouper, axis=1)
+            .apply(join_exprs)
         )
-        .T.groupby(sgrouper, axis=1)
-        .apply(join_exprs)
-    )
-    lhs_spill = lhs_spill.reindex(lhs_gen.index).fillna("")
-    lhs = lhs_gen + lhs_spill
+        lhs_spill = lhs_spill.reindex(lhs_gen.index).fillna("")
+        lhs = lhs_gen + lhs_spill
+    else:
+        lhs = lhs_gen
     define_constraints(n, lhs, ">=", rhs, "equity", "min")
 
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
The PyPSA-Eur tutorial will fail if someone tests the EQ constraint.
The bug appears because no spillage variable exists if there is no inflow.
Since the tutorial for 'BE' has no 'hydro' but 'DE' has 'hydro', the current bug was not spotted before.

The solution is to check if there is an inflow and then execute the spillage-related code.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
