### PR TITLE
fix docs build in readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,8 +8,11 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - graphviz
 
 python:
   install:
   - requirements: doc/requirements.txt
   system_packages: false
+  apt_packages:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ build:
   tools:
     python: "3.11"
   apt_packages:
-    - graphviz
+  - graphviz
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,4 +12,4 @@ build:
 python:
   install:
   - requirements: doc/requirements.txt
-  system_packages: true
+  system_packages: false

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,4 +15,3 @@ python:
   install:
   - requirements: doc/requirements.txt
   system_packages: false
-  apt_packages:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,8 +4,12 @@
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: 3.8
   install:
   - requirements: doc/requirements.txt
   system_packages: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ build:
   tools:
     python: "3.11"
   apt_packages:
-  - graphviz
+    - graphviz
 
 python:
   install:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,6 +36,7 @@ sys.path.insert(0, os.path.abspath("../scripts"))
 extensions = [
     #'sphinx.ext.autodoc',
     #'sphinx.ext.autosummary',
+    "myst_parser",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -17,7 +17,7 @@ Upcoming Release
 
 * Renamed script file from PyPSA-EUR ``build_load_data`` to ``build_electricity_demand`` and ``retrieve_load_data`` to ``retrieve_electricity_demand``.
 
-
+* Fix docs readthedocs built
 
 * Add plain hydrogen turbine as additional re-electrification option besides
   hydrogen fuel cell. Add switches for both re-electrification options under

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,9 +2,11 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
+setuptools
 sphinx
 sphinx_book_theme
 sphinxcontrib-bibtex
+myst-parser  # recommark is deprecated, https://stackoverflow.com/a/71660856/13573820
 
 pypsa
 vresutils>=0.3.1


### PR DESCRIPTION
pypsa-eur docs build is failing on [readthedocs < see here](https://readthedocs.org/projects/pypsa-eur/builds/20403765/)

## Changes proposed in this Pull Request
PyPSA-Earth docs are passing so I add here changes that should work on PyPSA-Eur as well:
- bump python version, see https://github.com/pypsa-meets-earth/pypsa-earth/pull/717
- add setuptools, myst-parser, see parts of https://github.com/pypsa-meets-earth/pypsa-earth/pull/694

Tested these locally, and  below you can also see that the readthedocs build is working

Thanks for the really cool new docs theme :)

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] A release note `doc/release_notes.rst` is added.
