### PR TITLE
Adapt equity constraint to sector-coupled networks

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -23,6 +23,8 @@ Upcoming Release
   hydrogen fuel cell. Add switches for both re-electrification options under
   ``sector: hydrogen_turbine:`` and ``sector: hydrogen_fuel_cell:``.
 
+* Adapt equity constraint option (EQ) to sector-coupled networks.
+
 PyPSA-Eur 0.8.0 (18th March 2023)
 =================================
 


### PR DESCRIPTION
This pull requests updates the equity constraint to include all energy carriers in sector-coupled models. For details on how this is done and which modelling and implementation choices were made, see the docstring and comments in the relevant function.

For example, here are two networks solved with a 30% and 95% country-level equity constraint, respectively:
![Skjermbilde fra 2023-05-08 17-34-05](https://user-images.githubusercontent.com/74298901/236866628-5d396405-d28b-4130-9afe-ca26a4e58f07.png)
![Skjermbilde fra 2023-05-08 17-34-09](https://user-images.githubusercontent.com/74298901/236866637-2be17ce9-c791-4530-8e2e-5e87c3579103.png)
Note the significant shift of solar investment to Germany, the Netherlands and Belgium in the higher equity network (the lower picture), as well as some smaller regional differences (e.g. Finland/Estonia). (However, these results were produced with a _weekly_ time resolution in order to test quickly, so don't take them too seriously!)

From my testing, the constraint starts to have a significant effect from an equity level of around 70-80%. All in all the results seem reasonable and I think having some level of equity can even be a good "default" or "baseline" for most modelling.

Unfortunately, since there are so many different components in the sector-coupled network, the implementation is on the long side, and I don't think it can be made much smaller. There is also potential for bugs or leaks where some new component is added in future versions and it's forgotten to take it into account in the equity constraint. Even for the current implementation, I tried quite hard to make sure that I caught everything but it would be great if something else could also have a look through it just to have a second pair of eyes.

Maybe it would also be an idea to add an automated test to make sure that this implementation at least keeps running? Checking that the constraint actually works is unfortunately quite a bit of work; about as much as writing the constraint in the first place in fact. But it would also be useful to write a post-processing step which calculates equity levels after the fact and checks that they are within bounds.

I think the only obvious problems with the current implementation are:
- Tested for electricity-only and sector coupled networks, but _only_ for overnight foresight. (But the original implementation was also only for overnight foresight.)
- Gas production (e.g. in the North Sea) is counted as imported since implementation-wise this is lumped together with pipeline and LNG imports. Too bad for Norway, the Netherlands and the UK: all their locally produced gas is not counted towards energy equity. Fixing this would require some changes "upstream" in the workflow.

I would document this better in the wildcards documentation, but whole sector-coupled network wildcards section of the documentation seems to be under construction. Anyway it's not so clear how to document options that can appear both in `{opts}` and `{sector_opts}` (such as EQ) but might have slightly different behaviour in the different cases.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
