### PR TITLE
Bugfix typo in CPLEX configuration settings

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -684,8 +684,8 @@ solving:
       threads: 4
       lpmethod: 4 # barrier
       solutiontype: 2 # non basic solution, ie no crossover
-      barrier_convergetol: 1.e-5
-      feasopt_tolerance: 1.e-6
+      barrier.convergetol: 1.e-5
+      feasopt.tolerance: 1.e-6
     cbc-default: {} # Used in CI
     glpk-default: {} # Used in CI
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,8 +10,7 @@ Release Notes
 Upcoming Release
 ================
 
-* new feature or bugfix
-
+* Bugfix: Correct typo in the CPLEX solver configuration in ``config.default.yaml``.
 
 PyPSA-Eur 0.8.0 (18th March 2023)
 =================================


### PR DESCRIPTION
This just fixes two typos of the CPLEX configuration settings in `config.default.yaml`.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
