### PR TITLE
Replace 'closed' to 'inclusive' in config snapshot

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -25,7 +25,7 @@ countries: ['AL', 'AT', 'BA', 'BE', 'BG', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'F
 snapshots:
   start: "2013-01-01"
   end: "2014-01-01"
-  closed: 'left' # end is not inclusive
+  inclusive: 'left' # end is not inclusive
 
 enable:
   prepare_links_p_nom: false

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -24,7 +24,7 @@ countries: ['BE']
 snapshots:
   start: "2013-03-01"
   end: "2013-04-01"
-  closed: 'left' # end is not inclusive
+  inclusive: 'left' # end is not inclusive
 
 enable:
   prepare_links_p_nom: false


### PR DESCRIPTION
Replace 'closed' to 'inclusive' in config snapshot to fix pandas FutureWarning: Argument `closed` is deprecated in favour of `inclusive`. This had cause warnings in rule build_load_data and rule base_network. Interestingly enough, pypsa-eur-sec has already amend those issue.

## Changes proposed in this Pull Request


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changes in configuration options are added in `config.default.yaml`, `config.tutorial.yaml`, and 
- [ ] Changes in configuration options are added in `test/config.test1.yaml`
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
