### PR TITLE
replace progressbar by tqdm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ on:
 
 env:
   CACHE_NUMBER: 1 # Change this value to manually reset the environment cache
+  PYTHONUNBUFFERED: 1 # to flush progress bars
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ on:
 
 env:
   CACHE_NUMBER: 1 # Change this value to manually reset the environment cache
-  PYTHONUNBUFFERED: 1 # to flush progress bars
 
 jobs:
   build:

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -33,7 +33,6 @@ dependencies:
 - networkx
 - scipy
 - shapely>=2.0
-- progressbar2
 - pyomo
 - matplotlib<3.6
 - proj

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path
-
+import urllib
+from tqdm import tqdm
 import pandas as pd
 
 REGION_COLS = ["geometry", "name", "x", "y", "country"]
@@ -251,16 +252,14 @@ def aggregate_costs(n, flatten=False, opts=None, existing_only=False):
 
 
 def progress_retrieve(url, file):
-    import urllib
-
-    from progressbar import ProgressBar
-
-    pbar = ProgressBar(0, 100)
-
-    def dlProgress(count, blockSize, totalSize):
-        pbar.update(int(count * blockSize * 100 / totalSize))
-
-    urllib.request.urlretrieve(url, file, reporthook=dlProgress)
+    
+    with tqdm(unit='B', unit_scale=True, unit_divisor=1024, miniters=1, position=0, leave=True) as t:
+        def update_to(b=1, bsize=1, tsize=None):
+            if tsize is not None:
+                t.total = tsize
+            t.update(b * bsize - t.n)
+        
+        urllib.request.urlretrieve(url, file, reporthook=update_to)
 
 
 def get_aggregation_strategies(aggregation_strategies):

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -254,7 +254,7 @@ def aggregate_costs(n, flatten=False, opts=None, existing_only=False):
 
 def progress_retrieve(url, file):
     with tqdm(
-        unit="B", unit_scale=True, unit_divisor=1024, miniters=1, position=0, leave=True
+        unit="B", unit_scale=True, unit_divisor=1024, miniters=1
     ) as t:
 
         def update_to(b=1, bsize=1, tsize=None):

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -3,10 +3,11 @@
 #
 # SPDX-License-Identifier: MIT
 
-from pathlib import Path
 import urllib
-from tqdm import tqdm
+from pathlib import Path
+
 import pandas as pd
+from tqdm import tqdm
 
 REGION_COLS = ["geometry", "name", "x", "y", "country"]
 
@@ -252,13 +253,15 @@ def aggregate_costs(n, flatten=False, opts=None, existing_only=False):
 
 
 def progress_retrieve(url, file):
-    
-    with tqdm(unit='B', unit_scale=True, unit_divisor=1024, miniters=1, position=0, leave=True) as t:
+    with tqdm(
+        unit="B", unit_scale=True, unit_divisor=1024, miniters=1, position=0, leave=True
+    ) as t:
+
         def update_to(b=1, bsize=1, tsize=None):
             if tsize is not None:
                 t.total = tsize
             t.update(b * bsize - t.n)
-        
+
         urllib.request.urlretrieve(url, file, reporthook=update_to)
 
 

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -253,9 +253,7 @@ def aggregate_costs(n, flatten=False, opts=None, existing_only=False):
 
 
 def progress_retrieve(url, file):
-    with tqdm(
-        unit="B", unit_scale=True, unit_divisor=1024, miniters=1
-    ) as t:
+    with tqdm(unit="B", unit_scale=True, unit_divisor=1024, miniters=1) as t:
 
         def update_to(b=1, bsize=1, tsize=None):
             if tsize is not None:

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -187,7 +187,6 @@ import time
 import atlite
 import geopandas as gpd
 import numpy as np
-import progressbar as pgb
 import xarray as xr
 from _helpers import configure_logging
 from dask.distributed import Client, LocalCluster
@@ -203,7 +202,6 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_renewable_profiles", technology="solar")
     configure_logging(snakemake)
-    pgb.streams.wrap_stderr()
 
     nprocesses = int(snakemake.threads)
     noprogress = not snakemake.config["atlite"].get("show_progress", False)


### PR DESCRIPTION
Initially the aim was to not let the output of the CI be bloat (which is the case with new prints of progressbars every half a second). However for that, I think we have to add an option to disable progressbars in general.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
