### PR TITLE
Post-merge `snakemake.params`

### DIFF
--- a/config/test/config.myopic.yaml
+++ b/config/test/config.myopic.yaml
@@ -31,6 +31,14 @@ snapshots:
   end: "2013-03-08"
 
 electricity:
+  co2limit: 100.e+6
+
+  extendable_carriers:
+    Generator: [OCGT]
+    StorageUnit: [battery]
+    Store: [H2]
+    Link: [H2 pipeline]
+
   renewable_carriers: [solar, onwind, offwind-ac, offwind-dc]
 
 atlite:

--- a/config/test/config.overnight.yaml
+++ b/config/test/config.overnight.yaml
@@ -28,6 +28,14 @@ snapshots:
   end: "2013-03-08"
 
 electricity:
+  co2limit: 100.e+6
+
+  extendable_carriers:
+    Generator: [OCGT]
+    StorageUnit: [battery]
+    Store: [H2]
+    Link: [H2 pipeline]
+
   renewable_carriers: [solar, onwind, offwind-ac, offwind-dc]
 
 atlite:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,7 @@ Release Notes
 Upcoming Release
 ================
 
+* ``param:`` section in rule definition are added to track changed settings in ``config.yaml``. The goal is to automatically re-execute rules whose parameters have changed. See `Non-file parameters for rules <https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#non-file-parameters-for-rules>`_ in the snakemake documentation.
 
 * **Important:** The configuration files are now located in the ``config`` directory. This counts for ``config.default.yaml``, ``config.yaml`` as well as the test configuration files which are now located in ``config/test``. Config files that are still in the root directory will be ignored.
 

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -321,7 +321,9 @@ rule simplify_network:
         renewable=config["renewable"],
         length_factor=config["lines"]["length_factor"],
         p_max_pu=config["links"].get("p_max_pu", 1.0),
-        exclude_carriers=config["clustering"]["simplify_network"].get("exclude_carriers", []),
+        exclude_carriers=config["clustering"]["simplify_network"].get(
+            "exclude_carriers", []
+        ),
         focus_weights=config.get("focus_weights", None),
         solver_name=config["solving"]["solver"]["name"],
     input:

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -39,7 +39,8 @@ rule build_electricity_demand:
 
 rule build_powerplants:
     params:
-        electricity=config["electricity"],
+        powerplants_filter=config["electricity"]["powerplants_filter"],
+        custom_powerplants=config["electricity"]["custom_powerplants"],
         countries=config["countries"],
     input:
         base_network=RESOURCES + "networks/base.nc",
@@ -138,7 +139,7 @@ if config["enable"].get("build_cutout", False):
     rule build_cutout:
         params:
             snapshots=config["snapshots"],
-            atlite=config["atlite"],
+            cutouts=config["atlite"]["cutouts"],
         input:
             regions_onshore=RESOURCES + "regions_onshore.geojson",
             regions_offshore=RESOURCES + "regions_offshore.geojson",
@@ -252,6 +253,7 @@ rule build_renewable_profiles:
 
 rule build_hydro_profile:
     params:
+        hydro=config["renewable"]["hydro"],
         countries=config["countries"],
         renewable=config["renewable"],
     input:
@@ -272,8 +274,8 @@ rule build_hydro_profile:
 
 rule add_electricity:
     params:
-        lines=config["lines"],
-        load=config["load"],
+        length_factor=config["lines"]["length_factor"],
+        scaling_factor=config["load"]["scaling_factor"],
         countries=config["countries"],
         renewable=config["renewable"],
         electricity=config["electricity"],
@@ -316,7 +318,7 @@ rule add_electricity:
 rule simplify_network:
     params:
         clustering=config["clustering"],
-        electricity=config["electricity"],
+        max_hours=config["electricity"]["max_hours"],
         costs=config["costs"],
         renewable=config["renewable"],
         length_factor=config["lines"]["length_factor"],
@@ -352,10 +354,11 @@ rule simplify_network:
 
 rule cluster_network:
     params:
-        solving=config["solving"],
-        electricity=config["electricity"],
+        solver_name=config["solving"]["solver"]["name"],
+        max_hours=config["electricity"]["max_hours"],
+        conventional_carriers=config["electricity"].get("conventional_carriers", []),
         costs=config["costs"],
-        lines=config["lines"],
+        length_factor=config["lines"]["length_factor"],
         renewable=config["renewable"],
         clustering=config["clustering"],
         custom_busmap=config["enable"].get("custom_busmap", False),
@@ -392,7 +395,8 @@ rule cluster_network:
 rule add_extra_components:
     params:
         costs=config["costs"],
-        electricity=config["electricity"],
+        ext_carriers=config["electricity"]["extendable_carriers"],
+        max_hours=config["electricity"]["max_hours"],
     input:
         network=RESOURCES + "networks/elec_s{simpl}_{clusters}.nc",
         tech_costs=COSTS,
@@ -414,9 +418,12 @@ rule add_extra_components:
 rule prepare_network:
     params:
         links=config["links"],
-        solving=config["solving"],
         lines=config["lines"],
-        electricity=config["electricity"],
+        solver_name=config["solving"]["solver"]["name"],
+        co2base=config["electricity"]["co2base"],
+        co2limit=config["electricity"]["co2limit"],
+        gaslimit=config["electricity"].get("gaslimit"),
+        max_hours=config["electricity"]["max_hours"],
         costs=config["costs"],
     input:
         RESOURCES + "networks/elec_s{simpl}_{clusters}_ec.nc",

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -274,13 +274,13 @@ rule add_electricity:
     output:
         RESOURCES + "networks/elec.nc",
     params:
-        costs=snakemake.config["costs"]
-        electricity=snakemake.config["electricity"]
-        renewable=snakemake.config["renewable"]
-        conventional=snakemake.config.get("conventional", {})
-        countries=snakemake.config["countries"]
-        scaling_factor=snakemake.config["load"]["scaling_factor"]
-        length_factor=snakemake.config["lines"]["length_factor"]
+        costs=snakemake.config["costs"],
+        electricity=snakemake.config["electricity"],
+        renewable=snakemake.config["renewable"],
+        conventional=snakemake.config.get("conventional", {}),
+        countries=snakemake.config["countries"],
+        scaling_factor=snakemake.config["load"]["scaling_factor"],
+        length_factor=snakemake.config["lines"]["length_factor"],
     log:
         LOGS + "add_electricity.log",
     benchmark:

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -201,7 +201,6 @@ rule build_ship_raster:
 
 rule build_renewable_profiles:
     params:
-        run=config["run"],
         renewable=config["renewable"],
     input:
         base_network=RESOURCES + "networks/base.nc",
@@ -350,7 +349,7 @@ rule cluster_network:
         lines=config["lines"],
         renewable=config["renewable"],
         clustering=config["clustering"],
-        enable=config["enable"],
+        enable=config["enable"].get("custom_busmap", False),
     input:
         network=RESOURCES + "networks/elec_s{simpl}.nc",
         regions_onshore=RESOURCES + "regions_onshore_elec_s{simpl}.geojson",

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -394,7 +394,7 @@ rule cluster_network:
 rule add_extra_components:
     params:
         costs=config["costs"],
-        ext_carriers=config["electricity"]["extendable_carriers"],
+        extendable_carriers=config["electricity"]["extendable_carriers"],
         max_hours=config["electricity"]["max_hours"],
     input:
         network=RESOURCES + "networks/elec_s{simpl}_{clusters}.nc",

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -201,6 +201,7 @@ rule build_ship_raster:
 
 rule build_renewable_profiles:
     params:
+        run=config["run"],
         renewable=config["renewable"],
     input:
         base_network=RESOURCES + "networks/base.nc",

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -273,6 +273,14 @@ rule add_electricity:
         nuts3_shapes=RESOURCES + "nuts3_shapes.geojson",
     output:
         RESOURCES + "networks/elec.nc",
+    params:
+        costs=snakemake.config["costs"]
+        electricity=snakemake.config["electricity"]
+        renewable=snakemake.config["renewable"]
+        conventional=snakemake.config.get("conventional", {})
+        countries=snakemake.config["countries"]
+        scaling_factor=snakemake.config["load"]["scaling_factor"]
+        length_factor=snakemake.config["lines"]["length_factor"]
     log:
         LOGS + "add_electricity.log",
     benchmark:

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -277,7 +277,7 @@ rule add_electricity:
         countries=config["countries"],
         renewable=config["renewable"],
         electricity=config["electricity"],
-        conventional=config.get("conventional", {})
+        conventional=config.get("conventional", {}),
         costs=config["costs"],
     input:
         **{

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -316,16 +316,14 @@ rule add_electricity:
 
 rule simplify_network:
     params:
-        clustering=config["clustering"],
-        max_hours=config["electricity"]["max_hours"],
+        simplify_network=config["clustering"]["simplify_network"],
+        aggregation_strategies=config["clustering"].get("aggregation_strategies", {}),
+        focus_weights=config.get("focus_weights", None),
+        renewable_carriers=config["electricity"]["renewable_carriers"],
         costs=config["costs"],
-        renewable=config["renewable"],
+        max_hours=config["electricity"]["max_hours"],
         length_factor=config["lines"]["length_factor"],
         p_max_pu=config["links"].get("p_max_pu", 1.0),
-        exclude_carriers=config["clustering"]["simplify_network"].get(
-            "exclude_carriers", []
-        ),
-        focus_weights=config.get("focus_weights", None),
         solver_name=config["solving"]["solver"]["name"],
     input:
         network=RESOURCES + "networks/elec.nc",
@@ -353,14 +351,16 @@ rule simplify_network:
 
 rule cluster_network:
     params:
-        solver_name=config["solving"]["solver"]["name"],
-        max_hours=config["electricity"]["max_hours"],
+        cluster_network=config["clustering"]["cluster_network"],
+        aggregation_strategies=config["clustering"].get("aggregation_strategies", {}),
+        custom_busmap=config["enable"].get("custom_busmap", False),
+        focus_weights=config.get("focus_weights", None),
+        renewable_carriers=config["electricity"]["renewable_carriers"],
         conventional_carriers=config["electricity"].get("conventional_carriers", []),
         costs=config["costs"],
+        max_hours=config["electricity"]["max_hours"],
         length_factor=config["lines"]["length_factor"],
-        renewable=config["renewable"],
-        clustering=config["clustering"],
-        custom_busmap=config["enable"].get("custom_busmap", False),
+        solver_name=config["solving"]["solver"]["name"],
     input:
         network=RESOURCES + "networks/elec_s{simpl}.nc",
         regions_onshore=RESOURCES + "regions_onshore_elec_s{simpl}.geojson",

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -320,11 +320,10 @@ rule simplify_network:
         aggregation_strategies=config["clustering"].get("aggregation_strategies", {}),
         focus_weights=config.get("focus_weights", None),
         renewable_carriers=config["electricity"]["renewable_carriers"],
-        costs=config["costs"],
         max_hours=config["electricity"]["max_hours"],
         length_factor=config["lines"]["length_factor"],
         p_max_pu=config["links"].get("p_max_pu", 1.0),
-        solver_name=config["solving"]["solver"]["name"],
+        costs=config["costs"],
     input:
         network=RESOURCES + "networks/elec.nc",
         tech_costs=COSTS,
@@ -357,10 +356,9 @@ rule cluster_network:
         focus_weights=config.get("focus_weights", None),
         renewable_carriers=config["electricity"]["renewable_carriers"],
         conventional_carriers=config["electricity"].get("conventional_carriers", []),
-        costs=config["costs"],
         max_hours=config["electricity"]["max_hours"],
         length_factor=config["lines"]["length_factor"],
-        solver_name=config["solving"]["solver"]["name"],
+        costs=config["costs"],
     input:
         network=RESOURCES + "networks/elec_s{simpl}.nc",
         regions_onshore=RESOURCES + "regions_onshore_elec_s{simpl}.geojson",
@@ -393,9 +391,9 @@ rule cluster_network:
 
 rule add_extra_components:
     params:
-        costs=config["costs"],
         extendable_carriers=config["electricity"]["extendable_carriers"],
         max_hours=config["electricity"]["max_hours"],
+        costs=config["costs"],
     input:
         network=RESOURCES + "networks/elec_s{simpl}_{clusters}.nc",
         tech_costs=COSTS,
@@ -418,7 +416,6 @@ rule prepare_network:
     params:
         links=config["links"],
         lines=config["lines"],
-        solver_name=config["solving"]["solver"]["name"],
         co2base=config["electricity"]["co2base"],
         co2limit=config["electricity"]["co2limit"],
         gaslimit=config["electricity"].get("gaslimit"),

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -318,6 +318,12 @@ rule simplify_network:
         clustering=config["clustering"],
         electricity=config["electricity"],
         costs=config["costs"],
+        renewable=config["renewable"],
+        length_factor=config["lines"]["length_factor"],
+        p_max_pu=config["links"].get("p_max_pu", 1.0),
+        exclude_carriers=config["clustering"]["simplify_network"].get("exclude_carriers", []),
+        focus_weights=config.get("focus_weights", None),
+        solver_name=config["solving"]["solver"]["name"],
     input:
         network=RESOURCES + "networks/elec.nc",
         tech_costs=COSTS,
@@ -350,7 +356,7 @@ rule cluster_network:
         lines=config["lines"],
         renewable=config["renewable"],
         clustering=config["clustering"],
-        enable=config["enable"].get("custom_busmap", False),
+        custom_busmap=config["enable"].get("custom_busmap", False),
     input:
         network=RESOURCES + "networks/elec_s{simpl}.nc",
         regions_onshore=RESOURCES + "regions_onshore_elec_s{simpl}.geojson",

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -277,6 +277,7 @@ rule add_electricity:
         countries=config["countries"],
         renewable=config["renewable"],
         electricity=config["electricity"],
+        conventional=config.get("conventional", {})
         costs=config["costs"],
     input:
         **{

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -255,7 +255,6 @@ rule build_hydro_profile:
     params:
         hydro=config["renewable"]["hydro"],
         countries=config["countries"],
-        renewable=config["renewable"],
     input:
         country_shapes=RESOURCES + "country_shapes.geojson",
         eia_hydro_generation="data/eia_hydro_annual_generation.csv",

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -405,40 +405,7 @@ rule build_ammonia_production:
 
 rule build_industry_sector_ratios:
     params:
-        industry={
-            "H2_DRI": config["industry"]["H2_DRI"],
-            "elec_DRI": config["industry"]["elec_DRI"],
-            "HVC_production_today": config["industry"]["HVC_production_today"],
-            "petrochemical_process_emissions": config["industry"][
-            "petrochemical_process_emissions"
-            ],
-            "NH3_process_emissions": config["industry"]["NH3_process_emissions"],
-            "MWh_CH4_per_tNH3_SMR": config["industry"]["MWh_CH4_per_tNH3_SMR"],
-            "MWh_elec_per_tNH3_SMR": config["industry"]["MWh_elec_per_tNH3_SMR"],
-            "chlorine_production_today": config["industry"][
-            "chlorine_production_today"
-            ],
-            "MWh_H2_per_tCl": config["industry"]["MWh_H2_per_tCl"],
-            "MWh_elec_per_tCl": config["industry"]["MWh_elec_per_tCl"],
-            "methanol_production_today": config["industry"][
-            "methanol_production_today"
-            ],
-            "MWh_CH4_per_tMeOH": config["industry"]["MWh_CH4_per_tMeOH"],
-            "MWh_elec_per_tMeOH": config["industry"]["MWh_elec_per_tMeOH"],
-            "MWh_elec_per_tHVC_mechanical_recycling": config["industry"][
-            "MWh_elec_per_tHVC_mechanical_recycling"
-            ],
-            "MWh_elec_per_tHVC_chemical_recycling": config["industry"][
-            "MWh_elec_per_tHVC_chemical_recycling"
-            ],
-            "MWh_NH3_per_tNH3": config["industry"]["MWh_NH3_per_tNH3"],
-            "MWh_H2_per_tNH3_electrolysis": config["industry"][
-            "MWh_H2_per_tNH3_electrolysis"
-            ],
-            "MWh_elec_per_tNH3_electrolysis": config["industry"][
-            "MWh_elec_per_tNH3_electrolysis"
-            ],
-        },
+        industry=config["industry"],
         sector_amonia=config["sector"].get("ammonia", False),
     input:
         ammonia_production=RESOURCES + "ammonia_production.csv",
@@ -460,16 +427,7 @@ rule build_industry_sector_ratios:
 
 rule build_industrial_production_per_country:
     params:
-        industry={
-            "reference_year": config["industry"]["reference_year"],
-            "HVC_production_today": config["industry"]["HVC_production_today"],
-            "chlorine_production_today": config["industry"][
-            "chlorine_production_today"
-            ],
-            "methanol_production_today": config["industry"][
-            "methanol_production_today"
-            ],
-        },
+        industry=config["industry"],
         countries=config["countries"],
     input:
         ammonia_production=RESOURCES + "ammonia_production.csv",
@@ -493,18 +451,7 @@ rule build_industrial_production_per_country:
 
 rule build_industrial_production_per_country_tomorrow:
     params:
-        industry={
-            "St_primary_fraction": config["industry"]["St_primary_fraction"],
-            "DRI_fraction": config["industry"]["DRI_fraction"],
-            "Al_primary_fraction": config["industry"]["Al_primary_fraction"],
-            "HVC_mechanical_recycling_fraction": config["industry"][
-            "HVC_mechanical_recycling_fraction"
-            ],
-            "HVC_chemical_recycling_fraction": config["industry"][
-            "HVC_chemical_recycling_fraction"
-            ],
-            "HVC_primary_fraction": config["industry"]["HVC_primary_fraction"],
-        },
+        industry=config["industry"],
     input:
         industrial_production_per_country=RESOURCES
         + "industrial_production_per_country.csv",
@@ -608,12 +555,7 @@ rule build_industrial_energy_demand_per_node:
 rule build_industrial_energy_demand_per_country_today:
     params:
         countries=config["countries"],
-        industry={
-            "reference_year": config["industry"].get("reference_year", 2015),
-            "MWh_CH4_per_tNH3_SMR": config["industry"]["MWh_CH4_per_tNH3_SMR"],
-            "MWh_elec_per_tNH3_SMR": config["industry"]["MWh_elec_per_tNH3_SMR"],
-            "MWh_NH3_per_tNH3": config["industry"]["MWh_NH3_per_tNH3"],
-        },
+        industry=config["industry"],
     input:
         jrc="data/jrc-idees-2015",
         ammonia_production=RESOURCES + "ammonia_production.csv",
@@ -768,18 +710,7 @@ rule prepare_sector_network:
         foresight=config["foresight"],
         costs=config["costs"],
         sector=config["sector"],
-        industry={
-            "MWh_elec_per_tNH3_electrolysis": config["industry"][
-            "MWh_elec_per_tNH3_electrolysis"
-            ],
-            "MWh_NH3_per_tNH3": config["industry"]["MWh_NH3_per_tNH3"],
-            "MWh_H2_per_tNH3_electrolysis": config["industry"][
-            "MWh_H2_per_tNH3_electrolysis"
-            ],
-            "MWh_NH3_per_MWh_H2_cracker": config["industry"][
-            "MWh_NH3_per_MWh_H2_cracker"
-            ],
-        },
+        industry=config["industry"],
         pypsa_eur=config["pypsa_eur"],
         length_factor=config["lines"]["length_factor"],
         planning_horizons=config["scenario"]["planning_horizons"],

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -4,6 +4,8 @@
 
 
 rule build_population_layouts:
+    params:
+        logging=config["logging"],
     input:
         nuts3_shapes=RESOURCES + "nuts3_shapes.geojson",
         urban_percent="data/urban_percent.csv",
@@ -70,6 +72,8 @@ rule build_simplified_population_layouts:
 if config["sector"]["gas_network"] or config["sector"]["H2_retrofit"]:
 
     rule build_gas_network:
+        params:
+            logging=config["logging"],
         input:
             gas_network="data/gas_network/scigrid-gas/data/IGGIELGN_PipeSegments.geojson",
         output:
@@ -84,6 +88,8 @@ if config["sector"]["gas_network"] or config["sector"]["H2_retrofit"]:
             "../scripts/build_gas_network.py"
 
     rule build_gas_input_locations:
+        params:
+            logging=config["logging"],
         input:
             lng=HTTP.remote(
                 "https://globalenergymonitor.org/wp-content/uploads/2022/09/Europe-Gas-Tracker-August-2022.xlsx",
@@ -110,6 +116,8 @@ if config["sector"]["gas_network"] or config["sector"]["H2_retrofit"]:
             "../scripts/build_gas_input_locations.py"
 
     rule cluster_gas_network:
+        params:
+            logging=config["logging"],
         input:
             cleaned_gas_network=RESOURCES + "gas_network.csv",
             regions_onshore=RESOURCES
@@ -140,6 +148,8 @@ if not (config["sector"]["gas_network"] or config["sector"]["H2_retrofit"]):
 
 
 rule build_heat_demands:
+    params:
+        snapshots=config["snapshots"],
     input:
         pop_layout=RESOURCES + "pop_layout_{scope}.nc",
         regions_onshore=RESOURCES + "regions_onshore_elec_s{simpl}_{clusters}.geojson",
@@ -160,6 +170,8 @@ rule build_heat_demands:
 
 
 rule build_temperature_profiles:
+    params:
+        snapshots=config["snapshots"],
     input:
         pop_layout=RESOURCES + "pop_layout_{scope}.nc",
         regions_onshore=RESOURCES + "regions_onshore_elec_s{simpl}_{clusters}.geojson",
@@ -181,6 +193,8 @@ rule build_temperature_profiles:
 
 
 rule build_cop_profiles:
+    params:
+        sector=config["sector"],
     input:
         temp_soil_total=RESOURCES + "temp_soil_total_elec_s{simpl}_{clusters}.nc",
         temp_soil_rural=RESOURCES + "temp_soil_rural_elec_s{simpl}_{clusters}.nc",
@@ -208,6 +222,9 @@ rule build_cop_profiles:
 
 
 rule build_solar_thermal_profiles:
+    params:
+        snapshots=config["snapshots"],
+        solar_thermal=config["solar_thermal"],
     input:
         pop_layout=RESOURCES + "pop_layout_{scope}.nc",
         regions_onshore=RESOURCES + "regions_onshore_elec_s{simpl}_{clusters}.geojson",
@@ -228,6 +245,11 @@ rule build_solar_thermal_profiles:
 
 
 rule build_energy_totals:
+    params:
+        run=config["run"],
+        countries=config["countries"],
+        energy=config["energy"],
+        logging=config["logging"],
     input:
         nuts3_shapes=RESOURCES + "nuts3_shapes.geojson",
         co2="data/eea/UNFCCC_v23.csv",
@@ -253,6 +275,8 @@ rule build_energy_totals:
 
 
 rule build_biomass_potentials:
+    params:
+        biomass=config["biomass"],
     input:
         enspreso_biomass=HTTP.remote(
             "https://cidportal.jrc.ec.europa.eu/ftp/jrc-opendata/ENSPRESO/ENSPRESO_BIOMASS.xlsx",
@@ -315,6 +339,8 @@ if not config["sector"]["biomass_transport"]:
 if config["sector"]["regional_co2_sequestration_potential"]["enable"]:
 
     rule build_sequestration_potentials:
+        params:
+            sector=config["sector"],
         input:
             sequestration_potential=HTTP.remote(
                 "https://raw.githubusercontent.com/ericzhou571/Co2Storage/main/resources/complete_map_2020_unit_Mt.geojson",
@@ -368,6 +394,8 @@ rule build_salt_cavern_potentials:
 
 
 rule build_ammonia_production:
+    params:
+        countries=config["countries"],
     input:
         usgs="data/myb1-2017-nitro.xls",
     output:
@@ -386,6 +414,9 @@ rule build_ammonia_production:
 
 
 rule build_industry_sector_ratios:
+    params:
+        industry=config["industry"],
+        sector=config["sector"],
     input:
         ammonia_production=RESOURCES + "ammonia_production.csv",
         idees="data/jrc-idees-2015",
@@ -405,6 +436,11 @@ rule build_industry_sector_ratios:
 
 
 rule build_industrial_production_per_country:
+    params:
+        run=config["run"],
+        industry=config["industry"],
+        countries=config["countries"],
+        logging=config["logging"],
     input:
         ammonia_production=RESOURCES + "ammonia_production.csv",
         jrc="data/jrc-idees-2015",
@@ -426,6 +462,8 @@ rule build_industrial_production_per_country:
 
 
 rule build_industrial_production_per_country_tomorrow:
+    params:
+        industry=config["industry"],
     input:
         industrial_production_per_country=RESOURCES
         + "industrial_production_per_country.csv",
@@ -450,6 +488,10 @@ rule build_industrial_production_per_country_tomorrow:
 
 
 rule build_industrial_distribution_key:
+    params:
+        industry=config["industry"],
+        countries=config["countries"],
+        logging=config["logging"],
     input:
         regions_onshore=RESOURCES + "regions_onshore_elec_s{simpl}_{clusters}.geojson",
         clustered_pop_layout=RESOURCES + "pop_layout_elec_s{simpl}_{clusters}.csv",
@@ -524,6 +566,10 @@ rule build_industrial_energy_demand_per_node:
 
 
 rule build_industrial_energy_demand_per_country_today:
+    params:
+        run=config["run"],
+        countries=config["countries"],
+        industry=config["industry"],
     input:
         jrc="data/jrc-idees-2015",
         ammonia_production=RESOURCES + "ammonia_production.csv",
@@ -570,6 +616,9 @@ rule build_industrial_energy_demand_per_node_today:
 if config["sector"]["retrofitting"]["retro_endogen"]:
 
     rule build_retro_cost:
+        params:
+            sector=config["sector"],
+            countries=config["countries"],
         input:
             building_stock="data/retro/data_building_stock.csv",
             data_tabula="data/retro/tabula-calculator-calcsetbuilding.csv",
@@ -640,6 +689,9 @@ rule build_shipping_demand:
 
 
 rule build_transport_demand:
+    params:
+        snapshots=config["snapshots"],
+        sector=config["sector"],
     input:
         clustered_pop_layout=RESOURCES + "pop_layout_elec_s{simpl}_{clusters}.csv",
         pop_weighted_energy_totals=RESOURCES
@@ -666,6 +718,19 @@ rule build_transport_demand:
 
 rule prepare_sector_network:
     params:
+        co2_budget=config["co2_budget"],
+        solving=config["solving"],
+        existing_capacities=config["existing_capacities"],
+        foresight=config["foresight"],
+        costs=config["costs"],
+        logging=config["logging"],
+        sector=config["sector"],
+        industry=config["industry"],
+        pypsa_eur=config["pypsa_eur"],
+        lines=config["lines"],
+        scenario=config["scenario"],
+        countries=config["countries"],
+        energy=config["energy"],
         RDIR=RDIR,
     input:
         **build_retro_cost_output,

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -406,24 +406,38 @@ rule build_ammonia_production:
 rule build_industry_sector_ratios:
     params:
         industry={
-            "H2_DRI":config["industry"]["H2_DRI"],
-            "elec_DRI":config["industry"]["elec_DRI"],
-            "HVC_production_today":config["industry"]["HVC_production_today"],
-            "petrochemical_process_emissions":config["industry"]["petrochemical_process_emissions"],
-            "NH3_process_emissions":config["industry"]["NH3_process_emissions"],
-            "MWh_CH4_per_tNH3_SMR":config["industry"]["MWh_CH4_per_tNH3_SMR"],
-            "MWh_elec_per_tNH3_SMR":config["industry"]["MWh_elec_per_tNH3_SMR"],
-            "chlorine_production_today":config["industry"]["chlorine_production_today"],
-            "MWh_H2_per_tCl":config["industry"]["MWh_H2_per_tCl"],
-            "MWh_elec_per_tCl":config["industry"]["MWh_elec_per_tCl"],
-            "methanol_production_today":config["industry"]["methanol_production_today"],
-            "MWh_CH4_per_tMeOH":config["industry"]["MWh_CH4_per_tMeOH"],
-            "MWh_elec_per_tMeOH":config["industry"]["MWh_elec_per_tMeOH"],
-            "MWh_elec_per_tHVC_mechanical_recycling":config["industry"]["MWh_elec_per_tHVC_mechanical_recycling"],
-            "MWh_elec_per_tHVC_chemical_recycling":config["industry"]["MWh_elec_per_tHVC_chemical_recycling"],
-            "MWh_NH3_per_tNH3":config["industry"]["MWh_NH3_per_tNH3"],
-            "MWh_H2_per_tNH3_electrolysis":config["industry"]["MWh_H2_per_tNH3_electrolysis"],
-            "MWh_elec_per_tNH3_electrolysis":config["industry"]["MWh_elec_per_tNH3_electrolysis"]
+            "H2_DRI": config["industry"]["H2_DRI"],
+            "elec_DRI": config["industry"]["elec_DRI"],
+            "HVC_production_today": config["industry"]["HVC_production_today"],
+            "petrochemical_process_emissions": config["industry"][
+            "petrochemical_process_emissions"
+            ],
+            "NH3_process_emissions": config["industry"]["NH3_process_emissions"],
+            "MWh_CH4_per_tNH3_SMR": config["industry"]["MWh_CH4_per_tNH3_SMR"],
+            "MWh_elec_per_tNH3_SMR": config["industry"]["MWh_elec_per_tNH3_SMR"],
+            "chlorine_production_today": config["industry"][
+            "chlorine_production_today"
+            ],
+            "MWh_H2_per_tCl": config["industry"]["MWh_H2_per_tCl"],
+            "MWh_elec_per_tCl": config["industry"]["MWh_elec_per_tCl"],
+            "methanol_production_today": config["industry"][
+            "methanol_production_today"
+            ],
+            "MWh_CH4_per_tMeOH": config["industry"]["MWh_CH4_per_tMeOH"],
+            "MWh_elec_per_tMeOH": config["industry"]["MWh_elec_per_tMeOH"],
+            "MWh_elec_per_tHVC_mechanical_recycling": config["industry"][
+            "MWh_elec_per_tHVC_mechanical_recycling"
+            ],
+            "MWh_elec_per_tHVC_chemical_recycling": config["industry"][
+            "MWh_elec_per_tHVC_chemical_recycling"
+            ],
+            "MWh_NH3_per_tNH3": config["industry"]["MWh_NH3_per_tNH3"],
+            "MWh_H2_per_tNH3_electrolysis": config["industry"][
+            "MWh_H2_per_tNH3_electrolysis"
+            ],
+            "MWh_elec_per_tNH3_electrolysis": config["industry"][
+            "MWh_elec_per_tNH3_electrolysis"
+            ],
         },
         sector_amonia=config["sector"].get("ammonia", False),
     input:
@@ -447,10 +461,14 @@ rule build_industry_sector_ratios:
 rule build_industrial_production_per_country:
     params:
         industry={
-            "reference_year":config["industry"]["reference_year"],
-            "HVC_production_today":config["industry"]["HVC_production_today"],
-            "chlorine_production_today":config["industry"]["chlorine_production_today"],
-            "methanol_production_today":config["industry"]["methanol_production_today"]
+            "reference_year": config["industry"]["reference_year"],
+            "HVC_production_today": config["industry"]["HVC_production_today"],
+            "chlorine_production_today": config["industry"][
+            "chlorine_production_today"
+            ],
+            "methanol_production_today": config["industry"][
+            "methanol_production_today"
+            ],
         },
         countries=config["countries"],
     input:
@@ -476,12 +494,16 @@ rule build_industrial_production_per_country:
 rule build_industrial_production_per_country_tomorrow:
     params:
         industry={
-            "St_primary_fraction":config["industry"]["St_primary_fraction"],
-            "DRI_fraction":config["industry"]["DRI_fraction"],
-            "Al_primary_fraction":config["industry"]["Al_primary_fraction"],
-            "HVC_mechanical_recycling_fraction":config["industry"]["HVC_mechanical_recycling_fraction"],
-            "HVC_chemical_recycling_fraction":config["industry"]["HVC_chemical_recycling_fraction"],
-            "HVC_primary_fraction":config["industry"]["HVC_primary_fraction"]
+            "St_primary_fraction": config["industry"]["St_primary_fraction"],
+            "DRI_fraction": config["industry"]["DRI_fraction"],
+            "Al_primary_fraction": config["industry"]["Al_primary_fraction"],
+            "HVC_mechanical_recycling_fraction": config["industry"][
+            "HVC_mechanical_recycling_fraction"
+            ],
+            "HVC_chemical_recycling_fraction": config["industry"][
+            "HVC_chemical_recycling_fraction"
+            ],
+            "HVC_primary_fraction": config["industry"]["HVC_primary_fraction"],
         },
     input:
         industrial_production_per_country=RESOURCES
@@ -587,10 +609,10 @@ rule build_industrial_energy_demand_per_country_today:
     params:
         countries=config["countries"],
         industry={
-            "reference_year":config["industry"].get("reference_year", 2015),
-            "MWh_CH4_per_tNH3_SMR":config["industry"]["MWh_CH4_per_tNH3_SMR"],
-            "MWh_elec_per_tNH3_SMR":config["industry"]["MWh_elec_per_tNH3_SMR"],
-            "MWh_NH3_per_tNH3":config["industry"]["MWh_NH3_per_tNH3"]
+            "reference_year": config["industry"].get("reference_year", 2015),
+            "MWh_CH4_per_tNH3_SMR": config["industry"]["MWh_CH4_per_tNH3_SMR"],
+            "MWh_elec_per_tNH3_SMR": config["industry"]["MWh_elec_per_tNH3_SMR"],
+            "MWh_NH3_per_tNH3": config["industry"]["MWh_NH3_per_tNH3"],
         },
     input:
         jrc="data/jrc-idees-2015",
@@ -747,10 +769,16 @@ rule prepare_sector_network:
         costs=config["costs"],
         sector=config["sector"],
         industry={
-            "MWh_elec_per_tNH3_electrolysis":config["industry"]["MWh_elec_per_tNH3_electrolysis"],
-            "MWh_NH3_per_tNH3":config["industry"]["MWh_NH3_per_tNH3"],
-            "MWh_H2_per_tNH3_electrolysis":config["industry"]["MWh_H2_per_tNH3_electrolysis"],
-            "MWh_NH3_per_MWh_H2_cracker":config["industry"]["MWh_NH3_per_MWh_H2_cracker"]
+            "MWh_elec_per_tNH3_electrolysis": config["industry"][
+            "MWh_elec_per_tNH3_electrolysis"
+            ],
+            "MWh_NH3_per_tNH3": config["industry"]["MWh_NH3_per_tNH3"],
+            "MWh_H2_per_tNH3_electrolysis": config["industry"][
+            "MWh_H2_per_tNH3_electrolysis"
+            ],
+            "MWh_NH3_per_MWh_H2_cracker": config["industry"][
+            "MWh_NH3_per_MWh_H2_cracker"
+            ],
         },
         pypsa_eur=config["pypsa_eur"],
         length_factor=config["lines"]["length_factor"],

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -330,7 +330,9 @@ if config["sector"]["regional_co2_sequestration_potential"]["enable"]:
 
     rule build_sequestration_potentials:
         params:
-            co2seq_potential=config["sector"]["regional_co2_sequestration_potential"],
+            sequestration_potential=config["sector"][
+                "regional_co2_sequestration_potential"
+            ],
         input:
             sequestration_potential=HTTP.remote(
                 "https://raw.githubusercontent.com/ericzhou571/Co2Storage/main/resources/complete_map_2020_unit_Mt.geojson",
@@ -705,7 +707,6 @@ rule build_transport_demand:
 rule prepare_sector_network:
     params:
         co2_budget=config["co2_budget"],
-        solver_name=config["solving"]["solver"]["name"],
         conventional_carriers=config["existing_capacities"]["conventional_carriers"],
         foresight=config["foresight"],
         costs=config["costs"],
@@ -716,7 +717,7 @@ rule prepare_sector_network:
         planning_horizons=config["scenario"]["planning_horizons"],
         countries=config["countries"],
         emissions_scope=config["energy"]["emissions"],
-        report_year=config["energy"]["eurostat_report_year"],
+        eurostat_report_year=config["energy"]["eurostat_report_year"],
         RDIR=RDIR,
     input:
         **build_retro_cost_output,

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -406,7 +406,7 @@ rule build_ammonia_production:
 rule build_industry_sector_ratios:
     params:
         industry=config["industry"],
-        sector_amonia=config["sector"].get("ammonia", False),
+        ammonia=config["sector"].get("ammonia", False),
     input:
         ammonia_production=RESOURCES + "ammonia_production.csv",
         idees="data/jrc-idees-2015",

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -4,8 +4,6 @@
 
 
 rule build_population_layouts:
-    params:
-        logging=config["logging"],
     input:
         nuts3_shapes=RESOURCES + "nuts3_shapes.geojson",
         urban_percent="data/urban_percent.csv",
@@ -72,8 +70,6 @@ rule build_simplified_population_layouts:
 if config["sector"]["gas_network"] or config["sector"]["H2_retrofit"]:
 
     rule build_gas_network:
-        params:
-            logging=config["logging"],
         input:
             gas_network="data/gas_network/scigrid-gas/data/IGGIELGN_PipeSegments.geojson",
         output:
@@ -88,8 +84,6 @@ if config["sector"]["gas_network"] or config["sector"]["H2_retrofit"]:
             "../scripts/build_gas_network.py"
 
     rule build_gas_input_locations:
-        params:
-            logging=config["logging"],
         input:
             lng=HTTP.remote(
                 "https://globalenergymonitor.org/wp-content/uploads/2022/09/Europe-Gas-Tracker-August-2022.xlsx",
@@ -116,8 +110,6 @@ if config["sector"]["gas_network"] or config["sector"]["H2_retrofit"]:
             "../scripts/build_gas_input_locations.py"
 
     rule cluster_gas_network:
-        params:
-            logging=config["logging"],
         input:
             cleaned_gas_network=RESOURCES + "gas_network.csv",
             regions_onshore=RESOURCES
@@ -246,10 +238,8 @@ rule build_solar_thermal_profiles:
 
 rule build_energy_totals:
     params:
-        run=config["run"],
         countries=config["countries"],
         energy=config["energy"],
-        logging=config["logging"],
     input:
         nuts3_shapes=RESOURCES + "nuts3_shapes.geojson",
         co2="data/eea/UNFCCC_v23.csv",
@@ -437,10 +427,8 @@ rule build_industry_sector_ratios:
 
 rule build_industrial_production_per_country:
     params:
-        run=config["run"],
         industry=config["industry"],
         countries=config["countries"],
-        logging=config["logging"],
     input:
         ammonia_production=RESOURCES + "ammonia_production.csv",
         jrc="data/jrc-idees-2015",
@@ -491,7 +479,6 @@ rule build_industrial_distribution_key:
     params:
         industry=config["industry"],
         countries=config["countries"],
-        logging=config["logging"],
     input:
         regions_onshore=RESOURCES + "regions_onshore_elec_s{simpl}_{clusters}.geojson",
         clustered_pop_layout=RESOURCES + "pop_layout_elec_s{simpl}_{clusters}.csv",
@@ -567,7 +554,6 @@ rule build_industrial_energy_demand_per_node:
 
 rule build_industrial_energy_demand_per_country_today:
     params:
-        run=config["run"],
         countries=config["countries"],
         industry=config["industry"],
     input:
@@ -723,7 +709,6 @@ rule prepare_sector_network:
         existing_capacities=config["existing_capacities"],
         foresight=config["foresight"],
         costs=config["costs"],
-        logging=config["logging"],
         sector=config["sector"],
         industry=config["industry"],
         pypsa_eur=config["pypsa_eur"],

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -186,7 +186,7 @@ rule build_temperature_profiles:
 
 rule build_cop_profiles:
     params:
-        sector=config["sector"],
+        heat_pump_sink_T=config["sector"]["heat_pump_sink_T"],
     input:
         temp_soil_total=RESOURCES + "temp_soil_total_elec_s{simpl}_{clusters}.nc",
         temp_soil_rural=RESOURCES + "temp_soil_rural_elec_s{simpl}_{clusters}.nc",
@@ -330,7 +330,7 @@ if config["sector"]["regional_co2_sequestration_potential"]["enable"]:
 
     rule build_sequestration_potentials:
         params:
-            sector=config["sector"],
+            co2seq_potential=config["sector"]["regional_co2_sequestration_potential"],
         input:
             sequestration_potential=HTTP.remote(
                 "https://raw.githubusercontent.com/ericzhou571/Co2Storage/main/resources/complete_map_2020_unit_Mt.geojson",
@@ -405,8 +405,27 @@ rule build_ammonia_production:
 
 rule build_industry_sector_ratios:
     params:
-        industry=config["industry"],
-        sector=config["sector"],
+        industry={
+            "H2_DRI":config["industry"]["H2_DRI"],
+            "elec_DRI":config["industry"]["elec_DRI"],
+            "HVC_production_today":config["industry"]["HVC_production_today"],
+            "petrochemical_process_emissions":config["industry"]["petrochemical_process_emissions"],
+            "NH3_process_emissions":config["industry"]["NH3_process_emissions"],
+            "MWh_CH4_per_tNH3_SMR":config["industry"]["MWh_CH4_per_tNH3_SMR"],
+            "MWh_elec_per_tNH3_SMR":config["industry"]["MWh_elec_per_tNH3_SMR"],
+            "chlorine_production_today":config["industry"]["chlorine_production_today"],
+            "MWh_H2_per_tCl":config["industry"]["MWh_H2_per_tCl"],
+            "MWh_elec_per_tCl":config["industry"]["MWh_elec_per_tCl"],
+            "methanol_production_today":config["industry"]["methanol_production_today"],
+            "MWh_CH4_per_tMeOH":config["industry"]["MWh_CH4_per_tMeOH"],
+            "MWh_elec_per_tMeOH":config["industry"]["MWh_elec_per_tMeOH"],
+            "MWh_elec_per_tHVC_mechanical_recycling":config["industry"]["MWh_elec_per_tHVC_mechanical_recycling"],
+            "MWh_elec_per_tHVC_chemical_recycling":config["industry"]["MWh_elec_per_tHVC_chemical_recycling"],
+            "MWh_NH3_per_tNH3":config["industry"]["MWh_NH3_per_tNH3"],
+            "MWh_H2_per_tNH3_electrolysis":config["industry"]["MWh_H2_per_tNH3_electrolysis"],
+            "MWh_elec_per_tNH3_electrolysis":config["industry"]["MWh_elec_per_tNH3_electrolysis"]
+        },
+        sector_amonia=config["sector"].get("ammonia", False),
     input:
         ammonia_production=RESOURCES + "ammonia_production.csv",
         idees="data/jrc-idees-2015",
@@ -427,7 +446,12 @@ rule build_industry_sector_ratios:
 
 rule build_industrial_production_per_country:
     params:
-        industry=config["industry"],
+        industry={
+            "reference_year":config["industry"]["reference_year"],
+            "HVC_production_today":config["industry"]["HVC_production_today"],
+            "chlorine_production_today":config["industry"]["chlorine_production_today"],
+            "methanol_production_today":config["industry"]["methanol_production_today"]
+        },
         countries=config["countries"],
     input:
         ammonia_production=RESOURCES + "ammonia_production.csv",
@@ -451,7 +475,14 @@ rule build_industrial_production_per_country:
 
 rule build_industrial_production_per_country_tomorrow:
     params:
-        industry=config["industry"],
+        industry={
+            "St_primary_fraction":config["industry"]["St_primary_fraction"],
+            "DRI_fraction":config["industry"]["DRI_fraction"],
+            "Al_primary_fraction":config["industry"]["Al_primary_fraction"],
+            "HVC_mechanical_recycling_fraction":config["industry"]["HVC_mechanical_recycling_fraction"],
+            "HVC_chemical_recycling_fraction":config["industry"]["HVC_chemical_recycling_fraction"],
+            "HVC_primary_fraction":config["industry"]["HVC_primary_fraction"]
+        },
     input:
         industrial_production_per_country=RESOURCES
         + "industrial_production_per_country.csv",
@@ -477,7 +508,7 @@ rule build_industrial_production_per_country_tomorrow:
 
 rule build_industrial_distribution_key:
     params:
-        industry=config["industry"],
+        hotmaps_locate_missing=config["industry"].get("hotmaps_locate_missing", False),
         countries=config["countries"],
     input:
         regions_onshore=RESOURCES + "regions_onshore_elec_s{simpl}_{clusters}.geojson",
@@ -555,7 +586,12 @@ rule build_industrial_energy_demand_per_node:
 rule build_industrial_energy_demand_per_country_today:
     params:
         countries=config["countries"],
-        industry=config["industry"],
+        industry={
+            "reference_year":config["industry"].get("reference_year", 2015),
+            "MWh_CH4_per_tNH3_SMR":config["industry"]["MWh_CH4_per_tNH3_SMR"],
+            "MWh_elec_per_tNH3_SMR":config["industry"]["MWh_elec_per_tNH3_SMR"],
+            "MWh_NH3_per_tNH3":config["industry"]["MWh_NH3_per_tNH3"]
+        },
     input:
         jrc="data/jrc-idees-2015",
         ammonia_production=RESOURCES + "ammonia_production.csv",
@@ -603,7 +639,7 @@ if config["sector"]["retrofitting"]["retro_endogen"]:
 
     rule build_retro_cost:
         params:
-            sector=config["sector"],
+            retrofitting=config["sector"]["retrofitting"],
             countries=config["countries"],
         input:
             building_stock="data/retro/data_building_stock.csv",
@@ -705,17 +741,23 @@ rule build_transport_demand:
 rule prepare_sector_network:
     params:
         co2_budget=config["co2_budget"],
-        solving=config["solving"],
-        existing_capacities=config["existing_capacities"],
+        solver_name=config["solving"]["solver"]["name"],
+        conventional_carriers=config["existing_capacities"]["conventional_carriers"],
         foresight=config["foresight"],
         costs=config["costs"],
         sector=config["sector"],
-        industry=config["industry"],
+        industry={
+            "MWh_elec_per_tNH3_electrolysis":config["industry"]["MWh_elec_per_tNH3_electrolysis"],
+            "MWh_NH3_per_tNH3":config["industry"]["MWh_NH3_per_tNH3"],
+            "MWh_H2_per_tNH3_electrolysis":config["industry"]["MWh_H2_per_tNH3_electrolysis"],
+            "MWh_NH3_per_MWh_H2_cracker":config["industry"]["MWh_NH3_per_MWh_H2_cracker"]
+        },
         pypsa_eur=config["pypsa_eur"],
-        lines=config["lines"],
-        scenario=config["scenario"],
+        length_factor=config["lines"]["length_factor"],
+        planning_horizons=config["scenario"]["planning_horizons"],
         countries=config["countries"],
-        energy=config["energy"],
+        emissions_scope=config["energy"]["emissions"],
+        report_year=config["energy"]["eurostat_report_year"],
         RDIR=RDIR,
     input:
         **build_retro_cost_output,

--- a/rules/postprocess.smk
+++ b/rules/postprocess.smk
@@ -122,7 +122,8 @@ rule make_summary:
 rule plot_summary:
     params:
         countries=config["countries"],
-        scenario=config["scenario"],
+        planning_horizons=config["scenario"]["planning_horizons"],
+        sector_opts=config["scenario"]["sector_opts"],
         plotting=config["plotting"],
         RDIR=RDIR,
     input:

--- a/rules/postprocess.smk
+++ b/rules/postprocess.smk
@@ -9,6 +9,10 @@ localrules:
 
 
 rule plot_network:
+    params:
+        logging=config["logging"],
+        foresight=config["foresight"],
+        plotting=config["plotting"],
     input:
         overrides="data/override_component_attrs",
         network=RESULTS
@@ -67,6 +71,11 @@ rule copy_conda_env:
 
 rule make_summary:
     params:
+        foresight=config["foresight"],
+        costs=config["costs"],
+        snapshots=config["snapshots"],
+        logging=config["logging"],
+        scenario=config["scenario"],
         RDIR=RDIR,
     input:
         overrides="data/override_component_attrs",
@@ -114,6 +123,10 @@ rule make_summary:
 
 rule plot_summary:
     params:
+        logging=config["logging"],
+        countries=config["countries"],
+        scenario=config["scenario"],
+        plotting=config["plotting"],
         RDIR=RDIR,
     input:
         costs=RESULTS + "csvs/costs.csv",

--- a/rules/postprocess.smk
+++ b/rules/postprocess.smk
@@ -10,7 +10,6 @@ localrules:
 
 rule plot_network:
     params:
-        logging=config["logging"],
         foresight=config["foresight"],
         plotting=config["plotting"],
     input:
@@ -74,7 +73,6 @@ rule make_summary:
         foresight=config["foresight"],
         costs=config["costs"],
         snapshots=config["snapshots"],
-        logging=config["logging"],
         scenario=config["scenario"],
         RDIR=RDIR,
     input:
@@ -123,7 +121,6 @@ rule make_summary:
 
 rule plot_summary:
     params:
-        logging=config["logging"],
         countries=config["countries"],
         scenario=config["scenario"],
         plotting=config["plotting"],

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -19,6 +19,8 @@ if config["enable"].get("retrieve_databundle", True):
         datafiles.extend(["natura/Natura2000_end2015.shp", "GEBCO_2014_2D.nc"])
 
     rule retrieve_databundle:
+        params:
+            tutorial=config["tutorial"],
         output:
             expand("data/bundle/{file}", file=datafiles),
         log:

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -20,6 +20,7 @@ if config["enable"].get("retrieve_databundle", True):
 
     rule retrieve_databundle:
         params:
+            run=config["run"],
             tutorial=config["tutorial"],
         output:
             expand("data/bundle/{file}", file=datafiles),

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -20,7 +20,6 @@ if config["enable"].get("retrieve_databundle", True):
 
     rule retrieve_databundle:
         params:
-            run=config["run"],
             tutorial=config["tutorial"],
         output:
             expand("data/bundle/{file}", file=datafiles),

--- a/rules/solve_electricity.smk
+++ b/rules/solve_electricity.smk
@@ -7,11 +7,15 @@ rule solve_network:
     params:
         solving=config["solving"],
         config_parts={
-                    "foresight":config["foresight"],
-                    "planning_horizons":config["scenario"]["planning_horizons"],
-                    "co2_sequestration_potential":config["sector"].get("co2_sequestration_potential", 200),
-                    "H2_retrofit_capacity_per_CH4":config["sector"]["H2_retrofit_capacity_per_CH4"]
-                    },
+            "foresight": config["foresight"],
+            "planning_horizons": config["scenario"]["planning_horizons"],
+            "co2_sequestration_potential": config["sector"].get(
+                "co2_sequestration_potential", 200
+            ),
+            "H2_retrofit_capacity_per_CH4": config["sector"][
+            "H2_retrofit_capacity_per_CH4"
+            ],
+        },
     input:
         network=RESOURCES + "networks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc",
     output:

--- a/rules/solve_electricity.smk
+++ b/rules/solve_electricity.smk
@@ -41,7 +41,7 @@ rule solve_network:
 
 rule solve_operations_network:
     params:
-        solving=config["solving"],
+        options=config["solving"]["options"],
     input:
         network=RESULTS + "networks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc",
     output:

--- a/rules/solve_electricity.smk
+++ b/rules/solve_electricity.smk
@@ -8,7 +8,9 @@ rule solve_network:
         solving=config["solving"],
         foresight=config["foresight"],
         planning_horizons=config["scenario"]["planning_horizons"],
-        co2_sequestration_potential=config["sector"].get("co2_sequestration_potential", 200),
+        co2_sequestration_potential=config["sector"].get(
+            "co2_sequestration_potential", 200
+        ),
     input:
         network=RESOURCES + "networks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc",
     output:

--- a/rules/solve_electricity.smk
+++ b/rules/solve_electricity.smk
@@ -4,6 +4,8 @@
 
 
 rule solve_network:
+    params:
+        solving=config["solving"],
     input:
         network=RESOURCES + "networks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc",
     output:
@@ -30,6 +32,8 @@ rule solve_network:
 
 
 rule solve_operations_network:
+    params:
+        solving=config["solving"],
     input:
         network=RESULTS + "networks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc",
     output:

--- a/rules/solve_electricity.smk
+++ b/rules/solve_electricity.smk
@@ -6,16 +6,9 @@
 rule solve_network:
     params:
         solving=config["solving"],
-        config_parts={
-            "foresight": config["foresight"],
-            "planning_horizons": config["scenario"]["planning_horizons"],
-            "co2_sequestration_potential": config["sector"].get(
-                "co2_sequestration_potential", 200
-            ),
-            "H2_retrofit_capacity_per_CH4": config["sector"][
-            "H2_retrofit_capacity_per_CH4"
-            ],
-        },
+        foresight=config["foresight"],
+        planning_horizons=config["scenario"]["planning_horizons"],
+        co2_sequestration_potential=config["sector"].get("co2_sequestration_potential", 200),
     input:
         network=RESOURCES + "networks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc",
     output:

--- a/rules/solve_electricity.smk
+++ b/rules/solve_electricity.smk
@@ -6,6 +6,12 @@
 rule solve_network:
     params:
         solving=config["solving"],
+        config_parts={
+                    "foresight":config["foresight"],
+                    "planning_horizons":config["scenario"]["planning_horizons"],
+                    "co2_sequestration_potential":config["sector"].get("co2_sequestration_potential", 200),
+                    "H2_retrofit_capacity_per_CH4":config["sector"]["H2_retrofit_capacity_per_CH4"]
+                    },
     input:
         network=RESOURCES + "networks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}.nc",
     output:

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -87,7 +87,9 @@ rule solve_sector_network_myopic:
         solving=config["solving"],
         foresight=config["foresight"],
         planning_horizons=config["scenario"]["planning_horizons"],
-        co2_sequestration_potential=config["sector"].get("co2_sequestration_potential", 200),
+        co2_sequestration_potential=config["sector"].get(
+            "co2_sequestration_potential", 200
+        ),
     input:
         overrides="data/override_component_attrs",
         network=RESULTS

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -4,6 +4,12 @@
 
 
 rule add_existing_baseyear:
+    params:
+        scenario=config["scenario"],
+        sector=config["sector"],
+        logging=config["logging"],
+        existing_capacities=config["existing_capacities"],
+        costs=config["costs"],
     input:
         overrides="data/override_component_attrs",
         network=RESULTS
@@ -42,6 +48,10 @@ rule add_existing_baseyear:
 
 
 rule add_brownfield:
+    params:
+        logging=config["logging"],
+        sector=config["sector"],
+        existing_capacities=config["existing_capacities"],
     input:
         overrides="data/override_component_attrs",
         network=RESULTS
@@ -74,6 +84,8 @@ ruleorder: add_existing_baseyear > add_brownfield
 
 
 rule solve_sector_network_myopic:
+    params:
+        solving=config["solving"],
     input:
         overrides="data/override_component_attrs",
         network=RESULTS

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -5,7 +5,7 @@
 
 rule add_existing_baseyear:
     params:
-        scenario=config["scenario"],
+        baseyear=config["scenario"]["planning_horizons"][0],
         sector=config["sector"],
         existing_capacities=config["existing_capacities"],
         costs=config["costs"],
@@ -48,8 +48,9 @@ rule add_existing_baseyear:
 
 rule add_brownfield:
     params:
-        sector=config["sector"],
-        existing_capacities=config["existing_capacities"],
+        H2_retrofit=config["sector"]["H2_retrofit"],
+        H2_retrofit_capacity_per_CH4=config["sector"]["H2_retrofit_capacity_per_CH4"],
+        threshold_capacity=config["existing_capacities"]["threshold_capacity"],
     input:
         overrides="data/override_component_attrs",
         network=RESULTS

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -84,6 +84,12 @@ ruleorder: add_existing_baseyear > add_brownfield
 rule solve_sector_network_myopic:
     params:
         solving=config["solving"],
+        config_parts={
+                    "foresight":config["foresight"],
+                    "planning_horizons":config["scenario"]["planning_horizons"],
+                    "co2_sequestration_potential":config["sector"].get("co2_sequestration_potential", 200),
+                    "H2_retrofit_capacity_per_CH4":config["sector"]["H2_retrofit_capacity_per_CH4"]
+                    },
     input:
         overrides="data/override_component_attrs",
         network=RESULTS

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -7,7 +7,6 @@ rule add_existing_baseyear:
     params:
         scenario=config["scenario"],
         sector=config["sector"],
-        logging=config["logging"],
         existing_capacities=config["existing_capacities"],
         costs=config["costs"],
     input:
@@ -49,7 +48,6 @@ rule add_existing_baseyear:
 
 rule add_brownfield:
     params:
-        logging=config["logging"],
         sector=config["sector"],
         existing_capacities=config["existing_capacities"],
     input:

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -85,16 +85,9 @@ ruleorder: add_existing_baseyear > add_brownfield
 rule solve_sector_network_myopic:
     params:
         solving=config["solving"],
-        config_parts={
-            "foresight": config["foresight"],
-            "planning_horizons": config["scenario"]["planning_horizons"],
-            "co2_sequestration_potential": config["sector"].get(
-                "co2_sequestration_potential", 200
-            ),
-            "H2_retrofit_capacity_per_CH4": config["sector"][
-            "H2_retrofit_capacity_per_CH4"
-            ],
-        },
+        foresight=config["foresight"],
+        planning_horizons=config["scenario"]["planning_horizons"],
+        co2_sequestration_potential=config["sector"].get("co2_sequestration_potential", 200),
     input:
         overrides="data/override_component_attrs",
         network=RESULTS

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -85,11 +85,15 @@ rule solve_sector_network_myopic:
     params:
         solving=config["solving"],
         config_parts={
-                    "foresight":config["foresight"],
-                    "planning_horizons":config["scenario"]["planning_horizons"],
-                    "co2_sequestration_potential":config["sector"].get("co2_sequestration_potential", 200),
-                    "H2_retrofit_capacity_per_CH4":config["sector"]["H2_retrofit_capacity_per_CH4"]
-                    },
+            "foresight": config["foresight"],
+            "planning_horizons": config["scenario"]["planning_horizons"],
+            "co2_sequestration_potential": config["sector"].get(
+                "co2_sequestration_potential", 200
+            ),
+            "H2_retrofit_capacity_per_CH4": config["sector"][
+            "H2_retrofit_capacity_per_CH4"
+            ],
+        },
     input:
         overrides="data/override_component_attrs",
         network=RESULTS

--- a/rules/solve_overnight.smk
+++ b/rules/solve_overnight.smk
@@ -6,16 +6,9 @@
 rule solve_sector_network:
     params:
         solving=config["solving"],
-        config_parts={
-            "foresight": config["foresight"],
-            "planning_horizons": config["scenario"]["planning_horizons"],
-            "co2_sequestration_potential": config["sector"].get(
-                "co2_sequestration_potential", 200
-            ),
-            "H2_retrofit_capacity_per_CH4": config["sector"][
-            "H2_retrofit_capacity_per_CH4"
-            ],
-        },
+        foresight=config["foresight"],
+        planning_horizons=config["scenario"]["planning_horizons"],
+        co2_sequestration_potential=config["sector"].get("co2_sequestration_potential", 200),
     input:
         overrides="data/override_component_attrs",
         network=RESULTS

--- a/rules/solve_overnight.smk
+++ b/rules/solve_overnight.smk
@@ -6,6 +6,12 @@
 rule solve_sector_network:
     params:
         solving=config["solving"],
+        config_parts={
+                    "foresight":config["foresight"],
+                    "planning_horizons":config["scenario"]["planning_horizons"],
+                    "co2_sequestration_potential":config["sector"].get("co2_sequestration_potential", 200),
+                    "H2_retrofit_capacity_per_CH4":config["sector"]["H2_retrofit_capacity_per_CH4"]
+                    },
     input:
         overrides="data/override_component_attrs",
         network=RESULTS

--- a/rules/solve_overnight.smk
+++ b/rules/solve_overnight.smk
@@ -7,11 +7,15 @@ rule solve_sector_network:
     params:
         solving=config["solving"],
         config_parts={
-                    "foresight":config["foresight"],
-                    "planning_horizons":config["scenario"]["planning_horizons"],
-                    "co2_sequestration_potential":config["sector"].get("co2_sequestration_potential", 200),
-                    "H2_retrofit_capacity_per_CH4":config["sector"]["H2_retrofit_capacity_per_CH4"]
-                    },
+            "foresight": config["foresight"],
+            "planning_horizons": config["scenario"]["planning_horizons"],
+            "co2_sequestration_potential": config["sector"].get(
+                "co2_sequestration_potential", 200
+            ),
+            "H2_retrofit_capacity_per_CH4": config["sector"][
+            "H2_retrofit_capacity_per_CH4"
+            ],
+        },
     input:
         overrides="data/override_component_attrs",
         network=RESULTS

--- a/rules/solve_overnight.smk
+++ b/rules/solve_overnight.smk
@@ -4,6 +4,8 @@
 
 
 rule solve_sector_network:
+    params:
+        solving=config["solving"],
     input:
         overrides="data/override_component_attrs",
         network=RESULTS

--- a/rules/solve_overnight.smk
+++ b/rules/solve_overnight.smk
@@ -8,7 +8,9 @@ rule solve_sector_network:
         solving=config["solving"],
         foresight=config["foresight"],
         planning_horizons=config["scenario"]["planning_horizons"],
-        co2_sequestration_potential=config["sector"].get("co2_sequestration_potential", 200),
+        co2_sequestration_potential=config["sector"].get(
+            "co2_sequestration_potential", 200
+        ),
     input:
         overrides="data/override_component_attrs",
         network=RESULTS

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -82,7 +82,7 @@ def load_network(import_name=None, custom_components=None):
         As in pypsa.Network(import_name)
     custom_components : dict
         Dictionary listing custom components.
-        For using ``snakemake.config['override_components']``
+        For using ``snakemake.params['override_components']``
         in ``config/config.yaml`` define:
 
         .. code:: yaml

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -49,7 +49,7 @@ def add_brownfield(n, n_p, year):
             )
         ]
 
-        threshold = snakemake.config["existing_capacities"]["threshold_capacity"]
+        threshold = snakemake.params["existing_capacities"]["threshold_capacity"]
 
         if not chp_heat.empty:
             threshold_chp_heat = (
@@ -87,7 +87,7 @@ def add_brownfield(n, n_p, year):
 
         # deal with gas network
         pipe_carrier = ["gas pipeline"]
-        if snakemake.config["sector"]["H2_retrofit"]:
+        if snakemake.params["sector"]["H2_retrofit"]:
             # drop capacities of previous year to avoid duplicating
             to_drop = n.links.carrier.isin(pipe_carrier) & (n.links.build_year != year)
             n.mremove("Link", n.links.loc[to_drop].index)
@@ -98,7 +98,7 @@ def add_brownfield(n, n_p, year):
                 & (n.links.build_year != year)
             ].index
             gas_pipes_i = n.links[n.links.carrier.isin(pipe_carrier)].index
-            CH4_per_H2 = 1 / snakemake.config["sector"]["H2_retrofit_capacity_per_CH4"]
+            CH4_per_H2 = 1 / snakemake.params["sector"]["H2_retrofit_capacity_per_CH4"]
             fr = "H2 pipeline retrofitted"
             to = "gas pipeline"
             # today's pipe capacity
@@ -139,7 +139,7 @@ if __name__ == "__main__":
             planning_horizons=2030,
         )
 
-    logging.basicConfig(level=snakemake.config["logging"]["level"])
+    logging.basicConfig(level=snakemake.params["logging"]["level"])
 
     update_config_with_sector_opts(snakemake.config, snakemake.wildcards.sector_opts)
 

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -49,7 +49,7 @@ def add_brownfield(n, n_p, year):
             )
         ]
 
-        threshold = snakemake.params["existing_capacities"]["threshold_capacity"]
+        threshold = snakemake.params["threshold_capacity"]
 
         if not chp_heat.empty:
             threshold_chp_heat = (
@@ -87,7 +87,7 @@ def add_brownfield(n, n_p, year):
 
         # deal with gas network
         pipe_carrier = ["gas pipeline"]
-        if snakemake.params["sector"]["H2_retrofit"]:
+        if snakemake.params["H2_retrofit"]:
             # drop capacities of previous year to avoid duplicating
             to_drop = n.links.carrier.isin(pipe_carrier) & (n.links.build_year != year)
             n.mremove("Link", n.links.loc[to_drop].index)
@@ -98,7 +98,7 @@ def add_brownfield(n, n_p, year):
                 & (n.links.build_year != year)
             ].index
             gas_pipes_i = n.links[n.links.carrier.isin(pipe_carrier)].index
-            CH4_per_H2 = 1 / snakemake.params["sector"]["H2_retrofit_capacity_per_CH4"]
+            CH4_per_H2 = 1 / snakemake.params["H2_retrofit_capacity_per_CH4"]
             fr = "H2 pipeline retrofitted"
             to = "gas pipeline"
             # today's pipe capacity

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -139,7 +139,7 @@ if __name__ == "__main__":
             planning_horizons=2030,
         )
 
-    logging.basicConfig(level=snakemake.params["logging"]["level"])
+    logging.basicConfig(level=snakemake.config["logging"]["level"])
 
     update_config_with_sector_opts(snakemake.config, snakemake.wildcards.sector_opts)
 

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -49,7 +49,7 @@ def add_brownfield(n, n_p, year):
             )
         ]
 
-        threshold = snakemake.params["threshold_capacity"]
+        threshold = snakemake.params.threshold_capacity
 
         if not chp_heat.empty:
             threshold_chp_heat = (
@@ -87,7 +87,7 @@ def add_brownfield(n, n_p, year):
 
         # deal with gas network
         pipe_carrier = ["gas pipeline"]
-        if snakemake.params["H2_retrofit"]:
+        if snakemake.params.H2_retrofit:
             # drop capacities of previous year to avoid duplicating
             to_drop = n.links.carrier.isin(pipe_carrier) & (n.links.build_year != year)
             n.mremove("Link", n.links.loc[to_drop].index)
@@ -98,7 +98,7 @@ def add_brownfield(n, n_p, year):
                 & (n.links.build_year != year)
             ].index
             gas_pipes_i = n.links[n.links.carrier.isin(pipe_carrier)].index
-            CH4_per_H2 = 1 / snakemake.params["H2_retrofit_capacity_per_CH4"]
+            CH4_per_H2 = 1 / snakemake.params.H2_retrofit_capacity_per_CH4
             fr = "H2 pipeline retrofitted"
             to = "gas pipeline"
             # today's pipe capacity

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -137,7 +137,7 @@ def _add_missing_carriers_from_costs(n, costs, carriers):
     n.import_components_from_dataframe(emissions, "Carrier")
 
 
-def load_costs(tech_costs, params, elec_params, Nyears=1.0):
+def load_costs(tech_costs, params, max_hours, Nyears=1.0):
     # set all asset costs and other parameters
     costs = pd.read_csv(tech_costs, index_col=[0, 1]).sort_index()
 
@@ -180,7 +180,6 @@ def load_costs(tech_costs, params, elec_params, Nyears=1.0):
             dict(capital_cost=capital_cost, marginal_cost=0.0, co2_emissions=0.0)
         )
 
-    max_hours = elec_params["max_hours"]
     costs.loc["battery"] = costs_for_storage(
         costs.loc["battery storage"],
         costs.loc["battery inverter"],
@@ -728,7 +727,7 @@ if __name__ == "__main__":
     costs = load_costs(
         snakemake.input.tech_costs,
         snakemake.params["costs"],
-        snakemake.params["electricity"],
+        snakemake.params["electricity"]["max_hours"],
         Nyears,
     )
     ppl = load_powerplants(snakemake.input.powerplants)
@@ -759,10 +758,10 @@ if __name__ == "__main__":
         snakemake.input.load,
         snakemake.input.nuts3_shapes,
         snakemake.params["countries"],
-        snakemake.params["load"]["scaling_factor"],
+        snakemake.params["scaling_factor"],
     )
 
-    update_transmission_costs(n, costs, snakemake.params["lines"]["length_factor"])
+    update_transmission_costs(n, costs, snakemake.params["length_factor"])
 
     conventional_inputs = {
         k: v for k, v in snakemake.input.items() if k.startswith("conventional_")
@@ -783,7 +782,7 @@ if __name__ == "__main__":
         snakemake.input,
         renewable_carriers,
         extendable_carriers,
-        snakemake.params["lines"]["length_factor"],
+        snakemake.params["length_factor"],
     )
 
     if "hydro" in renewable_carriers:

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -686,15 +686,15 @@ def estimate_renewable_capacities(n, config):
             )
 
 
-def add_nice_carrier_names(n, config):
+def add_nice_carrier_names(n, plotting):
     carrier_i = n.carriers.index
     nice_names = (
-        pd.Series(config["plotting"]["nice_names"])
+        pd.Series(plotting["nice_names"])
         .reindex(carrier_i)
         .fillna(carrier_i.to_series().str.title())
     )
     n.carriers["nice_name"] = nice_names
-    colors = pd.Series(config["plotting"]["tech_colors"]).reindex(carrier_i)
+    colors = pd.Series(plotting["tech_colors"]).reindex(carrier_i)
     if colors.isna().any():
         missing_i = list(colors.index[colors.isna()])
         logger.warning(f"tech_colors for carriers {missing_i} not defined in config.")
@@ -713,23 +713,23 @@ if __name__ == "__main__":
 
     costs = load_costs(
         snakemake.input.tech_costs,
-        snakemake.config["costs"],
-        snakemake.config["electricity"],
+        snakemake.param["costs"],
+        snakemake.param["electricity"],
         Nyears,
     )
     ppl = load_powerplants(snakemake.input.powerplants)
 
-    if "renewable_carriers" in snakemake.config["electricity"]:
-        renewable_carriers = set(snakemake.config["electricity"]["renewable_carriers"])
+    if "renewable_carriers" in snakemake.param["electricity"]:
+        renewable_carriers = set(snakemake.param["electricity"]["renewable_carriers"])
     else:
         logger.warning(
             "Missing key `renewable_carriers` under config entry `electricity`. "
             "In future versions, this will raise an error. "
             "Falling back to carriers listed under `renewable`."
         )
-        renewable_carriers = snakemake.config["renewable"]
+        renewable_carriers = snakemake.param["renewable"]
 
-    extendable_carriers = snakemake.config["electricity"]["extendable_carriers"]
+    extendable_carriers = snakemake.param["electricity"]["extendable_carriers"]
     if not (set(renewable_carriers) & set(extendable_carriers["Generator"])):
         logger.warning(
             "No renewables found in config entry `extendable_carriers`. "
@@ -737,18 +737,18 @@ if __name__ == "__main__":
             "Falling back to all renewables."
         )
 
-    conventional_carriers = snakemake.config["electricity"]["conventional_carriers"]
+    conventional_carriers = snakemake.param["electricity"]["conventional_carriers"]
 
     attach_load(
         n,
         snakemake.input.regions,
         snakemake.input.load,
         snakemake.input.nuts3_shapes,
-        snakemake.config["countries"],
-        snakemake.config["load"]["scaling_factor"],
+        snakemake.param["countries"],
+        snakemake.param["load"]["scaling_factor"],
     )
 
-    update_transmission_costs(n, costs, snakemake.config["lines"]["length_factor"])
+    update_transmission_costs(n, costs, snakemake.param["lines"]["length_factor"])
 
     conventional_inputs = {
         k: v for k, v in snakemake.input.items() if k.startswith("conventional_")
@@ -759,7 +759,7 @@ if __name__ == "__main__":
         ppl,
         conventional_carriers,
         extendable_carriers,
-        snakemake.config.get("conventional", {}),
+        snakemake.param.get("conventional", {}),
         conventional_inputs,
     )
 
@@ -769,11 +769,11 @@ if __name__ == "__main__":
         snakemake.input,
         renewable_carriers,
         extendable_carriers,
-        snakemake.config["lines"]["length_factor"],
+        snakemake.param["lines"]["length_factor"],
     )
 
     if "hydro" in renewable_carriers:
-        conf = snakemake.config["renewable"]["hydro"]
+        conf = snakemake.param["renewable"]["hydro"]
         attach_hydro(
             n,
             costs,
@@ -784,7 +784,7 @@ if __name__ == "__main__":
             **conf,
         )
 
-    if "estimate_renewable_capacities" not in snakemake.config["electricity"]:
+    if "estimate_renewable_capacities" not in snakemake.param["electricity"]:
         logger.warning(
             "Missing key `estimate_renewable_capacities` under config entry `electricity`. "
             "In future versions, this will raise an error. "
@@ -792,18 +792,18 @@ if __name__ == "__main__":
         )
         if (
             "estimate_renewable_capacities_from_capacity_stats"
-            in snakemake.config["electricity"]
+            in snakemake.param["electricity"]
         ):
             estimate_renewable_caps = {
                 "enable": True,
-                **snakemake.config["electricity"][
+                **snakemake.param["electricity"][
                     "estimate_renewable_capacities_from_capacity_stats"
                 ],
             }
         else:
             estimate_renewable_caps = {"enable": False}
     else:
-        estimate_renewable_caps = snakemake.config["electricity"][
+        estimate_renewable_caps = snakemake.param["electricity"][
             "estimate_renewable_capacities"
         ]
     if "enable" not in estimate_renewable_caps:
@@ -819,21 +819,21 @@ if __name__ == "__main__":
             "Falling back to whether `renewable_capacities_from_opsd` is non-empty."
         )
         from_opsd = bool(
-            snakemake.config["electricity"].get("renewable_capacities_from_opsd", False)
+            snakemake.param["electricity"].get("renewable_capacities_from_opsd", False)
         )
         estimate_renewable_caps["from_opsd"] = from_opsd
 
     if estimate_renewable_caps["enable"]:
         if estimate_renewable_caps["from_opsd"]:
-            tech_map = snakemake.config["electricity"]["estimate_renewable_capacities"][
+            tech_map = snakemake.param["electricity"]["estimate_renewable_capacities"][
                 "technology_mapping"
             ]
             attach_OPSD_renewables(n, tech_map)
-        estimate_renewable_capacities(n, snakemake.config)
+        estimate_renewable_capacities(n, snakemake.param)
 
     update_p_nom_max(n)
 
-    add_nice_carrier_names(n, snakemake.config)
+    add_nice_carrier_names(n, snakemake.param["plotting"])
 
-    n.meta = snakemake.config
+    n.meta = snakemake.param
     n.export_to_netcdf(snakemake.output[0])

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -638,9 +638,7 @@ def attach_OPSD_renewables(n, tech_map):
 
 def estimate_renewable_capacities(n, electricity_params, countries):
     year = electricity_params["estimate_renewable_capacities"]["year"]
-    tech_map = electricity_params["estimate_renewable_capacities"][
-        "technology_mapping"
-    ]
+    tech_map = electricity_params["estimate_renewable_capacities"]["technology_mapping"]
     expansion_limit = electricity_params["estimate_renewable_capacities"][
         "expansion_limit"
     ]
@@ -828,7 +826,9 @@ if __name__ == "__main__":
                 "technology_mapping"
             ]
             attach_OPSD_renewables(n, tech_map)
-        estimate_renewable_capacities(n, snakemake.params["electricity"],snakemake.params["countries"])
+        estimate_renewable_capacities(
+            n, snakemake.params["electricity"], snakemake.params["countries"]
+        )
 
     update_p_nom_max(n)
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -137,7 +137,7 @@ def _add_missing_carriers_from_costs(n, costs, carriers):
     n.import_components_from_dataframe(emissions, "Carrier")
 
 
-def load_costs(tech_costs, costs, max_hours, Nyears=1.0):
+def load_costs(tech_costs, config, max_hours, Nyears=1.0):
     # set all asset costs and other parameters
     costs = pd.read_csv(tech_costs, index_col=[0, 1]).sort_index()
 
@@ -145,7 +145,7 @@ def load_costs(tech_costs, costs, max_hours, Nyears=1.0):
     costs.loc[costs.unit.str.contains("/kW"), "value"] *= 1e3
     costs.unit = costs.unit.str.replace("/kW", "/MW")
 
-    fill_values = costs["fill_values"]
+    fill_values = config["fill_values"]
     costs = costs.value.unstack().fillna(fill_values)
 
     costs["capital_cost"] = (
@@ -168,8 +168,8 @@ def load_costs(tech_costs, costs, max_hours, Nyears=1.0):
     costs.at["CCGT", "co2_emissions"] = costs.at["gas", "co2_emissions"]
 
     costs.at["solar", "capital_cost"] = (
-        costs["rooftop_share"] * costs.at["solar-rooftop", "capital_cost"]
-        + (1 - costs["rooftop_share"]) * costs.at["solar-utility", "capital_cost"]
+        config["rooftop_share"] * costs.at["solar-rooftop", "capital_cost"]
+        + (1 - config["rooftop_share"]) * costs.at["solar-utility", "capital_cost"]
     )
 
     def costs_for_storage(store, link1, link2=None, max_hours=1.0):
@@ -193,7 +193,7 @@ def load_costs(tech_costs, costs, max_hours, Nyears=1.0):
     )
 
     for attr in ("marginal_cost", "capital_cost"):
-        overwrites = costs.get(attr)
+        overwrites = config.get(attr)
         if overwrites is not None:
             overwrites = pd.Series(overwrites)
             costs.loc[overwrites.index, attr] = overwrites

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -756,7 +756,7 @@ if __name__ == "__main__":
         ppl,
         conventional_carriers,
         extendable_carriers,
-        snakemake.params.get("conventional", {}),
+        snakemake.params["conventional"],
         conventional_inputs,
     )
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -726,23 +726,23 @@ if __name__ == "__main__":
 
     costs = load_costs(
         snakemake.input.tech_costs,
-        snakemake.params["costs"],
-        snakemake.params["electricity"]["max_hours"],
+        snakemake.params.costs,
+        snakemake.params.electricity["max_hours"],
         Nyears,
     )
     ppl = load_powerplants(snakemake.input.powerplants)
 
-    if "renewable_carriers" in snakemake.params["electricity"]:
-        renewable_carriers = set(snakemake.params["electricity"]["renewable_carriers"])
+    if "renewable_carriers" in snakemake.params.electricity:
+        renewable_carriers = set(snakemake.params.electricity["renewable_carriers"])
     else:
         logger.warning(
             "Missing key `renewable_carriers` under config entry `electricity`. "
             "In future versions, this will raise an error. "
             "Falling back to carriers listed under `renewable`."
         )
-        renewable_carriers = snakemake.params["renewable"]
+        renewable_carriers = snakemake.params.renewable
 
-    extendable_carriers = snakemake.params["electricity"]["extendable_carriers"]
+    extendable_carriers = snakemake.params.electricity["extendable_carriers"]
     if not (set(renewable_carriers) & set(extendable_carriers["Generator"])):
         logger.warning(
             "No renewables found in config entry `extendable_carriers`. "
@@ -750,18 +750,18 @@ if __name__ == "__main__":
             "Falling back to all renewables."
         )
 
-    conventional_carriers = snakemake.params["electricity"]["conventional_carriers"]
+    conventional_carriers = snakemake.params.electricity["conventional_carriers"]
 
     attach_load(
         n,
         snakemake.input.regions,
         snakemake.input.load,
         snakemake.input.nuts3_shapes,
-        snakemake.params["countries"],
-        snakemake.params["scaling_factor"],
+        snakemake.params.countries,
+        snakemake.params.scaling_factor,
     )
 
-    update_transmission_costs(n, costs, snakemake.params["length_factor"])
+    update_transmission_costs(n, costs, snakemake.params.length_factor)
 
     conventional_inputs = {
         k: v for k, v in snakemake.input.items() if k.startswith("conventional_")
@@ -772,7 +772,7 @@ if __name__ == "__main__":
         ppl,
         conventional_carriers,
         extendable_carriers,
-        snakemake.params["conventional"],
+        snakemake.params.conventional,
         conventional_inputs,
     )
 
@@ -782,11 +782,11 @@ if __name__ == "__main__":
         snakemake.input,
         renewable_carriers,
         extendable_carriers,
-        snakemake.params["length_factor"],
+        snakemake.params.length_factor,
     )
 
     if "hydro" in renewable_carriers:
-        para = snakemake.params["renewable"]["hydro"]
+        para = snakemake.params.renewable["hydro"]
         attach_hydro(
             n,
             costs,
@@ -797,7 +797,7 @@ if __name__ == "__main__":
             **para,
         )
 
-    if "estimate_renewable_capacities" not in snakemake.params["electricity"]:
+    if "estimate_renewable_capacities" not in snakemake.params.electricity:
         logger.warning(
             "Missing key `estimate_renewable_capacities` under config entry `electricity`. "
             "In future versions, this will raise an error. "
@@ -805,18 +805,18 @@ if __name__ == "__main__":
         )
         if (
             "estimate_renewable_capacities_from_capacity_stats"
-            in snakemake.params["electricity"]
+            in snakemake.params.electricity
         ):
             estimate_renewable_caps = {
                 "enable": True,
-                **snakemake.params["electricity"][
+                **snakemake.params.electricity[
                     "estimate_renewable_capacities_from_capacity_stats"
                 ],
             }
         else:
             estimate_renewable_caps = {"enable": False}
     else:
-        estimate_renewable_caps = snakemake.params["electricity"][
+        estimate_renewable_caps = snakemake.params.electricity[
             "estimate_renewable_capacities"
         ]
     if "enable" not in estimate_renewable_caps:
@@ -832,18 +832,18 @@ if __name__ == "__main__":
             "Falling back to whether `renewable_capacities_from_opsd` is non-empty."
         )
         from_opsd = bool(
-            snakemake.params["electricity"].get("renewable_capacities_from_opsd", False)
+            snakemake.params.electricity.get("renewable_capacities_from_opsd", False)
         )
         estimate_renewable_caps["from_opsd"] = from_opsd
 
     if estimate_renewable_caps["enable"]:
         if estimate_renewable_caps["from_opsd"]:
-            tech_map = snakemake.params["electricity"]["estimate_renewable_capacities"][
+            tech_map = snakemake.params.electricity["estimate_renewable_capacities"][
                 "technology_mapping"
             ]
             attach_OPSD_renewables(n, tech_map)
         estimate_renewable_capacities(
-            n, snakemake.params["electricity"], snakemake.params["countries"]
+            n, snakemake.params.electricity, snakemake.params.countries
         )
 
     update_p_nom_max(n)

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -157,7 +157,7 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
     # Fill missing DateOut
     dateout = (
         df_agg.loc[biomass_i, "DateIn"]
-        + snakemake.config["costs"]["fill_values"]["lifetime"]
+        + snakemake.params["costs"]["fill_values"]["lifetime"]
     )
     df_agg.loc[biomass_i, "DateOut"] = df_agg.loc[biomass_i, "DateOut"].fillna(dateout)
 
@@ -218,7 +218,7 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
         capacity = df.loc[grouping_year, generator]
         capacity = capacity[~capacity.isna()]
         capacity = capacity[
-            capacity > snakemake.config["existing_capacities"]["threshold_capacity"]
+            capacity > snakemake.params["existing_capacities"]["threshold_capacity"]
         ]
         suffix = "-ac" if generator == "offwind" else ""
         name_suffix = f" {generator}{suffix}-{grouping_year}"
@@ -582,7 +582,7 @@ def add_heating_capacities_installed_before_baseyear(
             )
 
             # delete links with capacities below threshold
-            threshold = snakemake.config["existing_capacities"]["threshold_capacity"]
+            threshold = snakemake.params["existing_capacities"]["threshold_capacity"]
             n.mremove(
                 "Link",
                 [
@@ -608,14 +608,14 @@ if __name__ == "__main__":
             planning_horizons=2020,
         )
 
-    logging.basicConfig(level=snakemake.config["logging"]["level"])
+    logging.basicConfig(level=snakemake.params["logging"]["level"])
 
     update_config_with_sector_opts(snakemake.config, snakemake.wildcards.sector_opts)
 
-    options = snakemake.config["sector"]
+    options = snakemake.params["sector"]
     opts = snakemake.wildcards.sector_opts.split("-")
 
-    baseyear = snakemake.config["scenario"]["planning_horizons"][0]
+    baseyear = snakemake.params["scenario"]["planning_horizons"][0]
 
     overrides = override_component_attrs(snakemake.input.overrides)
     n = pypsa.Network(snakemake.input.network, override_component_attrs=overrides)
@@ -626,14 +626,14 @@ if __name__ == "__main__":
     Nyears = n.snapshot_weightings.generators.sum() / 8760.0
     costs = prepare_costs(
         snakemake.input.costs,
-        snakemake.config["costs"],
+        snakemake.params["costs"],
         Nyears,
     )
 
-    grouping_years_power = snakemake.config["existing_capacities"][
+    grouping_years_power = snakemake.params["existing_capacities"][
         "grouping_years_power"
     ]
-    grouping_years_heat = snakemake.config["existing_capacities"]["grouping_years_heat"]
+    grouping_years_heat = snakemake.params["existing_capacities"]["grouping_years_heat"]
     add_power_capacities_installed_before_baseyear(
         n, grouping_years_power, costs, baseyear
     )
@@ -650,7 +650,7 @@ if __name__ == "__main__":
             .to_pandas()
             .reindex(index=n.snapshots)
         )
-        default_lifetime = snakemake.config["costs"]["fill_values"]["lifetime"]
+        default_lifetime = snakemake.params["costs"]["fill_values"]["lifetime"]
         add_heating_capacities_installed_before_baseyear(
             n,
             baseyear,

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -615,7 +615,7 @@ if __name__ == "__main__":
     options = snakemake.params["sector"]
     opts = snakemake.wildcards.sector_opts.split("-")
 
-    baseyear = snakemake.params["scenario"]["planning_horizons"][0]
+    baseyear = snakemake.params["baseyear"]
 
     overrides = override_component_attrs(snakemake.input.overrides)
     n = pypsa.Network(snakemake.input.network, override_component_attrs=overrides)

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -157,7 +157,7 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
     # Fill missing DateOut
     dateout = (
         df_agg.loc[biomass_i, "DateIn"]
-        + snakemake.params["costs"]["fill_values"]["lifetime"]
+        + snakemake.params.costs["fill_values"]["lifetime"]
     )
     df_agg.loc[biomass_i, "DateOut"] = df_agg.loc[biomass_i, "DateOut"].fillna(dateout)
 
@@ -218,7 +218,7 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
         capacity = df.loc[grouping_year, generator]
         capacity = capacity[~capacity.isna()]
         capacity = capacity[
-            capacity > snakemake.params["existing_capacities"]["threshold_capacity"]
+            capacity > snakemake.params.existing_capacities["threshold_capacity"]
         ]
         suffix = "-ac" if generator == "offwind" else ""
         name_suffix = f" {generator}{suffix}-{grouping_year}"
@@ -582,7 +582,7 @@ def add_heating_capacities_installed_before_baseyear(
             )
 
             # delete links with capacities below threshold
-            threshold = snakemake.params["existing_capacities"]["threshold_capacity"]
+            threshold = snakemake.params.existing_capacities["threshold_capacity"]
             n.mremove(
                 "Link",
                 [
@@ -612,10 +612,10 @@ if __name__ == "__main__":
 
     update_config_with_sector_opts(snakemake.config, snakemake.wildcards.sector_opts)
 
-    options = snakemake.params["sector"]
+    options = snakemake.params.sector
     opts = snakemake.wildcards.sector_opts.split("-")
 
-    baseyear = snakemake.params["baseyear"]
+    baseyear = snakemake.params.baseyear
 
     overrides = override_component_attrs(snakemake.input.overrides)
     n = pypsa.Network(snakemake.input.network, override_component_attrs=overrides)
@@ -626,14 +626,12 @@ if __name__ == "__main__":
     Nyears = n.snapshot_weightings.generators.sum() / 8760.0
     costs = prepare_costs(
         snakemake.input.costs,
-        snakemake.params["costs"],
+        snakemake.params.costs,
         Nyears,
     )
 
-    grouping_years_power = snakemake.params["existing_capacities"][
-        "grouping_years_power"
-    ]
-    grouping_years_heat = snakemake.params["existing_capacities"]["grouping_years_heat"]
+    grouping_years_power = snakemake.params.existing_capacities["grouping_years_power"]
+    grouping_years_heat = snakemake.params.existing_capacities["grouping_years_heat"]
     add_power_capacities_installed_before_baseyear(
         n, grouping_years_power, costs, baseyear
     )
@@ -650,7 +648,7 @@ if __name__ == "__main__":
             .to_pandas()
             .reindex(index=n.snapshots)
         )
-        default_lifetime = snakemake.params["costs"]["fill_values"]["lifetime"]
+        default_lifetime = snakemake.params.costs["fill_values"]["lifetime"]
         add_heating_capacities_installed_before_baseyear(
             n,
             baseyear,

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -608,7 +608,7 @@ if __name__ == "__main__":
             planning_horizons=2020,
         )
 
-    logging.basicConfig(level=snakemake.params["logging"]["level"])
+    logging.basicConfig(level=snakemake.config["logging"]["level"])
 
     update_config_with_sector_opts(snakemake.config, snakemake.wildcards.sector_opts)
 

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -67,8 +67,8 @@ idx = pd.IndexSlice
 logger = logging.getLogger(__name__)
 
 
-def attach_storageunits(n, costs, ext_carriers, max_hours):
-    carriers = ext_carriers["StorageUnit"]
+def attach_storageunits(n, costs, extendable_carriers, max_hours):
+    carriers = extendable_carriers["StorageUnit"]
 
     _add_missing_carriers_from_costs(n, costs, carriers)
 
@@ -98,8 +98,8 @@ def attach_storageunits(n, costs, ext_carriers, max_hours):
         )
 
 
-def attach_stores(n, costs, ext_carriers):
-    carriers = ext_carriers["Store"]
+def attach_stores(n, costs, extendable_carriers):
+    carriers = extendable_carriers["Store"]
 
     _add_missing_carriers_from_costs(n, costs, carriers)
 
@@ -186,10 +186,10 @@ def attach_stores(n, costs, ext_carriers):
         )
 
 
-def attach_hydrogen_pipelines(n, costs, ext_carriers):
-    as_stores = ext_carriers.get("Store", [])
+def attach_hydrogen_pipelines(n, costs, extendable_carriers):
+    as_stores = extendable_carriers.get("Store", [])
 
-    if "H2 pipeline" not in ext_carriers.get("Link", []):
+    if "H2 pipeline" not in extendable_carriers.get("Link", []):
         return
 
     assert "H2" in as_stores, (
@@ -233,17 +233,17 @@ if __name__ == "__main__":
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)
-    ext_carriers = snakemake.params["ext_carriers"]
-    max_hours = snakemake.params["max_hours"]
+    extendable_carriers = snakemake.params.extendable_carriers
+    max_hours = snakemake.params.max_hours
 
     Nyears = n.snapshot_weightings.objective.sum() / 8760.0
     costs = load_costs(
-        snakemake.input.tech_costs, snakemake.params["costs"], max_hours, Nyears
+        snakemake.input.tech_costs, snakemake.params.costs, max_hours, Nyears
     )
 
-    attach_storageunits(n, costs, ext_carriers, max_hours)
-    attach_stores(n, costs, ext_carriers)
-    attach_hydrogen_pipelines(n, costs, ext_carriers)
+    attach_storageunits(n, costs, extendable_carriers, max_hours)
+    attach_stores(n, costs, extendable_carriers)
+    attach_hydrogen_pipelines(n, costs, extendable_carriers)
 
     add_nice_carrier_names(n, snakemake.config)
 

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -235,11 +235,11 @@ if __name__ == "__main__":
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)
-    elec_config = snakemake.config["electricity"]
+    elec_config = snakemake.params["electricity"]
 
     Nyears = n.snapshot_weightings.objective.sum() / 8760.0
     costs = load_costs(
-        snakemake.input.tech_costs, snakemake.config["costs"], elec_config, Nyears
+        snakemake.input.tech_costs, snakemake.params["costs"], elec_config, Nyears
     )
 
     attach_storageunits(n, costs, elec_config)

--- a/scripts/build_ammonia_production.py
+++ b/scripts/build_ammonia_production.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     ammonia.index = cc.convert(ammonia.index, to="iso2")
 
     years = [str(i) for i in range(2013, 2018)]
-    countries = ammonia.index.intersection(snakemake.config["countries"])
+    countries = ammonia.index.intersection(snakemake.params["countries"])
     ammonia = ammonia.loc[countries, years].astype(float)
 
     # convert from ktonN to ktonNH3

--- a/scripts/build_ammonia_production.py
+++ b/scripts/build_ammonia_production.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     ammonia.index = cc.convert(ammonia.index, to="iso2")
 
     years = [str(i) for i in range(2013, 2018)]
-    countries = ammonia.index.intersection(snakemake.params["countries"])
+    countries = ammonia.index.intersection(snakemake.params.countries)
     ammonia = ammonia.loc[countries, years].astype(float)
 
     # convert from ktonN to ktonNH3

--- a/scripts/build_biomass_potentials.py
+++ b/scripts/build_biomass_potentials.py
@@ -210,7 +210,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_biomass_potentials", simpl="", clusters="5")
 
-    params = snakemake.params["biomass"]
+    params = snakemake.params.biomass
     year = params["year"]
     scenario = params["scenario"]
 

--- a/scripts/build_biomass_potentials.py
+++ b/scripts/build_biomass_potentials.py
@@ -210,7 +210,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_biomass_potentials", simpl="", clusters="5")
 
-    config = snakemake.config["biomass"]
+    config = snakemake.params["biomass"]
     year = config["year"]
     scenario = config["scenario"]
 

--- a/scripts/build_biomass_potentials.py
+++ b/scripts/build_biomass_potentials.py
@@ -210,9 +210,9 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_biomass_potentials", simpl="", clusters="5")
 
-    config = snakemake.params["biomass"]
-    year = config["year"]
-    scenario = config["scenario"]
+    params = snakemake.params["biomass"]
+    year = params["year"]
+    scenario = params["scenario"]
 
     enspreso = enspreso_biomass_potentials(year, scenario)
 
@@ -228,7 +228,7 @@ if __name__ == "__main__":
 
     df.to_csv(snakemake.output.biomass_potentials_all)
 
-    grouper = {v: k for k, vv in config["classes"].items() for v in vv}
+    grouper = {v: k for k, vv in params["classes"].items() for v in vv}
     df = df.groupby(grouper, axis=1).sum()
 
     df *= 1e6  # TWh/a to MWh/a

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("build_bus_regions")
     configure_logging(snakemake)
 
-    countries = snakemake.config["countries"]
+    countries = snakemake.params["countries"]
 
     n = pypsa.Network(snakemake.input.base_network)
 

--- a/scripts/build_bus_regions.py
+++ b/scripts/build_bus_regions.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("build_bus_regions")
     configure_logging(snakemake)
 
-    countries = snakemake.params["countries"]
+    countries = snakemake.params.countries
 
     n = pypsa.Network(snakemake.input.base_network)
 

--- a/scripts/build_cop_profiles.py
+++ b/scripts/build_cop_profiles.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         for source in ["air", "soil"]:
             source_T = xr.open_dataarray(snakemake.input[f"temp_{source}_{area}"])
 
-            delta_T = snakemake.params["sector"]["heat_pump_sink_T"] - source_T
+            delta_T = snakemake.params["heat_pump_sink_T"] - source_T
 
             cop = coefficient_of_performance(delta_T, source)
 

--- a/scripts/build_cop_profiles.py
+++ b/scripts/build_cop_profiles.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         for source in ["air", "soil"]:
             source_T = xr.open_dataarray(snakemake.input[f"temp_{source}_{area}"])
 
-            delta_T = snakemake.config["sector"]["heat_pump_sink_T"] - source_T
+            delta_T = snakemake.params["sector"]["heat_pump_sink_T"] - source_T
 
             cop = coefficient_of_performance(delta_T, source)
 

--- a/scripts/build_cop_profiles.py
+++ b/scripts/build_cop_profiles.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         for source in ["air", "soil"]:
             source_T = xr.open_dataarray(snakemake.input[f"temp_{source}_{area}"])
 
-            delta_T = snakemake.params["heat_pump_sink_T"] - source_T
+            delta_T = snakemake.params.heat_pump_sink_T - source_T
 
             cop = coefficient_of_performance(delta_T, source)
 

--- a/scripts/build_cutout.py
+++ b/scripts/build_cutout.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("build_cutout", cutout="europe-2013-era5")
     configure_logging(snakemake)
 
-    cutout_params = snakemake.params["atlite"]["cutouts"][snakemake.wildcards.cutout]
+    cutout_params = snakemake.params["cutouts"][snakemake.wildcards.cutout]
 
     snapshots = pd.date_range(freq="h", **snakemake.params["snapshots"])
     time = [snapshots[0], snapshots[-1]]

--- a/scripts/build_cutout.py
+++ b/scripts/build_cutout.py
@@ -106,9 +106,9 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("build_cutout", cutout="europe-2013-era5")
     configure_logging(snakemake)
 
-    cutout_params = snakemake.config["atlite"]["cutouts"][snakemake.wildcards.cutout]
+    cutout_params = snakemake.params["atlite"]["cutouts"][snakemake.wildcards.cutout]
 
-    snapshots = pd.date_range(freq="h", **snakemake.config["snapshots"])
+    snapshots = pd.date_range(freq="h", **snakemake.params["snapshots"])
     time = [snapshots[0], snapshots[-1]]
     cutout_params["time"] = slice(*cutout_params.get("time", time))
 

--- a/scripts/build_cutout.py
+++ b/scripts/build_cutout.py
@@ -106,9 +106,9 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("build_cutout", cutout="europe-2013-era5")
     configure_logging(snakemake)
 
-    cutout_params = snakemake.params["cutouts"][snakemake.wildcards.cutout]
+    cutout_params = snakemake.params.cutouts[snakemake.wildcards.cutout]
 
-    snapshots = pd.date_range(freq="h", **snakemake.params["snapshots"])
+    snapshots = pd.date_range(freq="h", **snakemake.params.snapshots)
     time = [snapshots[0], snapshots[-1]]
     cutout_params["time"] = slice(*cutout_params.get("time", time))
 

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -279,16 +279,16 @@ if __name__ == "__main__":
 
     configure_logging(snakemake)
 
-    powerstatistics = snakemake.params["load"]["power_statistics"]
-    interpolate_limit = snakemake.params["load"]["interpolate_limit"]
-    countries = snakemake.params["countries"]
-    snapshots = pd.date_range(freq="h", **snakemake.params["snapshots"])
+    powerstatistics = snakemake.params.load["power_statistics"]
+    interpolate_limit = snakemake.params.load["interpolate_limit"]
+    countries = snakemake.params.countries
+    snapshots = pd.date_range(freq="h", **snakemake.params.snapshots)
     years = slice(snapshots[0], snapshots[-1])
-    time_shift = snakemake.params["load"]["time_shift_for_large_gaps"]
+    time_shift = snakemake.params.load["time_shift_for_large_gaps"]
 
     load = load_timeseries(snakemake.input[0], years, countries, powerstatistics)
 
-    if snakemake.params["load"]["manual_adjustments"]:
+    if snakemake.params.load["manual_adjustments"]:
         load = manual_adjustment(load, snakemake.input[0], powerstatistics)
 
     logger.info(f"Linearly interpolate gaps of size {interpolate_limit} and less.")

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -279,16 +279,16 @@ if __name__ == "__main__":
 
     configure_logging(snakemake)
 
-    powerstatistics = snakemake.config["load"]["power_statistics"]
-    interpolate_limit = snakemake.config["load"]["interpolate_limit"]
-    countries = snakemake.config["countries"]
-    snapshots = pd.date_range(freq="h", **snakemake.config["snapshots"])
+    powerstatistics = snakemake.params["load"]["power_statistics"]
+    interpolate_limit = snakemake.params["load"]["interpolate_limit"]
+    countries = snakemake.params["countries"]
+    snapshots = pd.date_range(freq="h", **snakemake.params["snapshots"])
     years = slice(snapshots[0], snapshots[-1])
-    time_shift = snakemake.config["load"]["time_shift_for_large_gaps"]
+    time_shift = snakemake.params["load"]["time_shift_for_large_gaps"]
 
     load = load_timeseries(snakemake.input[0], years, countries, powerstatistics)
 
-    if snakemake.config["load"]["manual_adjustments"]:
+    if snakemake.params["load"]["manual_adjustments"]:
         load = manual_adjustment(load, snakemake.input[0], powerstatistics)
 
     logger.info(f"Linearly interpolate gaps of size {interpolate_limit} and less.")

--- a/scripts/build_energy_totals.py
+++ b/scripts/build_energy_totals.py
@@ -737,7 +737,7 @@ if __name__ == "__main__":
 
     logging.basicConfig(level=snakemake.config["logging"]["level"])
 
-    config = snakemake.params["energy"]
+    params = snakemake.params["energy"]
 
     nuts3 = gpd.read_file(snakemake.input.nuts3_shapes).set_index("index")
     population = nuts3["pop"].groupby(nuts3.country).sum()
@@ -745,7 +745,7 @@ if __name__ == "__main__":
     countries = snakemake.params["countries"]
     idees_countries = pd.Index(countries).intersection(eu28)
 
-    data_year = config["energy_totals_year"]
+    data_year = params["energy_totals_year"]
     report_year = snakemake.params["energy"]["eurostat_report_year"]
     input_eurostat = snakemake.input.eurostat
     eurostat = build_eurostat(input_eurostat, countries, report_year, data_year)
@@ -755,7 +755,7 @@ if __name__ == "__main__":
     energy = build_energy_totals(countries, eurostat, swiss, idees)
     energy.to_csv(snakemake.output.energy_name)
 
-    base_year_emissions = config["base_emissions_year"]
+    base_year_emissions = params["base_emissions_year"]
     emissions_scope = snakemake.params["energy"]["emissions"]
     eea_co2 = build_eea_co2(snakemake.input.co2, base_year_emissions, emissions_scope)
     eurostat_co2 = build_eurostat_co2(

--- a/scripts/build_energy_totals.py
+++ b/scripts/build_energy_totals.py
@@ -737,16 +737,16 @@ if __name__ == "__main__":
 
     logging.basicConfig(level=snakemake.config["logging"]["level"])
 
-    params = snakemake.params["energy"]
+    params = snakemake.params.energy
 
     nuts3 = gpd.read_file(snakemake.input.nuts3_shapes).set_index("index")
     population = nuts3["pop"].groupby(nuts3.country).sum()
 
-    countries = snakemake.params["countries"]
+    countries = snakemake.params.countries
     idees_countries = pd.Index(countries).intersection(eu28)
 
     data_year = params["energy_totals_year"]
-    report_year = snakemake.params["energy"]["eurostat_report_year"]
+    report_year = snakemake.params.energy["eurostat_report_year"]
     input_eurostat = snakemake.input.eurostat
     eurostat = build_eurostat(input_eurostat, countries, report_year, data_year)
     swiss = build_swiss(data_year)
@@ -756,7 +756,7 @@ if __name__ == "__main__":
     energy.to_csv(snakemake.output.energy_name)
 
     base_year_emissions = params["base_emissions_year"]
-    emissions_scope = snakemake.params["energy"]["emissions"]
+    emissions_scope = snakemake.params.energy["emissions"]
     eea_co2 = build_eea_co2(snakemake.input.co2, base_year_emissions, emissions_scope)
     eurostat_co2 = build_eurostat_co2(
         input_eurostat, countries, report_year, base_year_emissions

--- a/scripts/build_energy_totals.py
+++ b/scripts/build_energy_totals.py
@@ -373,7 +373,7 @@ def idees_per_country(ct, year, base_dir):
 
 def build_idees(countries, year):
     nprocesses = snakemake.threads
-    disable_progress = snakemake.params["run"].get("disable_progressbar", False)
+    disable_progress = snakemake.config["run"].get("disable_progressbar", False)
 
     func = partial(idees_per_country, year=year, base_dir=snakemake.input.idees)
     tqdm_kwargs = dict(
@@ -735,7 +735,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_energy_totals")
 
-    logging.basicConfig(level=snakemake.params["logging"]["level"])
+    logging.basicConfig(level=snakemake.config["logging"]["level"])
 
     config = snakemake.params["energy"]
 

--- a/scripts/build_energy_totals.py
+++ b/scripts/build_energy_totals.py
@@ -373,7 +373,7 @@ def idees_per_country(ct, year, base_dir):
 
 def build_idees(countries, year):
     nprocesses = snakemake.threads
-    disable_progress = snakemake.config["run"].get("disable_progressbar", False)
+    disable_progress = snakemake.params["run"].get("disable_progressbar", False)
 
     func = partial(idees_per_country, year=year, base_dir=snakemake.input.idees)
     tqdm_kwargs = dict(
@@ -735,18 +735,18 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_energy_totals")
 
-    logging.basicConfig(level=snakemake.config["logging"]["level"])
+    logging.basicConfig(level=snakemake.params["logging"]["level"])
 
-    config = snakemake.config["energy"]
+    config = snakemake.params["energy"]
 
     nuts3 = gpd.read_file(snakemake.input.nuts3_shapes).set_index("index")
     population = nuts3["pop"].groupby(nuts3.country).sum()
 
-    countries = snakemake.config["countries"]
+    countries = snakemake.params["countries"]
     idees_countries = pd.Index(countries).intersection(eu28)
 
     data_year = config["energy_totals_year"]
-    report_year = snakemake.config["energy"]["eurostat_report_year"]
+    report_year = snakemake.params["energy"]["eurostat_report_year"]
     input_eurostat = snakemake.input.eurostat
     eurostat = build_eurostat(input_eurostat, countries, report_year, data_year)
     swiss = build_swiss(data_year)
@@ -756,7 +756,7 @@ if __name__ == "__main__":
     energy.to_csv(snakemake.output.energy_name)
 
     base_year_emissions = config["base_emissions_year"]
-    emissions_scope = snakemake.config["energy"]["emissions"]
+    emissions_scope = snakemake.params["energy"]["emissions"]
     eea_co2 = build_eea_co2(snakemake.input.co2, base_year_emissions, emissions_scope)
     eurostat_co2 = build_eurostat_co2(
         input_eurostat, countries, report_year, base_year_emissions

--- a/scripts/build_gas_input_locations.py
+++ b/scripts/build_gas_input_locations.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
             clusters="37",
         )
 
-    logging.basicConfig(level=snakemake.params["logging"]["level"])
+    logging.basicConfig(level=snakemake.config["logging"]["level"])
 
     regions = load_bus_regions(
         snakemake.input.regions_onshore, snakemake.input.regions_offshore

--- a/scripts/build_gas_input_locations.py
+++ b/scripts/build_gas_input_locations.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
             clusters="37",
         )
 
-    logging.basicConfig(level=snakemake.config["logging"]["level"])
+    logging.basicConfig(level=snakemake.params["logging"]["level"])
 
     regions = load_bus_regions(
         snakemake.input.regions_onshore, snakemake.input.regions_offshore

--- a/scripts/build_gas_network.py
+++ b/scripts/build_gas_network.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_gas_network")
 
-    logging.basicConfig(level=snakemake.config["logging"]["level"])
+    logging.basicConfig(level=snakemake.params["logging"]["level"])
 
     gas_network = load_dataset(snakemake.input.gas_network)
 

--- a/scripts/build_gas_network.py
+++ b/scripts/build_gas_network.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_gas_network")
 
-    logging.basicConfig(level=snakemake.params["logging"]["level"])
+    logging.basicConfig(level=snakemake.config["logging"]["level"])
 
     gas_network = load_dataset(snakemake.input.gas_network)
 

--- a/scripts/build_heat_demand.py
+++ b/scripts/build_heat_demand.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     cluster = LocalCluster(n_workers=nprocesses, threads_per_worker=1)
     client = Client(cluster, asynchronous=True)
 
-    time = pd.date_range(freq="h", **snakemake.config["snapshots"])
+    time = pd.date_range(freq="h", **snakemake.params["snapshots"])
     cutout = atlite.Cutout(snakemake.input.cutout).sel(time=time)
 
     clustered_regions = (

--- a/scripts/build_heat_demand.py
+++ b/scripts/build_heat_demand.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     cluster = LocalCluster(n_workers=nprocesses, threads_per_worker=1)
     client = Client(cluster, asynchronous=True)
 
-    time = pd.date_range(freq="h", **snakemake.params["snapshots"])
+    time = pd.date_range(freq="h", **snakemake.params.snapshots)
     cutout = atlite.Cutout(snakemake.input.cutout).sel(time=time)
 
     clustered_regions = (

--- a/scripts/build_hydro_profile.py
+++ b/scripts/build_hydro_profile.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("build_hydro_profile")
     configure_logging(snakemake)
 
-    params_hydro = snakemake.params["renewable"]["hydro"]
+    params_hydro = snakemake.params["hydro"]
     cutout = atlite.Cutout(snakemake.input.cutout)
 
     countries = snakemake.params["countries"]

--- a/scripts/build_hydro_profile.py
+++ b/scripts/build_hydro_profile.py
@@ -130,10 +130,10 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("build_hydro_profile")
     configure_logging(snakemake)
 
-    config_hydro = snakemake.config["renewable"]["hydro"]
+    config_hydro = snakemake.params["renewable"]["hydro"]
     cutout = atlite.Cutout(snakemake.input.cutout)
 
-    countries = snakemake.config["countries"]
+    countries = snakemake.params["countries"]
     country_shapes = (
         gpd.read_file(snakemake.input.country_shapes)
         .set_index("name")["geometry"]

--- a/scripts/build_hydro_profile.py
+++ b/scripts/build_hydro_profile.py
@@ -130,10 +130,10 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("build_hydro_profile")
     configure_logging(snakemake)
 
-    params_hydro = snakemake.params["hydro"]
+    params_hydro = snakemake.params.hydro
     cutout = atlite.Cutout(snakemake.input.cutout)
 
-    countries = snakemake.params["countries"]
+    countries = snakemake.params.countries
     country_shapes = (
         gpd.read_file(snakemake.input.country_shapes)
         .set_index("name")["geometry"]

--- a/scripts/build_hydro_profile.py
+++ b/scripts/build_hydro_profile.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("build_hydro_profile")
     configure_logging(snakemake)
 
-    config_hydro = snakemake.params["renewable"]["hydro"]
+    params_hydro = snakemake.params["renewable"]["hydro"]
     cutout = atlite.Cutout(snakemake.input.cutout)
 
     countries = snakemake.params["countries"]
@@ -151,7 +151,7 @@ if __name__ == "__main__":
         normalize_using_yearly=eia_stats,
     )
 
-    if "clip_min_inflow" in config_hydro:
-        inflow = inflow.where(inflow > config_hydro["clip_min_inflow"], 0)
+    if "clip_min_inflow" in params_hydro:
+        inflow = inflow.where(inflow > params_hydro["clip_min_inflow"], 0)
 
     inflow.to_netcdf(snakemake.output[0])

--- a/scripts/build_industrial_distribution_key.py
+++ b/scripts/build_industrial_distribution_key.py
@@ -73,7 +73,7 @@ def prepare_hotmaps_database(regions):
 
     df[["srid", "coordinates"]] = df.geom.str.split(";", expand=True)
 
-    if snakemake.params["industry"].get("hotmaps_locate_missing", False):
+    if snakemake.params["hotmaps_locate_missing"]:
         df = locate_missing_industrial_sites(df)
 
     # remove those sites without valid locations

--- a/scripts/build_industrial_distribution_key.py
+++ b/scripts/build_industrial_distribution_key.py
@@ -141,7 +141,7 @@ if __name__ == "__main__":
             clusters=48,
         )
 
-    logging.basicConfig(level=snakemake.params["logging"]["level"])
+    logging.basicConfig(level=snakemake.config["logging"]["level"])
 
     countries = snakemake.params["countries"]
 

--- a/scripts/build_industrial_distribution_key.py
+++ b/scripts/build_industrial_distribution_key.py
@@ -73,7 +73,7 @@ def prepare_hotmaps_database(regions):
 
     df[["srid", "coordinates"]] = df.geom.str.split(";", expand=True)
 
-    if snakemake.params["hotmaps_locate_missing"]:
+    if snakemake.params.hotmaps_locate_missing:
         df = locate_missing_industrial_sites(df)
 
     # remove those sites without valid locations
@@ -143,7 +143,7 @@ if __name__ == "__main__":
 
     logging.basicConfig(level=snakemake.config["logging"]["level"])
 
-    countries = snakemake.params["countries"]
+    countries = snakemake.params.countries
 
     regions = gpd.read_file(snakemake.input.regions_onshore).set_index("name")
 

--- a/scripts/build_industrial_distribution_key.py
+++ b/scripts/build_industrial_distribution_key.py
@@ -73,7 +73,7 @@ def prepare_hotmaps_database(regions):
 
     df[["srid", "coordinates"]] = df.geom.str.split(";", expand=True)
 
-    if snakemake.config["industry"].get("hotmaps_locate_missing", False):
+    if snakemake.params["industry"].get("hotmaps_locate_missing", False):
         df = locate_missing_industrial_sites(df)
 
     # remove those sites without valid locations
@@ -141,9 +141,9 @@ if __name__ == "__main__":
             clusters=48,
         )
 
-    logging.basicConfig(level=snakemake.config["logging"]["level"])
+    logging.basicConfig(level=snakemake.params["logging"]["level"])
 
-    countries = snakemake.config["countries"]
+    countries = snakemake.params["countries"]
 
     regions = gpd.read_file(snakemake.input.regions_onshore).set_index("name")
 

--- a/scripts/build_industrial_energy_demand_per_country_today.py
+++ b/scripts/build_industrial_energy_demand_per_country_today.py
@@ -101,8 +101,8 @@ def add_ammonia_energy_demand(demand):
 
     def get_ammonia_by_fuel(x):
         fuels = {
-            "gas": config["MWh_CH4_per_tNH3_SMR"],
-            "electricity": config["MWh_elec_per_tNH3_SMR"],
+            "gas": params["MWh_CH4_per_tNH3_SMR"],
+            "electricity": params["MWh_elec_per_tNH3_SMR"],
         }
 
         return pd.Series({k: x * v for k, v in fuels.items()})
@@ -112,7 +112,7 @@ def add_ammonia_energy_demand(demand):
         index=demand.index, fill_value=0.0
     )
 
-    ammonia = pd.DataFrame({"ammonia": ammonia * config["MWh_NH3_per_tNH3"]}).T
+    ammonia = pd.DataFrame({"ammonia": ammonia * params["MWh_NH3_per_tNH3"]}).T
 
     demand["Ammonia"] = ammonia.unstack().reindex(index=demand.index, fill_value=0.0)
 
@@ -178,8 +178,8 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_industrial_energy_demand_per_country_today")
 
-    config = snakemake.params["industry"]
-    year = config.get("reference_year", 2015)
+    params = snakemake.params["industry"]
+    year = params.get("reference_year", 2015)
     countries = pd.Index(snakemake.params["countries"])
 
     demand = industrial_energy_demand(countries.intersection(eu28), year)

--- a/scripts/build_industrial_energy_demand_per_country_today.py
+++ b/scripts/build_industrial_energy_demand_per_country_today.py
@@ -153,7 +153,7 @@ def add_non_eu28_industrial_energy_demand(countries, demand):
 
 def industrial_energy_demand(countries, year):
     nprocesses = snakemake.threads
-    disable_progress = snakemake.config["run"].get("disable_progressbar", False)
+    disable_progress = snakemake.params["run"].get("disable_progressbar", False)
     func = partial(
         industrial_energy_demand_per_country, year=year, jrc_dir=snakemake.input.jrc
     )
@@ -178,9 +178,9 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_industrial_energy_demand_per_country_today")
 
-    config = snakemake.config["industry"]
+    config = snakemake.params["industry"]
     year = config.get("reference_year", 2015)
-    countries = pd.Index(snakemake.config["countries"])
+    countries = pd.Index(snakemake.params["countries"])
 
     demand = industrial_energy_demand(countries.intersection(eu28), year)
 

--- a/scripts/build_industrial_energy_demand_per_country_today.py
+++ b/scripts/build_industrial_energy_demand_per_country_today.py
@@ -178,9 +178,9 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_industrial_energy_demand_per_country_today")
 
-    params = snakemake.params["industry"]
+    params = snakemake.params.industry
     year = params.get("reference_year", 2015)
-    countries = pd.Index(snakemake.params["countries"])
+    countries = pd.Index(snakemake.params.countries)
 
     demand = industrial_energy_demand(countries.intersection(eu28), year)
 

--- a/scripts/build_industrial_energy_demand_per_country_today.py
+++ b/scripts/build_industrial_energy_demand_per_country_today.py
@@ -153,7 +153,7 @@ def add_non_eu28_industrial_energy_demand(countries, demand):
 
 def industrial_energy_demand(countries, year):
     nprocesses = snakemake.threads
-    disable_progress = snakemake.params["run"].get("disable_progressbar", False)
+    disable_progress = snakemake.config["run"].get("disable_progressbar", False)
     func = partial(
         industrial_energy_demand_per_country, year=year, jrc_dir=snakemake.input.jrc
     )

--- a/scripts/build_industrial_production_per_country.py
+++ b/scripts/build_industrial_production_per_country.py
@@ -279,11 +279,11 @@ if __name__ == "__main__":
 
     logging.basicConfig(level=snakemake.config["logging"]["level"])
 
-    countries = snakemake.params["countries"]
+    countries = snakemake.params.countries
 
-    year = snakemake.params["industry"]["reference_year"]
+    year = snakemake.params.industry["reference_year"]
 
-    params = snakemake.params["industry"]
+    params = snakemake.params.industry
 
     jrc_dir = snakemake.input.jrc
     eurostat_dir = snakemake.input.eurostat

--- a/scripts/build_industrial_production_per_country.py
+++ b/scripts/build_industrial_production_per_country.py
@@ -217,7 +217,7 @@ def industry_production_per_country(country, year, eurostat_dir, jrc_dir):
 
 def industry_production(countries, year, eurostat_dir, jrc_dir):
     nprocesses = snakemake.threads
-    disable_progress = snakemake.params["run"].get("disable_progressbar", False)
+    disable_progress = snakemake.config["run"].get("disable_progressbar", False)
 
     func = partial(
         industry_production_per_country,
@@ -277,7 +277,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_industrial_production_per_country")
 
-    logging.basicConfig(level=snakemake.params["logging"]["level"])
+    logging.basicConfig(level=snakemake.config["logging"]["level"])
 
     countries = snakemake.params["countries"]
 

--- a/scripts/build_industrial_production_per_country.py
+++ b/scripts/build_industrial_production_per_country.py
@@ -217,7 +217,7 @@ def industry_production_per_country(country, year, eurostat_dir, jrc_dir):
 
 def industry_production(countries, year, eurostat_dir, jrc_dir):
     nprocesses = snakemake.threads
-    disable_progress = snakemake.config["run"].get("disable_progressbar", False)
+    disable_progress = snakemake.params["run"].get("disable_progressbar", False)
 
     func = partial(
         industry_production_per_country,
@@ -277,13 +277,13 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_industrial_production_per_country")
 
-    logging.basicConfig(level=snakemake.config["logging"]["level"])
+    logging.basicConfig(level=snakemake.params["logging"]["level"])
 
-    countries = snakemake.config["countries"]
+    countries = snakemake.params["countries"]
 
-    year = snakemake.config["industry"]["reference_year"]
+    year = snakemake.params["industry"]["reference_year"]
 
-    config = snakemake.config["industry"]
+    config = snakemake.params["industry"]
 
     jrc_dir = snakemake.input.jrc
     eurostat_dir = snakemake.input.eurostat

--- a/scripts/build_industrial_production_per_country.py
+++ b/scripts/build_industrial_production_per_country.py
@@ -264,9 +264,9 @@ def separate_basic_chemicals(demand, year):
 
     # assume HVC, methanol, chlorine production proportional to non-ammonia basic chemicals
     distribution_key = demand["Basic chemicals"] / demand["Basic chemicals"].sum()
-    demand["HVC"] = config["HVC_production_today"] * 1e3 * distribution_key
-    demand["Chlorine"] = config["chlorine_production_today"] * 1e3 * distribution_key
-    demand["Methanol"] = config["methanol_production_today"] * 1e3 * distribution_key
+    demand["HVC"] = params["HVC_production_today"] * 1e3 * distribution_key
+    demand["Chlorine"] = params["chlorine_production_today"] * 1e3 * distribution_key
+    demand["Methanol"] = params["methanol_production_today"] * 1e3 * distribution_key
 
     demand.drop(columns=["Basic chemicals"], inplace=True)
 
@@ -283,7 +283,7 @@ if __name__ == "__main__":
 
     year = snakemake.params["industry"]["reference_year"]
 
-    config = snakemake.params["industry"]
+    params = snakemake.params["industry"]
 
     jrc_dir = snakemake.input.jrc
     eurostat_dir = snakemake.input.eurostat

--- a/scripts/build_industrial_production_per_country_tomorrow.py
+++ b/scripts/build_industrial_production_per_country_tomorrow.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_industrial_production_per_country_tomorrow")
 
-    config = snakemake.params["industry"]
+    params = snakemake.params["industry"]
 
     investment_year = int(snakemake.wildcards.planning_horizons)
 
@@ -25,8 +25,8 @@ if __name__ == "__main__":
     keys = ["Integrated steelworks", "Electric arc"]
     total_steel = production[keys].sum(axis=1)
 
-    st_primary_fraction = get(config["St_primary_fraction"], investment_year)
-    dri_fraction = get(config["DRI_fraction"], investment_year)
+    st_primary_fraction = get(params["St_primary_fraction"], investment_year)
+    dri_fraction = get(params["DRI_fraction"], investment_year)
     int_steel = production["Integrated steelworks"].sum()
     fraction_persistent_primary = st_primary_fraction * total_steel.sum() / int_steel
 
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     key_pri = "Aluminium - primary production"
     key_sec = "Aluminium - secondary production"
 
-    al_primary_fraction = get(config["Al_primary_fraction"], investment_year)
+    al_primary_fraction = get(params["Al_primary_fraction"], investment_year)
     fraction_persistent_primary = (
         al_primary_fraction * total_aluminium.sum() / production[key_pri].sum()
     )
@@ -60,15 +60,15 @@ if __name__ == "__main__":
     production[key_sec] = total_aluminium - production[key_pri]
 
     production["HVC (mechanical recycling)"] = (
-        get(config["HVC_mechanical_recycling_fraction"], investment_year)
+        get(params["HVC_mechanical_recycling_fraction"], investment_year)
         * production["HVC"]
     )
     production["HVC (chemical recycling)"] = (
-        get(config["HVC_chemical_recycling_fraction"], investment_year)
+        get(params["HVC_chemical_recycling_fraction"], investment_year)
         * production["HVC"]
     )
 
-    production["HVC"] *= get(config["HVC_primary_fraction"], investment_year)
+    production["HVC"] *= get(params["HVC_primary_fraction"], investment_year)
 
     fn = snakemake.output.industrial_production_per_country_tomorrow
     production.to_csv(fn, float_format="%.2f")

--- a/scripts/build_industrial_production_per_country_tomorrow.py
+++ b/scripts/build_industrial_production_per_country_tomorrow.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_industrial_production_per_country_tomorrow")
 
-    config = snakemake.config["industry"]
+    config = snakemake.params["industry"]
 
     investment_year = int(snakemake.wildcards.planning_horizons)
 

--- a/scripts/build_industrial_production_per_country_tomorrow.py
+++ b/scripts/build_industrial_production_per_country_tomorrow.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_industrial_production_per_country_tomorrow")
 
-    params = snakemake.params["industry"]
+    params = snakemake.params.industry
 
     investment_year = int(snakemake.wildcards.planning_horizons)
 

--- a/scripts/build_industry_sector_ratios.py
+++ b/scripts/build_industry_sector_ratios.py
@@ -185,10 +185,10 @@ def iron_and_steel():
     df[sector] = df["Electric arc"]
 
     # add H2 consumption for DRI at 1.7 MWh H2 /ton steel
-    df.at["hydrogen", sector] = config["H2_DRI"]
+    df.at["hydrogen", sector] = params["H2_DRI"]
 
     # add electricity consumption in DRI shaft (0.322 MWh/tSl)
-    df.at["elec", sector] += config["elec_DRI"]
+    df.at["elec", sector] += params["elec_DRI"]
 
     ## Integrated steelworks
     # could be used in combination with CCS)
@@ -383,19 +383,19 @@ def chemicals_industry():
     assert s_emi.index[0] == sector
 
     # convert from MtHVC/a to ktHVC/a
-    s_out = config["HVC_production_today"] * 1e3
+    s_out = params["HVC_production_today"] * 1e3
 
     # tCO2/t material
     df.loc["process emission", sector] += (
         s_emi["Process emissions"]
-        - config["petrochemical_process_emissions"] * 1e3
-        - config["NH3_process_emissions"] * 1e3
+        - params["petrochemical_process_emissions"] * 1e3
+        - params["NH3_process_emissions"] * 1e3
     ) / s_out
 
     # emissions originating from feedstock, could be non-fossil origin
     # tCO2/t material
     df.loc["process emission from feedstock", sector] += (
-        config["petrochemical_process_emissions"] * 1e3
+        params["petrochemical_process_emissions"] * 1e3
     ) / s_out
 
     # convert from ktoe/a to GWh/a
@@ -405,18 +405,18 @@ def chemicals_industry():
     # subtract ammonia energy demand (in ktNH3/a)
     ammonia = pd.read_csv(snakemake.input.ammonia_production, index_col=0)
     ammonia_total = ammonia.loc[ammonia.index.intersection(eu28), str(year)].sum()
-    df.loc["methane", sector] -= ammonia_total * config["MWh_CH4_per_tNH3_SMR"]
-    df.loc["elec", sector] -= ammonia_total * config["MWh_elec_per_tNH3_SMR"]
+    df.loc["methane", sector] -= ammonia_total * params["MWh_CH4_per_tNH3_SMR"]
+    df.loc["elec", sector] -= ammonia_total * params["MWh_elec_per_tNH3_SMR"]
 
     # subtract chlorine demand
-    chlorine_total = config["chlorine_production_today"]
-    df.loc["hydrogen", sector] -= chlorine_total * config["MWh_H2_per_tCl"]
-    df.loc["elec", sector] -= chlorine_total * config["MWh_elec_per_tCl"]
+    chlorine_total = params["chlorine_production_today"]
+    df.loc["hydrogen", sector] -= chlorine_total * params["MWh_H2_per_tCl"]
+    df.loc["elec", sector] -= chlorine_total * params["MWh_elec_per_tCl"]
 
     # subtract methanol demand
-    methanol_total = config["methanol_production_today"]
-    df.loc["methane", sector] -= methanol_total * config["MWh_CH4_per_tMeOH"]
-    df.loc["elec", sector] -= methanol_total * config["MWh_elec_per_tMeOH"]
+    methanol_total = params["methanol_production_today"]
+    df.loc["methane", sector] -= methanol_total * params["MWh_CH4_per_tMeOH"]
+    df.loc["elec", sector] -= methanol_total * params["MWh_elec_per_tMeOH"]
 
     # MWh/t material
     df.loc[sources, sector] = df.loc[sources, sector] / s_out
@@ -427,37 +427,37 @@ def chemicals_industry():
 
     sector = "HVC (mechanical recycling)"
     df[sector] = 0.0
-    df.loc["elec", sector] = config["MWh_elec_per_tHVC_mechanical_recycling"]
+    df.loc["elec", sector] = params["MWh_elec_per_tHVC_mechanical_recycling"]
 
     # HVC chemical recycling
 
     sector = "HVC (chemical recycling)"
     df[sector] = 0.0
-    df.loc["elec", sector] = config["MWh_elec_per_tHVC_chemical_recycling"]
+    df.loc["elec", sector] = params["MWh_elec_per_tHVC_chemical_recycling"]
 
     # Ammonia
 
     sector = "Ammonia"
     df[sector] = 0.0
     if snakemake.params["sector"].get("ammonia", False):
-        df.loc["ammonia", sector] = config["MWh_NH3_per_tNH3"]
+        df.loc["ammonia", sector] = params["MWh_NH3_per_tNH3"]
     else:
-        df.loc["hydrogen", sector] = config["MWh_H2_per_tNH3_electrolysis"]
-        df.loc["elec", sector] = config["MWh_elec_per_tNH3_electrolysis"]
+        df.loc["hydrogen", sector] = params["MWh_H2_per_tNH3_electrolysis"]
+        df.loc["elec", sector] = params["MWh_elec_per_tNH3_electrolysis"]
 
     # Chlorine
 
     sector = "Chlorine"
     df[sector] = 0.0
-    df.loc["hydrogen", sector] = config["MWh_H2_per_tCl"]
-    df.loc["elec", sector] = config["MWh_elec_per_tCl"]
+    df.loc["hydrogen", sector] = params["MWh_H2_per_tCl"]
+    df.loc["elec", sector] = params["MWh_elec_per_tCl"]
 
     # Methanol
 
     sector = "Methanol"
     df[sector] = 0.0
-    df.loc["methane", sector] = config["MWh_CH4_per_tMeOH"]
-    df.loc["elec", sector] = config["MWh_elec_per_tMeOH"]
+    df.loc["methane", sector] = params["MWh_CH4_per_tMeOH"]
+    df.loc["elec", sector] = params["MWh_elec_per_tMeOH"]
 
     # Other chemicals
 
@@ -1465,10 +1465,10 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_industry_sector_ratios")
 
-    # TODO make config option
+    # TODO make params option
     year = 2015
 
-    config = snakemake.params["industry"]
+    params = snakemake.params["industry"]
 
     df = pd.concat(
         [

--- a/scripts/build_industry_sector_ratios.py
+++ b/scripts/build_industry_sector_ratios.py
@@ -439,7 +439,7 @@ def chemicals_industry():
 
     sector = "Ammonia"
     df[sector] = 0.0
-    if snakemake.params["sector"].get("ammonia", False):
+    if snakemake.params["sector_amonia"]:
         df.loc["ammonia", sector] = params["MWh_NH3_per_tNH3"]
     else:
         df.loc["hydrogen", sector] = params["MWh_H2_per_tNH3_electrolysis"]

--- a/scripts/build_industry_sector_ratios.py
+++ b/scripts/build_industry_sector_ratios.py
@@ -439,7 +439,7 @@ def chemicals_industry():
 
     sector = "Ammonia"
     df[sector] = 0.0
-    if snakemake.config["sector"].get("ammonia", False):
+    if snakemake.params["sector"].get("ammonia", False):
         df.loc["ammonia", sector] = config["MWh_NH3_per_tNH3"]
     else:
         df.loc["hydrogen", sector] = config["MWh_H2_per_tNH3_electrolysis"]
@@ -1468,7 +1468,7 @@ if __name__ == "__main__":
     # TODO make config option
     year = 2015
 
-    config = snakemake.config["industry"]
+    config = snakemake.params["industry"]
 
     df = pd.concat(
         [

--- a/scripts/build_industry_sector_ratios.py
+++ b/scripts/build_industry_sector_ratios.py
@@ -439,7 +439,7 @@ def chemicals_industry():
 
     sector = "Ammonia"
     df[sector] = 0.0
-    if snakemake.params["sector_amonia"]:
+    if snakemake.params.ammonia:
         df.loc["ammonia", sector] = params["MWh_NH3_per_tNH3"]
     else:
         df.loc["hydrogen", sector] = params["MWh_H2_per_tNH3_electrolysis"]
@@ -1468,7 +1468,7 @@ if __name__ == "__main__":
     # TODO make params option
     year = 2015
 
-    params = snakemake.params["industry"]
+    params = snakemake.params.industry
 
     df = pd.concat(
         [

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_population_layouts")
 
-    logging.basicConfig(level=snakemake.config["logging"]["level"])
+    logging.basicConfig(level=snakemake.params["logging"]["level"])
 
     cutout = atlite.Cutout(snakemake.input.cutout)
 

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("build_population_layouts")
 
-    logging.basicConfig(level=snakemake.params["logging"]["level"])
+    logging.basicConfig(level=snakemake.config["logging"]["level"])
 
     cutout = atlite.Cutout(snakemake.input.cutout)
 

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.base_network)
-    countries = snakemake.params["countries"]
+    countries = snakemake.params.countries
 
     ppl = (
         pm.powerplants(from_url=True)
@@ -134,12 +134,12 @@ if __name__ == "__main__":
     ppl = ppl.query('not (Country in @available_countries and Fueltype == "Bioenergy")')
     ppl = pd.concat([ppl, opsd])
 
-    ppl_query = snakemake.params["powerplants_filter"]
+    ppl_query = snakemake.params.powerplants_filter
     if isinstance(ppl_query, str):
         ppl.query(ppl_query, inplace=True)
 
     # add carriers from own powerplant files:
-    custom_ppl_query = snakemake.params["custom_powerplants"]
+    custom_ppl_query = snakemake.params.custom_powerplants
     ppl = add_custom_powerplants(
         ppl, snakemake.input.custom_powerplants, custom_ppl_query
     )

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.base_network)
-    countries = snakemake.config["countries"]
+    countries = snakemake.params["countries"]
 
     ppl = (
         pm.powerplants(from_url=True)
@@ -134,12 +134,12 @@ if __name__ == "__main__":
     ppl = ppl.query('not (Country in @available_countries and Fueltype == "Bioenergy")')
     ppl = pd.concat([ppl, opsd])
 
-    ppl_query = snakemake.config["electricity"]["powerplants_filter"]
+    ppl_query = snakemake.params["electricity"]["powerplants_filter"]
     if isinstance(ppl_query, str):
         ppl.query(ppl_query, inplace=True)
 
     # add carriers from own powerplant files:
-    custom_ppl_query = snakemake.config["electricity"]["custom_powerplants"]
+    custom_ppl_query = snakemake.params["electricity"]["custom_powerplants"]
     ppl = add_custom_powerplants(
         ppl, snakemake.input.custom_powerplants, custom_ppl_query
     )

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -134,12 +134,12 @@ if __name__ == "__main__":
     ppl = ppl.query('not (Country in @available_countries and Fueltype == "Bioenergy")')
     ppl = pd.concat([ppl, opsd])
 
-    ppl_query = snakemake.params["electricity"]["powerplants_filter"]
+    ppl_query = snakemake.params["powerplants_filter"]
     if isinstance(ppl_query, str):
         ppl.query(ppl_query, inplace=True)
 
     # add carriers from own powerplant files:
-    custom_ppl_query = snakemake.params["electricity"]["custom_powerplants"]
+    custom_ppl_query = snakemake.params["custom_powerplants"]
     ppl = add_custom_powerplants(
         ppl, snakemake.input.custom_powerplants, custom_ppl_query
     )

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -203,8 +203,8 @@ if __name__ == "__main__":
     configure_logging(snakemake)
 
     nprocesses = int(snakemake.threads)
-    noprogress = snakemake.config["run"].get("disable_progressbar", True)
-    config = snakemake.config["renewable"][snakemake.wildcards.technology]
+    noprogress = snakemake.params["run"].get("disable_progressbar", True)
+    config = snakemake.params["renewable"][snakemake.wildcards.technology]
     resource = config["resource"]  # pv panel config / wind turbine config
     correction_factor = config.get("correction_factor", 1.0)
     capacity_per_sqkm = config["capacity_per_sqkm"]

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -204,7 +204,7 @@ if __name__ == "__main__":
 
     nprocesses = int(snakemake.threads)
     noprogress = snakemake.config["run"].get("disable_progressbar", True)
-    params = snakemake.params["renewable"][snakemake.wildcards.technology]
+    params = snakemake.params.renewable[snakemake.wildcards.technology]
     resource = params["resource"]  # pv panel params / wind turbine params
     correction_factor = params.get("correction_factor", 1.0)
     capacity_per_sqkm = params["capacity_per_sqkm"]

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -309,7 +309,7 @@ if __name__ == "__main__":
         p_nom_max = capacities / max_cap_factor
     else:
         raise AssertionError(
-            'params key `potential` should be one of "simple" '
+            'Config key `potential` should be one of "simple" '
             f'(default) or "conservative", not "{p_nom_max_meth}"'
         )
 

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -203,7 +203,7 @@ if __name__ == "__main__":
     configure_logging(snakemake)
 
     nprocesses = int(snakemake.threads)
-    noprogress = snakemake.params["run"].get("disable_progressbar", True)
+    noprogress = snakemake.config["run"].get("disable_progressbar", True)
     config = snakemake.params["renewable"][snakemake.wildcards.technology]
     resource = config["resource"]  # pv panel config / wind turbine config
     correction_factor = config.get("correction_factor", 1.0)

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -64,7 +64,7 @@ Inputs
 - ``resources/offshore_shapes.geojson``: confer :ref:`shapes`
 - ``resources/regions_onshore.geojson``: (if not offshore wind), confer :ref:`busregions`
 - ``resources/regions_offshore.geojson``: (if offshore wind), :ref:`busregions`
-- ``"cutouts/" + config["renewable"][{technology}]['cutout']``: :ref:`cutout`
+- ``"cutouts/" + params["renewable"][{technology}]['cutout']``: :ref:`cutout`
 - ``networks/base.nc``: :ref:`base`
 
 Outputs
@@ -204,14 +204,14 @@ if __name__ == "__main__":
 
     nprocesses = int(snakemake.threads)
     noprogress = snakemake.config["run"].get("disable_progressbar", True)
-    config = snakemake.params["renewable"][snakemake.wildcards.technology]
-    resource = config["resource"]  # pv panel config / wind turbine config
-    correction_factor = config.get("correction_factor", 1.0)
-    capacity_per_sqkm = config["capacity_per_sqkm"]
-    p_nom_max_meth = config.get("potential", "conservative")
+    params = snakemake.params["renewable"][snakemake.wildcards.technology]
+    resource = params["resource"]  # pv panel params / wind turbine params
+    correction_factor = params.get("correction_factor", 1.0)
+    capacity_per_sqkm = params["capacity_per_sqkm"]
+    p_nom_max_meth = params.get("potential", "conservative")
 
-    if isinstance(config.get("corine", {}), list):
-        config["corine"] = {"grid_codes": config["corine"]}
+    if isinstance(params.get("corine", {}), list):
+        params["corine"] = {"grid_codes": params["corine"]}
 
     if correction_factor != 1.0:
         logger.info(f"correction_factor is set as {correction_factor}")
@@ -229,13 +229,13 @@ if __name__ == "__main__":
     regions = regions.set_index("name").rename_axis("bus")
     buses = regions.index
 
-    res = config.get("excluder_resolution", 100)
+    res = params.get("excluder_resolution", 100)
     excluder = atlite.ExclusionContainer(crs=3035, res=res)
 
-    if config["natura"]:
+    if params["natura"]:
         excluder.add_raster(snakemake.input.natura, nodata=0, allow_no_overlap=True)
 
-    corine = config.get("corine", {})
+    corine = params.get("corine", {})
     if "grid_codes" in corine:
         codes = corine["grid_codes"]
         excluder.add_raster(snakemake.input.corine, codes=codes, invert=True, crs=3035)
@@ -246,28 +246,28 @@ if __name__ == "__main__":
             snakemake.input.corine, codes=codes, buffer=buffer, crs=3035
         )
 
-    if "ship_threshold" in config:
+    if "ship_threshold" in params:
         shipping_threshold = (
-            config["ship_threshold"] * 8760 * 6
+            params["ship_threshold"] * 8760 * 6
         )  # approximation because 6 years of data which is hourly collected
         func = functools.partial(np.less, shipping_threshold)
         excluder.add_raster(
             snakemake.input.ship_density, codes=func, crs=4326, allow_no_overlap=True
         )
 
-    if config.get("max_depth"):
+    if params.get("max_depth"):
         # lambda not supported for atlite + multiprocessing
         # use named function np.greater with partially frozen argument instead
         # and exclude areas where: -max_depth > grid cell depth
-        func = functools.partial(np.greater, -config["max_depth"])
+        func = functools.partial(np.greater, -params["max_depth"])
         excluder.add_raster(snakemake.input.gebco, codes=func, crs=4326, nodata=-1000)
 
-    if "min_shore_distance" in config:
-        buffer = config["min_shore_distance"]
+    if "min_shore_distance" in params:
+        buffer = params["min_shore_distance"]
         excluder.add_geometry(snakemake.input.country_shapes, buffer=buffer)
 
-    if "max_shore_distance" in config:
-        buffer = config["max_shore_distance"]
+    if "max_shore_distance" in params:
+        buffer = params["max_shore_distance"]
         excluder.add_geometry(
             snakemake.input.country_shapes, buffer=buffer, invert=True
         )
@@ -309,7 +309,7 @@ if __name__ == "__main__":
         p_nom_max = capacities / max_cap_factor
     else:
         raise AssertionError(
-            'Config key `potential` should be one of "simple" '
+            'params key `potential` should be one of "simple" '
             f'(default) or "conservative", not "{p_nom_max_meth}"'
         )
 
@@ -358,13 +358,13 @@ if __name__ == "__main__":
     # select only buses with some capacity and minimal capacity factor
     ds = ds.sel(
         bus=(
-            (ds["profile"].mean("time") > config.get("min_p_max_pu", 0.0))
-            & (ds["p_nom_max"] > config.get("min_p_nom_max", 0.0))
+            (ds["profile"].mean("time") > params.get("min_p_max_pu", 0.0))
+            & (ds["p_nom_max"] > params.get("min_p_nom_max", 0.0))
         )
     )
 
-    if "clip_p_max_pu" in config:
-        min_p_max_pu = config["clip_p_max_pu"]
+    if "clip_p_max_pu" in params:
+        min_p_max_pu = params["clip_p_max_pu"]
         ds["profile"] = ds["profile"].where(ds["profile"] >= min_p_max_pu, 0)
 
     ds.to_netcdf(snakemake.output.profile)

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -305,7 +305,7 @@ def prepare_building_stock_data():
     u_values.set_index(["country_code", "subsector", "bage", "type"], inplace=True)
 
     #  only take in config.yaml specified countries into account
-    countries = snakemake.config["countries"]
+    countries = snakemake.params["countries"]
     area_tot = area_tot.loc[countries]
 
     return u_values, country_iso_dic, countries, area_tot, area
@@ -1040,7 +1040,7 @@ if __name__ == "__main__":
 
     #  ********  config  *********************************************************
 
-    retro_opts = snakemake.config["sector"]["retrofitting"]
+    retro_opts = snakemake.params["sector"]["retrofitting"]
     interest_rate = retro_opts["interest_rate"]
     annualise_cost = retro_opts["annualise_cost"]  # annualise the investment costs
     tax_weighting = retro_opts[

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -305,7 +305,7 @@ def prepare_building_stock_data():
     u_values.set_index(["country_code", "subsector", "bage", "type"], inplace=True)
 
     #  only take in config.yaml specified countries into account
-    countries = snakemake.params["countries"]
+    countries = snakemake.params.countries
     area_tot = area_tot.loc[countries]
 
     return u_values, country_iso_dic, countries, area_tot, area
@@ -1040,7 +1040,7 @@ if __name__ == "__main__":
 
     #  ********  config  *********************************************************
 
-    retro_opts = snakemake.params["retrofitting"]
+    retro_opts = snakemake.params.retrofitting
     interest_rate = retro_opts["interest_rate"]
     annualise_cost = retro_opts["annualise_cost"]  # annualise the investment costs
     tax_weighting = retro_opts[

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -1040,7 +1040,7 @@ if __name__ == "__main__":
 
     #  ********  config  *********************************************************
 
-    retro_opts = snakemake.params["sector"]["retrofitting"]
+    retro_opts = snakemake.params["retrofitting"]
     interest_rate = retro_opts["interest_rate"]
     annualise_cost = retro_opts["annualise_cost"]  # annualise the investment costs
     tax_weighting = retro_opts[

--- a/scripts/build_sequestration_potentials.py
+++ b/scripts/build_sequestration_potentials.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
             "build_sequestration_potentials", simpl="", clusters="181"
         )
 
-    cf = snakemake.params.co2seq_potential
+    cf = snakemake.params.sequestration_potential
 
     gdf = gpd.read_file(snakemake.input.sequestration_potential[0])
 

--- a/scripts/build_sequestration_potentials.py
+++ b/scripts/build_sequestration_potentials.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
             "build_sequestration_potentials", simpl="", clusters="181"
         )
 
-    cf = snakemake.config["sector"]["regional_co2_sequestration_potential"]
+    cf = snakemake.params["sector"]["regional_co2_sequestration_potential"]
 
     gdf = gpd.read_file(snakemake.input.sequestration_potential[0])
 

--- a/scripts/build_sequestration_potentials.py
+++ b/scripts/build_sequestration_potentials.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
             "build_sequestration_potentials", simpl="", clusters="181"
         )
 
-    cf = snakemake.params["co2seq_potential"]
+    cf = snakemake.params.co2seq_potential
 
     gdf = gpd.read_file(snakemake.input.sequestration_potential[0])
 

--- a/scripts/build_sequestration_potentials.py
+++ b/scripts/build_sequestration_potentials.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
             "build_sequestration_potentials", simpl="", clusters="181"
         )
 
-    cf = snakemake.params["sector"]["regional_co2_sequestration_potential"]
+    cf = snakemake.params["co2seq_potential"]
 
     gdf = gpd.read_file(snakemake.input.sequestration_potential[0])
 

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -255,13 +255,11 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("build_shapes")
     configure_logging(snakemake)
 
-    country_shapes = countries(
-        snakemake.input.naturalearth, snakemake.params["countries"]
-    )
+    country_shapes = countries(snakemake.input.naturalearth, snakemake.params.countries)
     country_shapes.reset_index().to_file(snakemake.output.country_shapes)
 
     offshore_shapes = eez(
-        country_shapes, snakemake.input.eez, snakemake.params["countries"]
+        country_shapes, snakemake.input.eez, snakemake.params.countries
     )
     offshore_shapes.reset_index().to_file(snakemake.output.offshore_shapes)
 

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -255,12 +255,12 @@ if __name__ == "__main__":
     configure_logging(snakemake)
 
     country_shapes = countries(
-        snakemake.input.naturalearth, snakemake.config["countries"]
+        snakemake.input.naturalearth, snakemake.params["countries"]
     )
     country_shapes.reset_index().to_file(snakemake.output.country_shapes)
 
     offshore_shapes = eez(
-        country_shapes, snakemake.input.eez, snakemake.config["countries"]
+        country_shapes, snakemake.input.eez, snakemake.params["countries"]
     )
     offshore_shapes.reset_index().to_file(snakemake.output.offshore_shapes)
 

--- a/scripts/build_solar_thermal_profiles.py
+++ b/scripts/build_solar_thermal_profiles.py
@@ -27,9 +27,9 @@ if __name__ == "__main__":
     cluster = LocalCluster(n_workers=nprocesses, threads_per_worker=1)
     client = Client(cluster, asynchronous=True)
 
-    config = snakemake.config["solar_thermal"]
+    config = snakemake.params["solar_thermal"]
 
-    time = pd.date_range(freq="h", **snakemake.config["snapshots"])
+    time = pd.date_range(freq="h", **snakemake.params["snapshots"])
     cutout = atlite.Cutout(snakemake.input.cutout).sel(time=time)
 
     clustered_regions = (

--- a/scripts/build_solar_thermal_profiles.py
+++ b/scripts/build_solar_thermal_profiles.py
@@ -27,9 +27,9 @@ if __name__ == "__main__":
     cluster = LocalCluster(n_workers=nprocesses, threads_per_worker=1)
     client = Client(cluster, asynchronous=True)
 
-    config = snakemake.params["solar_thermal"]
+    config = snakemake.params.solar_thermal
 
-    time = pd.date_range(freq="h", **snakemake.params["snapshots"])
+    time = pd.date_range(freq="h", **snakemake.params.snapshots)
     cutout = atlite.Cutout(snakemake.input.cutout).sel(time=time)
 
     clustered_regions = (

--- a/scripts/build_temperature_profiles.py
+++ b/scripts/build_temperature_profiles.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     cluster = LocalCluster(n_workers=nprocesses, threads_per_worker=1)
     client = Client(cluster, asynchronous=True)
 
-    time = pd.date_range(freq="h", **snakemake.config["snapshots"])
+    time = pd.date_range(freq="h", **snakemake.params["snapshots"])
     cutout = atlite.Cutout(snakemake.input.cutout).sel(time=time)
 
     clustered_regions = (

--- a/scripts/build_temperature_profiles.py
+++ b/scripts/build_temperature_profiles.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     cluster = LocalCluster(n_workers=nprocesses, threads_per_worker=1)
     client = Client(cluster, asynchronous=True)
 
-    time = pd.date_range(freq="h", **snakemake.params["snapshots"])
+    time = pd.date_range(freq="h", **snakemake.params.snapshots)
     cutout = atlite.Cutout(snakemake.input.cutout).sel(time=time)
 
     clustered_regions = (

--- a/scripts/build_transport_demand.py
+++ b/scripts/build_transport_demand.py
@@ -175,9 +175,9 @@ if __name__ == "__main__":
         snakemake.input.pop_weighted_energy_totals, index_col=0
     )
 
-    options = snakemake.params["sector"]
+    options = snakemake.params.sector
 
-    snapshots = pd.date_range(freq="h", **snakemake.params["snapshots"], tz="UTC")
+    snapshots = pd.date_range(freq="h", **snakemake.params.snapshots, tz="UTC")
 
     nyears = len(snapshots) / 8760
 

--- a/scripts/build_transport_demand.py
+++ b/scripts/build_transport_demand.py
@@ -175,9 +175,9 @@ if __name__ == "__main__":
         snakemake.input.pop_weighted_energy_totals, index_col=0
     )
 
-    options = snakemake.config["sector"]
+    options = snakemake.params["sector"]
 
-    snapshots = pd.date_range(freq="h", **snakemake.config["snapshots"], tz="UTC")
+    snapshots = pd.date_range(freq="h", **snakemake.params["snapshots"], tz="UTC")
 
     nyears = len(snapshots) / 8760
 

--- a/scripts/cluster_gas_network.py
+++ b/scripts/cluster_gas_network.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("cluster_gas_network", simpl="", clusters="37")
 
-    logging.basicConfig(level=snakemake.config["logging"]["level"])
+    logging.basicConfig(level=snakemake.params["logging"]["level"])
 
     fn = snakemake.input.cleaned_gas_network
     df = pd.read_csv(fn, index_col=0)

--- a/scripts/cluster_gas_network.py
+++ b/scripts/cluster_gas_network.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("cluster_gas_network", simpl="", clusters="37")
 
-    logging.basicConfig(level=snakemake.params["logging"]["level"])
+    logging.basicConfig(level=snakemake.config["logging"]["level"])
 
     fn = snakemake.input.cleaned_gas_network
     df = pd.read_csv(fn, index_col=0)

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -479,7 +479,7 @@ if __name__ == "__main__":
     if snakemake.wildcards.clusters.endswith("m"):
         n_clusters = int(snakemake.wildcards.clusters[:-1])
         conventional = set(
-            snakemake.params["electricity"].get("conventional_carriers", [])
+            snakemake.params["conventional_carriers"]
         )
         aggregate_carriers = conventional.intersection(aggregate_carriers)
     elif snakemake.wildcards.clusters == "all":
@@ -495,13 +495,13 @@ if __name__ == "__main__":
             n, busmap, linemap, linemap, pd.Series(dtype="O")
         )
     else:
-        line_length_factor = snakemake.params["lines"]["length_factor"]
+        line_length_factor = snakemake.params["length_factor"]
         Nyears = n.snapshot_weightings.objective.sum() / 8760
 
         hvac_overhead_cost = load_costs(
             snakemake.input.tech_costs,
             snakemake.params["costs"],
-            snakemake.params["electricity"],
+            snakemake.params["max_hours"],
             Nyears,
         ).at["HVAC overhead", "capital_cost"]
 
@@ -539,7 +539,7 @@ if __name__ == "__main__":
             aggregate_carriers,
             line_length_factor,
             aggregation_strategies,
-            snakemake.params["solving"]["solver"]["name"],
+            snakemake.params["solver_name"],
             cluster_config.get("algorithm", "hac"),
             cluster_config.get("feature", "solar+onwind-time"),
             hvac_overhead_cost,

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -478,9 +478,7 @@ if __name__ == "__main__":
     aggregate_carriers = set(n.generators.carrier) - set(exclude_carriers)
     if snakemake.wildcards.clusters.endswith("m"):
         n_clusters = int(snakemake.wildcards.clusters[:-1])
-        conventional = set(
-            snakemake.params["conventional_carriers"]
-        )
+        conventional = set(snakemake.params["conventional_carriers"])
         aggregate_carriers = conventional.intersection(aggregate_carriers)
     elif snakemake.wildcards.clusters == "all":
         n_clusters = len(n.buses)

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -468,18 +468,18 @@ if __name__ == "__main__":
         [
             tech
             for tech in n.generators.carrier.unique()
-            if tech in snakemake.config["renewable"]
+            if tech in snakemake.params["renewable"]
         ]
     )
 
-    exclude_carriers = snakemake.config["clustering"]["cluster_network"].get(
+    exclude_carriers = snakemake.params["clustering"]["cluster_network"].get(
         "exclude_carriers", []
     )
     aggregate_carriers = set(n.generators.carrier) - set(exclude_carriers)
     if snakemake.wildcards.clusters.endswith("m"):
         n_clusters = int(snakemake.wildcards.clusters[:-1])
         conventional = set(
-            snakemake.config["electricity"].get("conventional_carriers", [])
+            snakemake.params["electricity"].get("conventional_carriers", [])
         )
         aggregate_carriers = conventional.intersection(aggregate_carriers)
     elif snakemake.wildcards.clusters == "all":
@@ -495,13 +495,13 @@ if __name__ == "__main__":
             n, busmap, linemap, linemap, pd.Series(dtype="O")
         )
     else:
-        line_length_factor = snakemake.config["lines"]["length_factor"]
+        line_length_factor = snakemake.params["lines"]["length_factor"]
         Nyears = n.snapshot_weightings.objective.sum() / 8760
 
         hvac_overhead_cost = load_costs(
             snakemake.input.tech_costs,
-            snakemake.config["costs"],
-            snakemake.config["electricity"],
+            snakemake.params["costs"],
+            snakemake.params["electricity"],
             Nyears,
         ).at["HVAC overhead", "capital_cost"]
 
@@ -512,7 +512,7 @@ if __name__ == "__main__":
             ).all() or x.isnull().all(), "The `potential` configuration option must agree for all renewable carriers, for now!"
             return v
 
-        aggregation_strategies = snakemake.config["clustering"].get(
+        aggregation_strategies = snakemake.params["clustering"].get(
             "aggregation_strategies", {}
         )
         # translate str entries of aggregation_strategies to pd.Series functions:
@@ -521,7 +521,7 @@ if __name__ == "__main__":
             for p in aggregation_strategies.keys()
         }
 
-        custom_busmap = snakemake.config["enable"].get("custom_busmap", False)
+        custom_busmap = snakemake.params["enable"].get("custom_busmap", False)
         if custom_busmap:
             custom_busmap = pd.read_csv(
                 snakemake.input.custom_busmap, index_col=0, squeeze=True
@@ -539,7 +539,7 @@ if __name__ == "__main__":
             aggregate_carriers,
             line_length_factor,
             aggregation_strategies,
-            snakemake.config["solving"]["solver"]["name"],
+            snakemake.params["solving"]["solver"]["name"],
             cluster_config.get("algorithm", "hac"),
             cluster_config.get("feature", "solar+onwind-time"),
             hvac_overhead_cost,

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -521,7 +521,7 @@ if __name__ == "__main__":
             for p in aggregation_strategies.keys()
         }
 
-        custom_busmap = snakemake.params["enable"].get("custom_busmap", False)
+        custom_busmap = snakemake.params["custom_busmap"]
         if custom_busmap:
             custom_busmap = pd.read_csv(
                 snakemake.input.custom_busmap, index_col=0, squeeze=True

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -198,7 +198,7 @@ def calculate_costs(n, label, costs):
 
 
 def calculate_cumulative_cost():
-    planning_horizons = snakemake.config["scenario"]["planning_horizons"]
+    planning_horizons = snakemake.params["scenario"]["planning_horizons"]
 
     cumulative_cost = pd.DataFrame(
         index=df["costs"].sum().index,
@@ -682,25 +682,25 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("make_summary")
 
-    logging.basicConfig(level=snakemake.config["logging"]["level"])
+    logging.basicConfig(level=snakemake.params["logging"]["level"])
 
     networks_dict = {
         (cluster, ll, opt + sector_opt, planning_horizon): "results/"
         + snakemake.params.RDIR
         + f"/postnetworks/elec_s{simpl}_{cluster}_l{ll}_{opt}_{sector_opt}_{planning_horizon}.nc"
-        for simpl in snakemake.config["scenario"]["simpl"]
-        for cluster in snakemake.config["scenario"]["clusters"]
-        for opt in snakemake.config["scenario"]["opts"]
-        for sector_opt in snakemake.config["scenario"]["sector_opts"]
-        for ll in snakemake.config["scenario"]["ll"]
-        for planning_horizon in snakemake.config["scenario"]["planning_horizons"]
+        for simpl in snakemake.params["scenario"]["simpl"]
+        for cluster in snakemake.params["scenario"]["clusters"]
+        for opt in snakemake.params["scenario"]["opts"]
+        for sector_opt in snakemake.params["scenario"]["sector_opts"]
+        for ll in snakemake.params["scenario"]["ll"]
+        for planning_horizon in snakemake.params["scenario"]["planning_horizons"]
     }
 
-    Nyears = len(pd.date_range(freq="h", **snakemake.config["snapshots"])) / 8760
+    Nyears = len(pd.date_range(freq="h", **snakemake.params["snapshots"])) / 8760
 
     costs_db = prepare_costs(
         snakemake.input.costs,
-        snakemake.config["costs"],
+        snakemake.params["costs"],
         Nyears,
     )
 
@@ -710,7 +710,7 @@ if __name__ == "__main__":
 
     to_csv(df)
 
-    if snakemake.config["foresight"] == "myopic":
+    if snakemake.params["foresight"] == "myopic":
         cumulative_cost = calculate_cumulative_cost()
         cumulative_cost.to_csv(
             "results/" + snakemake.params.RDIR + "/csvs/cumulative_cost.csv"

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -682,7 +682,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("make_summary")
 
-    logging.basicConfig(level=snakemake.params["logging"]["level"])
+    logging.basicConfig(level=snakemake.config["logging"]["level"])
 
     networks_dict = {
         (cluster, ll, opt + sector_opt, planning_horizon): "results/"

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -198,7 +198,7 @@ def calculate_costs(n, label, costs):
 
 
 def calculate_cumulative_cost():
-    planning_horizons = snakemake.params["scenario"]["planning_horizons"]
+    planning_horizons = snakemake.params.scenario["planning_horizons"]
 
     cumulative_cost = pd.DataFrame(
         index=df["costs"].sum().index,
@@ -688,19 +688,19 @@ if __name__ == "__main__":
         (cluster, ll, opt + sector_opt, planning_horizon): "results/"
         + snakemake.params.RDIR
         + f"/postnetworks/elec_s{simpl}_{cluster}_l{ll}_{opt}_{sector_opt}_{planning_horizon}.nc"
-        for simpl in snakemake.params["scenario"]["simpl"]
-        for cluster in snakemake.params["scenario"]["clusters"]
-        for opt in snakemake.params["scenario"]["opts"]
-        for sector_opt in snakemake.params["scenario"]["sector_opts"]
-        for ll in snakemake.params["scenario"]["ll"]
-        for planning_horizon in snakemake.params["scenario"]["planning_horizons"]
+        for simpl in snakemake.params.scenario["simpl"]
+        for cluster in snakemake.params.scenario["clusters"]
+        for opt in snakemake.params.scenario["opts"]
+        for sector_opt in snakemake.params.scenario["sector_opts"]
+        for ll in snakemake.params.scenario["ll"]
+        for planning_horizon in snakemake.params.scenario["planning_horizons"]
     }
 
-    Nyears = len(pd.date_range(freq="h", **snakemake.params["snapshots"])) / 8760
+    Nyears = len(pd.date_range(freq="h", **snakemake.params.snapshots)) / 8760
 
     costs_db = prepare_costs(
         snakemake.input.costs,
-        snakemake.params["costs"],
+        snakemake.params.costs,
         Nyears,
     )
 
@@ -710,7 +710,7 @@ if __name__ == "__main__":
 
     to_csv(df)
 
-    if snakemake.params["foresight"] == "myopic":
+    if snakemake.params.foresight == "myopic":
         cumulative_cost = calculate_cumulative_cost()
         cumulative_cost.to_csv(
             "results/" + snakemake.params.RDIR + "/csvs/cumulative_cost.csv"

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -930,7 +930,7 @@ if __name__ == "__main__":
             planning_horizons="2030",
         )
 
-    logging.basicConfig(level=snakemake.params["logging"]["level"])
+    logging.basicConfig(level=snakemake.config["logging"]["level"])
 
     overrides = override_component_attrs(snakemake.input.overrides)
     n = pypsa.Network(snakemake.input.network, override_component_attrs=overrides)

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -70,7 +70,7 @@ def plot_map(
     transmission=False,
     with_legend=True,
 ):
-    tech_colors = snakemake.config["plotting"]["tech_colors"]
+    tech_colors = snakemake.params["plotting"]["tech_colors"]
 
     n = network.copy()
     assign_location(n)
@@ -116,7 +116,7 @@ def plot_map(
     costs = costs.stack()  # .sort_index()
 
     # hack because impossible to drop buses...
-    eu_location = snakemake.config["plotting"].get(
+    eu_location = snakemake.params["plotting"].get(
         "eu_node_location", dict(x=-5.5, y=46)
     )
     n.buses.loc["EU gas", "x"] = eu_location["x"]
@@ -315,7 +315,7 @@ def plot_h2_map(network, regions):
     h2_new = n.links[n.links.carrier == "H2 pipeline"]
     h2_retro = n.links[n.links.carrier == "H2 pipeline retrofitted"]
 
-    if snakemake.config["foresight"] == "myopic":
+    if snakemake.params["foresight"] == "myopic":
         # sum capacitiy for pipelines from different investment periods
         h2_new = group_pipes(h2_new)
 
@@ -558,7 +558,7 @@ def plot_ch4_map(network):
     link_widths_used = max_usage / linewidth_factor
     link_widths_used[max_usage < line_lower_threshold] = 0.0
 
-    tech_colors = snakemake.config["plotting"]["tech_colors"]
+    tech_colors = snakemake.params["plotting"]["tech_colors"]
 
     pipe_colors = {
         "gas pipeline": "#f08080",
@@ -700,7 +700,7 @@ def plot_map_without(network):
 
     # hack because impossible to drop buses...
     if "EU gas" in n.buses.index:
-        eu_location = snakemake.config["plotting"].get(
+        eu_location = snakemake.params["plotting"].get(
             "eu_node_location", dict(x=-5.5, y=46)
         )
         n.buses.loc["EU gas", "x"] = eu_location["x"]
@@ -876,7 +876,7 @@ def plot_series(network, carrier="AC", name="test"):
             stacked=True,
             linewidth=0.0,
             color=[
-                snakemake.config["plotting"]["tech_colors"][i.replace(suffix, "")]
+                snakemake.params["plotting"]["tech_colors"][i.replace(suffix, "")]
                 for i in new_columns
             ],
         )
@@ -930,14 +930,14 @@ if __name__ == "__main__":
             planning_horizons="2030",
         )
 
-    logging.basicConfig(level=snakemake.config["logging"]["level"])
+    logging.basicConfig(level=snakemake.params["logging"]["level"])
 
     overrides = override_component_attrs(snakemake.input.overrides)
     n = pypsa.Network(snakemake.input.network, override_component_attrs=overrides)
 
     regions = gpd.read_file(snakemake.input.regions).set_index("name")
 
-    map_opts = snakemake.config["plotting"]["map"]
+    map_opts = snakemake.params["plotting"]["map"]
 
     if map_opts["boundaries"] is None:
         map_opts["boundaries"] = regions.total_bounds[[0, 2, 1, 3]] + [-1, 1, -1, 1]

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -70,7 +70,7 @@ def plot_map(
     transmission=False,
     with_legend=True,
 ):
-    tech_colors = snakemake.params["plotting"]["tech_colors"]
+    tech_colors = snakemake.params.plotting["tech_colors"]
 
     n = network.copy()
     assign_location(n)
@@ -116,9 +116,7 @@ def plot_map(
     costs = costs.stack()  # .sort_index()
 
     # hack because impossible to drop buses...
-    eu_location = snakemake.params["plotting"].get(
-        "eu_node_location", dict(x=-5.5, y=46)
-    )
+    eu_location = snakemake.params.plotting.get("eu_node_location", dict(x=-5.5, y=46))
     n.buses.loc["EU gas", "x"] = eu_location["x"]
     n.buses.loc["EU gas", "y"] = eu_location["y"]
 
@@ -315,7 +313,7 @@ def plot_h2_map(network, regions):
     h2_new = n.links[n.links.carrier == "H2 pipeline"]
     h2_retro = n.links[n.links.carrier == "H2 pipeline retrofitted"]
 
-    if snakemake.params["foresight"] == "myopic":
+    if snakemake.params.foresight == "myopic":
         # sum capacitiy for pipelines from different investment periods
         h2_new = group_pipes(h2_new)
 
@@ -558,7 +556,7 @@ def plot_ch4_map(network):
     link_widths_used = max_usage / linewidth_factor
     link_widths_used[max_usage < line_lower_threshold] = 0.0
 
-    tech_colors = snakemake.params["plotting"]["tech_colors"]
+    tech_colors = snakemake.params.plotting["tech_colors"]
 
     pipe_colors = {
         "gas pipeline": "#f08080",
@@ -700,7 +698,7 @@ def plot_map_without(network):
 
     # hack because impossible to drop buses...
     if "EU gas" in n.buses.index:
-        eu_location = snakemake.params["plotting"].get(
+        eu_location = snakemake.params.plotting.get(
             "eu_node_location", dict(x=-5.5, y=46)
         )
         n.buses.loc["EU gas", "x"] = eu_location["x"]
@@ -876,7 +874,7 @@ def plot_series(network, carrier="AC", name="test"):
             stacked=True,
             linewidth=0.0,
             color=[
-                snakemake.params["plotting"]["tech_colors"][i.replace(suffix, "")]
+                snakemake.params.plotting["tech_colors"][i.replace(suffix, "")]
                 for i in new_columns
             ],
         )
@@ -937,7 +935,7 @@ if __name__ == "__main__":
 
     regions = gpd.read_file(snakemake.input.regions).set_index("name")
 
-    map_opts = snakemake.params["plotting"]["map"]
+    map_opts = snakemake.params.plotting["map"]
 
     if map_opts["boundaries"] is None:
         map_opts["boundaries"] = regions.total_bounds[[0, 2, 1, 3]] + [-1, 1, -1, 1]

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -545,7 +545,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("plot_summary")
 
-    logging.basicConfig(level=snakemake.params["logging"]["level"])
+    logging.basicConfig(level=snakemake.config["logging"]["level"])
 
     n_header = 4
 

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -142,10 +142,10 @@ def plot_costs():
 
     df = df.groupby(df.index.map(rename_techs)).sum()
 
-    to_drop = df.index[df.max(axis=1) < snakemake.config["plotting"]["costs_threshold"]]
+    to_drop = df.index[df.max(axis=1) < snakemake.params["plotting"]["costs_threshold"]]
 
     logger.info(
-        f"Dropping technology with costs below {snakemake.config['plotting']['costs_threshold']} EUR billion per year"
+        f"Dropping technology with costs below {snakemake.params['plotting']['costs_threshold']} EUR billion per year"
     )
     logger.debug(df.loc[to_drop])
 
@@ -165,7 +165,7 @@ def plot_costs():
         kind="bar",
         ax=ax,
         stacked=True,
-        color=[snakemake.config["plotting"]["tech_colors"][i] for i in new_index],
+        color=[snakemake.params["plotting"]["tech_colors"][i] for i in new_index],
     )
 
     handles, labels = ax.get_legend_handles_labels()
@@ -173,7 +173,7 @@ def plot_costs():
     handles.reverse()
     labels.reverse()
 
-    ax.set_ylim([0, snakemake.config["plotting"]["costs_max"]])
+    ax.set_ylim([0, snakemake.params["plotting"]["costs_max"]])
 
     ax.set_ylabel("System Cost [EUR billion per year]")
 
@@ -201,11 +201,11 @@ def plot_energy():
     df = df.groupby(df.index.map(rename_techs)).sum()
 
     to_drop = df.index[
-        df.abs().max(axis=1) < snakemake.config["plotting"]["energy_threshold"]
+        df.abs().max(axis=1) < snakemake.params["plotting"]["energy_threshold"]
     ]
 
     logger.info(
-        f"Dropping all technology with energy consumption or production below {snakemake.config['plotting']['energy_threshold']} TWh/a"
+        f"Dropping all technology with energy consumption or production below {snakemake.params['plotting']['energy_threshold']} TWh/a"
     )
     logger.debug(df.loc[to_drop])
 
@@ -227,7 +227,7 @@ def plot_energy():
         kind="bar",
         ax=ax,
         stacked=True,
-        color=[snakemake.config["plotting"]["tech_colors"][i] for i in new_index],
+        color=[snakemake.params["plotting"]["tech_colors"][i] for i in new_index],
     )
 
     handles, labels = ax.get_legend_handles_labels()
@@ -237,8 +237,8 @@ def plot_energy():
 
     ax.set_ylim(
         [
-            snakemake.config["plotting"]["energy_min"],
-            snakemake.config["plotting"]["energy_max"],
+            snakemake.params["plotting"]["energy_min"],
+            snakemake.params["plotting"]["energy_max"],
         ]
     )
 
@@ -287,7 +287,7 @@ def plot_balances():
         df = df.groupby(df.index.map(rename_techs)).sum()
 
         to_drop = df.index[
-            df.abs().max(axis=1) < snakemake.config["plotting"]["energy_threshold"] / 10
+            df.abs().max(axis=1) < snakemake.params["plotting"]["energy_threshold"] / 10
         ]
 
         if v[0] in co2_carriers:
@@ -296,7 +296,7 @@ def plot_balances():
             units = "TWh/a"
 
         logger.debug(
-            f"Dropping technology energy balance smaller than {snakemake.config['plotting']['energy_threshold']/10} {units}"
+            f"Dropping technology energy balance smaller than {snakemake.params['plotting']['energy_threshold']/10} {units}"
         )
         logger.debug(df.loc[to_drop])
 
@@ -317,7 +317,7 @@ def plot_balances():
             kind="bar",
             ax=ax,
             stacked=True,
-            color=[snakemake.config["plotting"]["tech_colors"][i] for i in new_index],
+            color=[snakemake.params["plotting"]["tech_colors"][i] for i in new_index],
         )
 
         handles, labels = ax.get_legend_handles_labels()
@@ -455,10 +455,10 @@ def plot_carbon_budget_distribution(input_eurostat):
     ax1 = plt.subplot(gs1[0, 0])
     ax1.set_ylabel("CO$_2$ emissions (Gt per year)", fontsize=22)
     ax1.set_ylim([0, 5])
-    ax1.set_xlim([1990, snakemake.config["scenario"]["planning_horizons"][-1] + 1])
+    ax1.set_xlim([1990, snakemake.params["scenario"]["planning_horizons"][-1] + 1])
 
     path_cb = "results/" + snakemake.params.RDIR + "/csvs/"
-    countries = snakemake.config["countries"]
+    countries = snakemake.params["countries"]
     e_1990 = co2_emissions_year(countries, input_eurostat, opts, year=1990)
     CO2_CAP = pd.read_csv(path_cb + "carbon_budget_distribution.csv", index_col=0)
 
@@ -545,7 +545,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake("plot_summary")
 
-    logging.basicConfig(level=snakemake.config["logging"]["level"])
+    logging.basicConfig(level=snakemake.params["logging"]["level"])
 
     n_header = 4
 
@@ -555,7 +555,7 @@ if __name__ == "__main__":
 
     plot_balances()
 
-    for sector_opts in snakemake.config["scenario"]["sector_opts"]:
+    for sector_opts in snakemake.params["scenario"]["sector_opts"]:
         opts = sector_opts.split("-")
         for o in opts:
             if "cb" in o:

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -142,7 +142,7 @@ def plot_costs():
 
     df = df.groupby(df.index.map(rename_techs)).sum()
 
-    to_drop = df.index[df.max(axis=1) < snakemake.params["plotting"]["costs_threshold"]]
+    to_drop = df.index[df.max(axis=1) < snakemake.params.plotting["costs_threshold"]]
 
     logger.info(
         f"Dropping technology with costs below {snakemake.params['plotting']['costs_threshold']} EUR billion per year"
@@ -165,7 +165,7 @@ def plot_costs():
         kind="bar",
         ax=ax,
         stacked=True,
-        color=[snakemake.params["plotting"]["tech_colors"][i] for i in new_index],
+        color=[snakemake.params.plotting["tech_colors"][i] for i in new_index],
     )
 
     handles, labels = ax.get_legend_handles_labels()
@@ -173,7 +173,7 @@ def plot_costs():
     handles.reverse()
     labels.reverse()
 
-    ax.set_ylim([0, snakemake.params["plotting"]["costs_max"]])
+    ax.set_ylim([0, snakemake.params.plotting["costs_max"]])
 
     ax.set_ylabel("System Cost [EUR billion per year]")
 
@@ -201,7 +201,7 @@ def plot_energy():
     df = df.groupby(df.index.map(rename_techs)).sum()
 
     to_drop = df.index[
-        df.abs().max(axis=1) < snakemake.params["plotting"]["energy_threshold"]
+        df.abs().max(axis=1) < snakemake.params.plotting["energy_threshold"]
     ]
 
     logger.info(
@@ -227,7 +227,7 @@ def plot_energy():
         kind="bar",
         ax=ax,
         stacked=True,
-        color=[snakemake.params["plotting"]["tech_colors"][i] for i in new_index],
+        color=[snakemake.params.plotting["tech_colors"][i] for i in new_index],
     )
 
     handles, labels = ax.get_legend_handles_labels()
@@ -237,8 +237,8 @@ def plot_energy():
 
     ax.set_ylim(
         [
-            snakemake.params["plotting"]["energy_min"],
-            snakemake.params["plotting"]["energy_max"],
+            snakemake.params.plotting["energy_min"],
+            snakemake.params.plotting["energy_max"],
         ]
     )
 
@@ -287,7 +287,7 @@ def plot_balances():
         df = df.groupby(df.index.map(rename_techs)).sum()
 
         to_drop = df.index[
-            df.abs().max(axis=1) < snakemake.params["plotting"]["energy_threshold"] / 10
+            df.abs().max(axis=1) < snakemake.params.plotting["energy_threshold"] / 10
         ]
 
         if v[0] in co2_carriers:
@@ -317,7 +317,7 @@ def plot_balances():
             kind="bar",
             ax=ax,
             stacked=True,
-            color=[snakemake.params["plotting"]["tech_colors"][i] for i in new_index],
+            color=[snakemake.params.plotting["tech_colors"][i] for i in new_index],
         )
 
         handles, labels = ax.get_legend_handles_labels()
@@ -455,10 +455,10 @@ def plot_carbon_budget_distribution(input_eurostat):
     ax1 = plt.subplot(gs1[0, 0])
     ax1.set_ylabel("CO$_2$ emissions (Gt per year)", fontsize=22)
     ax1.set_ylim([0, 5])
-    ax1.set_xlim([1990, snakemake.params["planning_horizons"][-1] + 1])
+    ax1.set_xlim([1990, snakemake.params.planning_horizons[-1] + 1])
 
     path_cb = "results/" + snakemake.params.RDIR + "/csvs/"
-    countries = snakemake.params["countries"]
+    countries = snakemake.params.countries
     e_1990 = co2_emissions_year(countries, input_eurostat, opts, year=1990)
     CO2_CAP = pd.read_csv(path_cb + "carbon_budget_distribution.csv", index_col=0)
 
@@ -555,7 +555,7 @@ if __name__ == "__main__":
 
     plot_balances()
 
-    for sector_opts in snakemake.params["sector_opts"]:
+    for sector_opts in snakemake.params.sector_opts:
         opts = sector_opts.split("-")
         for o in opts:
             if "cb" in o:

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -455,7 +455,7 @@ def plot_carbon_budget_distribution(input_eurostat):
     ax1 = plt.subplot(gs1[0, 0])
     ax1.set_ylabel("CO$_2$ emissions (Gt per year)", fontsize=22)
     ax1.set_ylim([0, 5])
-    ax1.set_xlim([1990, snakemake.params["scenario"]["planning_horizons"][-1] + 1])
+    ax1.set_xlim([1990, snakemake.params["planning_horizons"][-1] + 1])
 
     path_cb = "results/" + snakemake.params.RDIR + "/csvs/"
     countries = snakemake.params["countries"]
@@ -555,7 +555,7 @@ if __name__ == "__main__":
 
     plot_balances()
 
-    for sector_opts in snakemake.params["scenario"]["sector_opts"]:
+    for sector_opts in snakemake.params["sector_opts"]:
         opts = sector_opts.split("-")
         for o in opts:
             if "cb" in o:

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -253,12 +253,12 @@ if __name__ == "__main__":
     Nyears = n.snapshot_weightings.objective.sum() / 8760.0
     costs = load_costs(
         snakemake.input.tech_costs,
-        snakemake.params["costs"],
-        snakemake.params["max_hours"],
+        snakemake.params.costs,
+        snakemake.params.max_hours,
         Nyears,
     )
 
-    set_line_s_max_pu(n, snakemake.params["lines"]["s_max_pu"])
+    set_line_s_max_pu(n, snakemake.params.lines["s_max_pu"])
 
     for o in opts:
         m = re.match(r"^\d+h$", o, re.IGNORECASE)
@@ -269,7 +269,7 @@ if __name__ == "__main__":
     for o in opts:
         m = re.match(r"^\d+seg$", o, re.IGNORECASE)
         if m is not None:
-            solver_name = snakemake.params["solver_name"]
+            solver_name = snakemake.params.solver_name
             n = apply_time_segmentation(n, m.group(0)[:-3], solver_name)
             break
 
@@ -277,11 +277,11 @@ if __name__ == "__main__":
         if "Co2L" in o:
             m = re.findall("[0-9]*\.?[0-9]+$", o)
             if len(m) > 0:
-                co2limit = float(m[0]) * snakemake.params["co2base"]
+                co2limit = float(m[0]) * snakemake.params.co2base
                 add_co2limit(n, co2limit, Nyears)
                 logger.info("Setting CO2 limit according to wildcard value.")
             else:
-                add_co2limit(n, snakemake.params["co2limit"], Nyears)
+                add_co2limit(n, snakemake.params.co2limit, Nyears)
                 logger.info("Setting CO2 limit according to config value.")
             break
 
@@ -293,7 +293,7 @@ if __name__ == "__main__":
                 add_gaslimit(n, limit, Nyears)
                 logger.info("Setting gas usage limit according to wildcard value.")
             else:
-                add_gaslimit(n, snakemake.params["gaslimit"], Nyears)
+                add_gaslimit(n, snakemake.params.gaslimit, Nyears)
                 logger.info("Setting gas usage limit according to config value.")
             break
 
@@ -322,7 +322,7 @@ if __name__ == "__main__":
                 add_emission_prices(n, dict(co2=float(m[0])))
             else:
                 logger.info("Setting emission prices according to config value.")
-                add_emission_prices(n, snakemake.params["costs"]["emission_prices"])
+                add_emission_prices(n, snakemake.params.costs["emission_prices"])
             break
 
     ll_type, factor = snakemake.wildcards.ll[0], snakemake.wildcards.ll[1:]
@@ -330,8 +330,8 @@ if __name__ == "__main__":
 
     set_line_nom_max(
         n,
-        s_nom_max_set=snakemake.params["lines"].get("s_nom_max,", np.inf),
-        p_nom_max_set=snakemake.params["links"].get("p_nom_max,", np.inf),
+        s_nom_max_set=snakemake.params.lines.get("s_nom_max,", np.inf),
+        p_nom_max_set=snakemake.params.links.get("p_nom_max,", np.inf),
     )
 
     if "ATK" in opts:

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -253,12 +253,12 @@ if __name__ == "__main__":
     Nyears = n.snapshot_weightings.objective.sum() / 8760.0
     costs = load_costs(
         snakemake.input.tech_costs,
-        snakemake.config["costs"],
-        snakemake.config["electricity"],
+        snakemake.params["costs"],
+        snakemake.params["electricity"],
         Nyears,
     )
 
-    set_line_s_max_pu(n, snakemake.config["lines"]["s_max_pu"])
+    set_line_s_max_pu(n, snakemake.params["lines"]["s_max_pu"])
 
     for o in opts:
         m = re.match(r"^\d+h$", o, re.IGNORECASE)
@@ -269,7 +269,7 @@ if __name__ == "__main__":
     for o in opts:
         m = re.match(r"^\d+seg$", o, re.IGNORECASE)
         if m is not None:
-            solver_name = snakemake.config["solving"]["solver"]["name"]
+            solver_name = snakemake.params["solving"]["solver"]["name"]
             n = apply_time_segmentation(n, m.group(0)[:-3], solver_name)
             break
 
@@ -277,11 +277,11 @@ if __name__ == "__main__":
         if "Co2L" in o:
             m = re.findall("[0-9]*\.?[0-9]+$", o)
             if len(m) > 0:
-                co2limit = float(m[0]) * snakemake.config["electricity"]["co2base"]
+                co2limit = float(m[0]) * snakemake.params["electricity"]["co2base"]
                 add_co2limit(n, co2limit, Nyears)
                 logger.info("Setting CO2 limit according to wildcard value.")
             else:
-                add_co2limit(n, snakemake.config["electricity"]["co2limit"], Nyears)
+                add_co2limit(n, snakemake.params["electricity"]["co2limit"], Nyears)
                 logger.info("Setting CO2 limit according to config value.")
             break
 
@@ -293,7 +293,7 @@ if __name__ == "__main__":
                 add_gaslimit(n, limit, Nyears)
                 logger.info("Setting gas usage limit according to wildcard value.")
             else:
-                add_gaslimit(n, snakemake.config["electricity"].get("gaslimit"), Nyears)
+                add_gaslimit(n, snakemake.params["electricity"].get("gaslimit"), Nyears)
                 logger.info("Setting gas usage limit according to config value.")
             break
 
@@ -322,7 +322,7 @@ if __name__ == "__main__":
                 add_emission_prices(n, dict(co2=float(m[0])))
             else:
                 logger.info("Setting emission prices according to config value.")
-                add_emission_prices(n, snakemake.config["costs"]["emission_prices"])
+                add_emission_prices(n, snakemake.params["costs"]["emission_prices"])
             break
 
     ll_type, factor = snakemake.wildcards.ll[0], snakemake.wildcards.ll[1:]
@@ -330,8 +330,8 @@ if __name__ == "__main__":
 
     set_line_nom_max(
         n,
-        s_nom_max_set=snakemake.config["lines"].get("s_nom_max,", np.inf),
-        p_nom_max_set=snakemake.config["links"].get("p_nom_max,", np.inf),
+        s_nom_max_set=snakemake.params["lines"].get("s_nom_max,", np.inf),
+        p_nom_max_set=snakemake.params["links"].get("p_nom_max,", np.inf),
     )
 
     if "ATK" in opts:

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -269,7 +269,7 @@ if __name__ == "__main__":
     for o in opts:
         m = re.match(r"^\d+seg$", o, re.IGNORECASE)
         if m is not None:
-            solver_name = snakemake.params.solver_name
+            solver_name = snakemake.config["solving"]["solver"]["name"]
             n = apply_time_segmentation(n, m.group(0)[:-3], solver_name)
             break
 

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -254,7 +254,7 @@ if __name__ == "__main__":
     costs = load_costs(
         snakemake.input.tech_costs,
         snakemake.params["costs"],
-        snakemake.params["electricity"],
+        snakemake.params["max_hours"],
         Nyears,
     )
 
@@ -269,7 +269,7 @@ if __name__ == "__main__":
     for o in opts:
         m = re.match(r"^\d+seg$", o, re.IGNORECASE)
         if m is not None:
-            solver_name = snakemake.params["solving"]["solver"]["name"]
+            solver_name = snakemake.params["solver_name"]
             n = apply_time_segmentation(n, m.group(0)[:-3], solver_name)
             break
 
@@ -277,11 +277,11 @@ if __name__ == "__main__":
         if "Co2L" in o:
             m = re.findall("[0-9]*\.?[0-9]+$", o)
             if len(m) > 0:
-                co2limit = float(m[0]) * snakemake.params["electricity"]["co2base"]
+                co2limit = float(m[0]) * snakemake.params["co2base"]
                 add_co2limit(n, co2limit, Nyears)
                 logger.info("Setting CO2 limit according to wildcard value.")
             else:
-                add_co2limit(n, snakemake.params["electricity"]["co2limit"], Nyears)
+                add_co2limit(n, snakemake.params["co2limit"], Nyears)
                 logger.info("Setting CO2 limit according to config value.")
             break
 
@@ -293,7 +293,7 @@ if __name__ == "__main__":
                 add_gaslimit(n, limit, Nyears)
                 logger.info("Setting gas usage limit according to wildcard value.")
             else:
-                add_gaslimit(n, snakemake.params["electricity"].get("gaslimit"), Nyears)
+                add_gaslimit(n, snakemake.params["gaslimit"], Nyears)
                 logger.info("Setting gas usage limit according to config value.")
             break
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3266,7 +3266,7 @@ if __name__ == "__main__":
             planning_horizons="2030",
         )
 
-    logging.basicConfig(level=snakemake.params["logging"]["level"])
+    logging.basicConfig(level=snakemake.config["logging"]["level"])
 
     update_config_with_sector_opts(snakemake.config, snakemake.wildcards.sector_opts)
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -252,7 +252,7 @@ def build_carbon_budget(o, input_eurostat, fn, emissions_scope, report_year):
         countries, input_eurostat, opts, emissions_scope, report_year, year=2018
     )
 
-    planning_horizons = snakemake.params["scenario"]["planning_horizons"]
+    planning_horizons = snakemake.params["planning_horizons"]
     t_0 = planning_horizons[0]
 
     if "be" in o:
@@ -391,7 +391,7 @@ def update_wind_solar_costs(n, costs):
         with xr.open_dataset(profile) as ds:
             underwater_fraction = ds["underwater_fraction"].to_pandas()
             connection_cost = (
-                snakemake.params["lines"]["length_factor"]
+                snakemake.params["length_factor"]
                 * ds["average_distance"].to_pandas()
                 * (
                     underwater_fraction
@@ -3300,7 +3300,7 @@ if __name__ == "__main__":
     if snakemake.params["foresight"] == "myopic":
         add_lifetime_wind_solar(n, costs)
 
-        conventional = snakemake.params["existing_capacities"]["conventional_carriers"]
+        conventional = snakemake.params["conventional_carriers"]
         for carrier in conventional:
             add_carrier_buses(n, carrier)
 
@@ -3365,7 +3365,7 @@ if __name__ == "__main__":
     if options["allam_cycle"]:
         add_allam(n, costs)
 
-    solver_name = snakemake.params["solving"]["solver"]["name"]
+    solver_name = snakemake.params["solver_name"]
     n = set_temporal_aggregation(n, opts, solver_name)
 
     limit_type = "config"
@@ -3376,8 +3376,8 @@ if __name__ == "__main__":
         limit_type = "carbon budget"
         fn = "results/" + snakemake.params.RDIR + "/csvs/carbon_budget_distribution.csv"
         if not os.path.exists(fn):
-            emissions_scope = snakemake.params["energy"]["emissions"]
-            report_year = snakemake.params["energy"]["eurostat_report_year"]
+            emissions_scope = snakemake.params["emissions_scope"]
+            report_year = snakemake.params["report_year"]
             build_carbon_budget(
                 o, snakemake.input.eurostat, fn, emissions_scope, report_year
             )
@@ -3413,7 +3413,7 @@ if __name__ == "__main__":
         add_electricity_grid_connection(n, costs)
 
     first_year_myopic = (snakemake.params["foresight"] == "myopic") and (
-        snakemake.params["scenario"]["planning_horizons"][0] == investment_year
+        snakemake.params["planning_horizons"][0] == investment_year
     )
 
     if options.get("cluster_heat_buses", False) and not first_year_myopic:

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -727,7 +727,7 @@ def cycling_shift(df, steps=1):
     return df
 
 
-def prepare_costs(cost_file, config, nyears):
+def prepare_costs(cost_file, params, nyears):
     # set all asset costs and other parameters
     costs = pd.read_csv(cost_file, index_col=[0, 1]).sort_index()
 
@@ -739,7 +739,7 @@ def prepare_costs(cost_file, config, nyears):
         costs.loc[:, "value"].unstack(level=1).groupby("technology").sum(min_count=1)
     )
 
-    costs = costs.fillna(config["fill_values"])
+    costs = costs.fillna(params["fill_values"])
 
     def annuity_factor(v):
         return annuity(v["lifetime"], v["discount rate"]) + v["FOM"] / 100

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3369,7 +3369,7 @@ if __name__ == "__main__":
     if options["allam_cycle"]:
         add_allam(n, costs)
 
-    solver_name = snakemake.params.solver_name
+    solver_name = snakemake.config["solving"]["solver"]["name"]
     n = set_temporal_aggregation(n, opts, solver_name)
 
     limit_type = "config"
@@ -3381,7 +3381,7 @@ if __name__ == "__main__":
         fn = "results/" + snakemake.params.RDIR + "/csvs/carbon_budget_distribution.csv"
         if not os.path.exists(fn):
             emissions_scope = snakemake.params.emissions_scope
-            report_year = snakemake.params.report_year
+            report_year = snakemake.params.eurostat_report_year
             build_carbon_budget(
                 o, snakemake.input.eurostat, fn, emissions_scope, report_year
             )

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -200,12 +200,12 @@ def co2_emissions_year(
     """
     Calculate CO2 emissions in one specific year (e.g. 1990 or 2018).
     """
-    emissions_scope = snakemake.config["energy"]["emissions"]
+    emissions_scope = snakemake.params["energy"]["emissions"]
     eea_co2 = build_eea_co2(snakemake.input.co2, year, emissions_scope)
 
     # TODO: read Eurostat data from year > 2014
     # this only affects the estimation of CO2 emissions for BA, RS, AL, ME, MK
-    report_year = snakemake.config["energy"]["eurostat_report_year"]
+    report_year = snakemake.params["energy"]["eurostat_report_year"]
     if year > 2014:
         eurostat_co2 = build_eurostat_co2(
             input_eurostat, countries, report_year, year=2014
@@ -241,7 +241,7 @@ def build_carbon_budget(o, input_eurostat, fn, emissions_scope, report_year):
         carbon_budget = float(o[o.find("cb") + 2 : o.find("ex")])
         r = float(o[o.find("ex") + 2 :])
 
-    countries = snakemake.config["countries"]
+    countries = snakemake.params["countries"]
 
     e_1990 = co2_emissions_year(
         countries, input_eurostat, opts, emissions_scope, report_year, year=1990
@@ -252,7 +252,7 @@ def build_carbon_budget(o, input_eurostat, fn, emissions_scope, report_year):
         countries, input_eurostat, opts, emissions_scope, report_year, year=2018
     )
 
-    planning_horizons = snakemake.config["scenario"]["planning_horizons"]
+    planning_horizons = snakemake.params["scenario"]["planning_horizons"]
     t_0 = planning_horizons[0]
 
     if "be" in o:
@@ -391,7 +391,7 @@ def update_wind_solar_costs(n, costs):
         with xr.open_dataset(profile) as ds:
             underwater_fraction = ds["underwater_fraction"].to_pandas()
             connection_cost = (
-                snakemake.config["lines"]["length_factor"]
+                snakemake.params["lines"]["length_factor"]
                 * ds["average_distance"].to_pandas()
                 * (
                     underwater_fraction
@@ -483,8 +483,8 @@ def remove_elec_base_techs(n):
     batteries and H2) from base electricity-only network, since they're added
     here differently using links.
     """
-    for c in n.iterate_components(snakemake.config["pypsa_eur"]):
-        to_keep = snakemake.config["pypsa_eur"][c.name]
+    for c in n.iterate_components(snakemake.params["pypsa_eur"]):
+        to_keep = snakemake.params["pypsa_eur"][c.name]
         to_remove = pd.Index(c.df.carrier.unique()).symmetric_difference(to_keep)
         if to_remove.empty:
             continue
@@ -674,7 +674,7 @@ def add_dac(n, costs):
 def add_co2limit(n, nyears=1.0, limit=0.0):
     logger.info(f"Adding CO2 budget limit as per unit of 1990 levels of {limit}")
 
-    countries = snakemake.config["countries"]
+    countries = snakemake.params["countries"]
 
     sectors = emission_sectors_from_opts(opts)
 
@@ -787,7 +787,7 @@ def add_ammonia(n, costs):
 
     nodes = pop_layout.index
 
-    cf_industry = snakemake.config["industry"]
+    cf_industry = snakemake.params["industry"]
 
     n.add("Carrier", "NH3")
 
@@ -1102,7 +1102,7 @@ def add_storage_and_grids(n, costs):
             lifetime=costs.at["OCGT", "lifetime"],
         )
 
-    cavern_types = snakemake.config["sector"]["hydrogen_underground_storage_locations"]
+    cavern_types = snakemake.params["sector"]["hydrogen_underground_storage_locations"]
     h2_caverns = pd.read_csv(snakemake.input.h2_cavern, index_col=0)
 
     if not h2_caverns.empty and options["hydrogen_underground_storage"]:
@@ -3266,11 +3266,11 @@ if __name__ == "__main__":
             planning_horizons="2030",
         )
 
-    logging.basicConfig(level=snakemake.config["logging"]["level"])
+    logging.basicConfig(level=snakemake.params["logging"]["level"])
 
     update_config_with_sector_opts(snakemake.config, snakemake.wildcards.sector_opts)
 
-    options = snakemake.config["sector"]
+    options = snakemake.params["sector"]
 
     opts = snakemake.wildcards.sector_opts.split("-")
 
@@ -3285,7 +3285,7 @@ if __name__ == "__main__":
 
     costs = prepare_costs(
         snakemake.input.costs,
-        snakemake.config["costs"],
+        snakemake.params["costs"],
         nyears,
     )
 
@@ -3297,10 +3297,10 @@ if __name__ == "__main__":
 
     spatial = define_spatial(pop_layout.index, options)
 
-    if snakemake.config["foresight"] == "myopic":
+    if snakemake.params["foresight"] == "myopic":
         add_lifetime_wind_solar(n, costs)
 
-        conventional = snakemake.config["existing_capacities"]["conventional_carriers"]
+        conventional = snakemake.params["existing_capacities"]["conventional_carriers"]
         for carrier in conventional:
             add_carrier_buses(n, carrier)
 
@@ -3365,19 +3365,19 @@ if __name__ == "__main__":
     if options["allam_cycle"]:
         add_allam(n, costs)
 
-    solver_name = snakemake.config["solving"]["solver"]["name"]
+    solver_name = snakemake.params["solving"]["solver"]["name"]
     n = set_temporal_aggregation(n, opts, solver_name)
 
     limit_type = "config"
-    limit = get(snakemake.config["co2_budget"], investment_year)
+    limit = get(snakemake.params["co2_budget"], investment_year)
     for o in opts:
         if "cb" not in o:
             continue
         limit_type = "carbon budget"
         fn = "results/" + snakemake.params.RDIR + "/csvs/carbon_budget_distribution.csv"
         if not os.path.exists(fn):
-            emissions_scope = snakemake.config["energy"]["emissions"]
-            report_year = snakemake.config["energy"]["eurostat_report_year"]
+            emissions_scope = snakemake.params["energy"]["emissions"]
+            report_year = snakemake.params["energy"]["eurostat_report_year"]
             build_carbon_budget(
                 o, snakemake.input.eurostat, fn, emissions_scope, report_year
             )
@@ -3412,8 +3412,8 @@ if __name__ == "__main__":
     if options["electricity_grid_connection"]:
         add_electricity_grid_connection(n, costs)
 
-    first_year_myopic = (snakemake.config["foresight"] == "myopic") and (
-        snakemake.config["scenario"]["planning_horizons"][0] == investment_year
+    first_year_myopic = (snakemake.params["foresight"] == "myopic") and (
+        snakemake.params["scenario"]["planning_horizons"][0] == investment_year
     )
 
     if options.get("cluster_heat_buses", False) and not first_year_myopic:

--- a/scripts/retrieve_databundle.py
+++ b/scripts/retrieve_databundle.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     to_fn = Path(f"{rootpath}/data")
 
     logger.info(f"Downloading databundle from '{url}'.")
-    disable_progress = snakemake.params["run"].get("disable_progressbar", False)
+    disable_progress = snakemake.config["run"].get("disable_progressbar", False)
     progress_retrieve(url, tarball_fn, disable=disable_progress)
 
     logger.info("Extracting databundle.")

--- a/scripts/retrieve_databundle.py
+++ b/scripts/retrieve_databundle.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
         snakemake
     )  # TODO Make logging compatible with progressbar (see PR #102)
 
-    if snakemake.params["tutorial"]:
+    if snakemake.params.tutorial:
         url = "https://zenodo.org/record/3517921/files/pypsa-eur-tutorial-data-bundle.tar.xz"
     else:
         url = "https://zenodo.org/record/3517935/files/pypsa-eur-data-bundle.tar.xz"

--- a/scripts/retrieve_databundle.py
+++ b/scripts/retrieve_databundle.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
         snakemake
     )  # TODO Make logging compatible with progressbar (see PR #102)
 
-    if snakemake.config["tutorial"]:
+    if snakemake.params["tutorial"]:
         url = "https://zenodo.org/record/3517921/files/pypsa-eur-tutorial-data-bundle.tar.xz"
     else:
         url = "https://zenodo.org/record/3517935/files/pypsa-eur-data-bundle.tar.xz"
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     to_fn = Path(f"{rootpath}/data")
 
     logger.info(f"Downloading databundle from '{url}'.")
-    disable_progress = snakemake.config["run"].get("disable_progressbar", False)
+    disable_progress = snakemake.params["run"].get("disable_progressbar", False)
     progress_retrieve(url, tarball_fn, disable=disable_progress)
 
     logger.info("Extracting databundle.")

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -510,7 +510,7 @@ if __name__ == "__main__":
 
     n = pypsa.Network(snakemake.input.network)
 
-    aggregation_strategies = snakemake.config["clustering"].get(
+    aggregation_strategies = snakemake.params["clustering"].get(
         "aggregation_strategies", {}
     )
     # translate str entries of aggregation_strategies to pd.Series functions:
@@ -525,8 +525,8 @@ if __name__ == "__main__":
 
     technology_costs = load_costs(
         snakemake.input.tech_costs,
-        snakemake.config["costs"],
-        snakemake.config["electricity"],
+        snakemake.params["costs"],
+        snakemake.params["electricity"],
         Nyears,
     )
 
@@ -536,7 +536,7 @@ if __name__ == "__main__":
 
     busmaps = [trafo_map, simplify_links_map]
 
-    cluster_config = snakemake.config["clustering"]["simplify_network"]
+    cluster_config = snakemake.params["clustering"]["simplify_network"]
     if cluster_config.get("remove_stubs", True):
         n, stub_map = remove_stubs(
             n,

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -172,10 +172,18 @@ def _prepare_connection_costs_per_link(n, costs, renewable_param, length_factor_
 
 
 def _compute_connection_costs_to_bus(
-    n, busmap, costs, renewable_param, length_factor_param, connection_costs_per_link=None, buses=None
+    n,
+    busmap,
+    costs,
+    renewable_param,
+    length_factor_param,
+    connection_costs_per_link=None,
+    buses=None,
 ):
     if connection_costs_per_link is None:
-        connection_costs_per_link = _prepare_connection_costs_per_link(n, costs, renewable_param, length_factor_param)
+        connection_costs_per_link = _prepare_connection_costs_per_link(
+            n, costs, renewable_param, length_factor_param
+        )
 
     if buses is None:
         buses = busmap.index[busmap.index != busmap.values]
@@ -265,7 +273,16 @@ def _aggregate_and_move_components(
         n.mremove(c, df.index[df.bus0.isin(buses_to_del) | df.bus1.isin(buses_to_del)])
 
 
-def simplify_links(n, costs, renewable_param, length_factor_param, p_max_pu_param, exclude_carriers_param, output, aggregation_strategies=dict()):
+def simplify_links(
+    n,
+    costs,
+    renewable_param,
+    length_factor_param,
+    p_max_pu_param,
+    exclude_carriers_param,
+    output,
+    aggregation_strategies=dict(),
+):
     ## Complex multi-node links are folded into end-points
     logger.info("Simplifying connected link components")
 
@@ -315,7 +332,9 @@ def simplify_links(n, costs, renewable_param, length_factor_param, p_max_pu_para
 
     busmap = n.buses.index.to_series()
 
-    connection_costs_per_link = _prepare_connection_costs_per_link(n, costs, renewable_param, length_factor_param)
+    connection_costs_per_link = _prepare_connection_costs_per_link(
+        n, costs, renewable_param, length_factor_param
+    )
     connection_costs_to_bus = pd.DataFrame(
         0.0, index=n.buses.index, columns=list(connection_costs_per_link)
     )
@@ -333,7 +352,13 @@ def simplify_links(n, costs, renewable_param, length_factor_param, p_max_pu_para
             )
             busmap.loc[buses] = b[np.r_[0, m.argmin(axis=0), 1]]
             connection_costs_to_bus.loc[buses] += _compute_connection_costs_to_bus(
-                n, busmap, costs, renewable_param, length_factor_param, connection_costs_per_link, buses
+                n,
+                busmap,
+                costs,
+                renewable_param,
+                length_factor_param,
+                connection_costs_per_link,
+                buses,
             )
 
             all_links = [i for _, i in sum(links, [])]
@@ -387,7 +412,16 @@ def simplify_links(n, costs, renewable_param, length_factor_param, p_max_pu_para
     return n, busmap
 
 
-def remove_stubs(n, costs, renewable_param, length_factor_param, clustering_param, exclude_carriers_param, output, aggregation_strategies=dict()):
+def remove_stubs(
+    n,
+    costs,
+    renewable_param,
+    length_factor_param,
+    clustering_param,
+    exclude_carriers_param,
+    output,
+    aggregation_strategies=dict(),
+):
     logger.info("Removing stubs")
 
     across_borders = clustering_param["simplify_network"].get(
@@ -396,11 +430,11 @@ def remove_stubs(n, costs, renewable_param, length_factor_param, clustering_para
     matching_attrs = [] if across_borders else ["country"]
     busmap = busmap_by_stubs(n, matching_attrs)
 
-    connection_costs_to_bus = _compute_connection_costs_to_bus(n, busmap, costs, renewable_param, length_factor_param)
-
-    exclude_carriers = clustering_param["simplify_network"].get(
-        "exclude_carriers", []
+    connection_costs_to_bus = _compute_connection_costs_to_bus(
+        n, busmap, costs, renewable_param, length_factor_param
     )
+
+    exclude_carriers = clustering_param["simplify_network"].get("exclude_carriers", [])
 
     _aggregate_and_move_components(
         n,
@@ -468,7 +502,14 @@ def aggregate_to_substations(n, aggregation_strategies=dict(), buses_i=None):
 
 
 def cluster(
-    n, n_clusters, focus_weights_param, renewable_param, solver_name_param, algorithm="hac", feature=None, aggregation_strategies=dict()
+    n,
+    n_clusters,
+    focus_weights_param,
+    renewable_param,
+    solver_name_param,
+    algorithm="hac",
+    feature=None,
+    aggregation_strategies=dict(),
 ):
     logger.info(f"Clustering to {n_clusters} buses")
 
@@ -524,13 +565,14 @@ if __name__ == "__main__":
     )
 
     n, simplify_links_map = simplify_links(
-        n, technology_costs, 
-        snakemake.params['renewable'], 
-        snakemake.params['length_factor'],
-        snakemake.params['p_max_pu'],
-        snakemake.params['exclude_carriers'],
-        snakemake.output, 
-        aggregation_strategies
+        n,
+        technology_costs,
+        snakemake.params["renewable"],
+        snakemake.params["length_factor"],
+        snakemake.params["p_max_pu"],
+        snakemake.params["exclude_carriers"],
+        snakemake.output,
+        aggregation_strategies,
     )
 
     busmaps = [trafo_map, simplify_links_map]
@@ -540,10 +582,10 @@ if __name__ == "__main__":
         n, stub_map = remove_stubs(
             n,
             technology_costs,
-            snakemake.params['renewable'], 
-            snakemake.params['length_factor'],
+            snakemake.params["renewable"],
+            snakemake.params["length_factor"],
             snakemake.params["clustering"],
-            snakemake.params['exclude_carriers'],
+            snakemake.params["exclude_carriers"],
             snakemake.output,
             aggregation_strategies=aggregation_strategies,
         )
@@ -579,9 +621,9 @@ if __name__ == "__main__":
         n, cluster_map = cluster(
             n,
             int(snakemake.wildcards.simpl),
-            snakemake.params['focus_weights'],
-            snakemake.params['renewable'],
-            snakemake.params['solver_name'],
+            snakemake.params["focus_weights"],
+            snakemake.params["renewable"],
+            snakemake.params["solver_name"],
             cluster_param.get("algorithm", "hac"),
             cluster_param.get("feature", None),
             aggregation_strategies,

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -560,7 +560,7 @@ if __name__ == "__main__":
     technology_costs = load_costs(
         snakemake.input.tech_costs,
         snakemake.params["costs"],
-        snakemake.params["electricity"],
+        snakemake.params["max_hours"],
         Nyears,
     )
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -147,7 +147,7 @@ def prepare_network(
     config=None,
     foresight_param=None,
     planning_horizons_param=None,
-    co2_sequestration_potential=None,
+    co2_sequestration_potential_param=None,
 ):
     if "clip_p_max_pu" in solve_opts:
         for df in (
@@ -688,7 +688,7 @@ if __name__ == "__main__":
         config=snakemake.config,
         foresight_param=snakemake.params["foresight"],
         planning_horizons_param=snakemake.params["planning_horizons"],
-        co2_sequestration_potential=snakemake.params["co2_sequestration_potential"],
+        co2_sequestration_potential_param=snakemake.params["co2_sequestration_potential"],
     )
 
     n = solve_network(

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -663,7 +663,7 @@ if __name__ == "__main__":
     if "sector_opts" in snakemake.wildcards.keys():
         opts += "-" + snakemake.wildcards.sector_opts
     opts = [o for o in opts.split("-") if o != ""]
-    solve_opts = snakemake.config["solving"]["options"]
+    solve_opts = snakemake.params["solving"]["options"]
 
     np.random.seed(solve_opts.get("seed", 123))
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -222,7 +222,7 @@ def add_CCL_constraints(n, config):
         agg_p_nom_limits: data/agg_p_nom_minmax.csv
     """
     agg_p_nom_minmax = pd.read_csv(
-        config['electricity']["agg_p_nom_limits"], index_col=[0, 1]
+        config["electricity"]["agg_p_nom_limits"], index_col=[0, 1]
     )
     logger.info("Adding generation capacity constraints per carrier and country")
     p_nom = n.model["Generator-p_nom"]
@@ -370,7 +370,7 @@ def add_SAFE_constraints(n, config):
     Which sets a reserve margin of 10% above the peak demand.
     """
     peakdemand = n.loads_t.p_set.sum(axis=1).max()
-    margin = 1.0 + config['electricity']["SAFE_reservemargin"]
+    margin = 1.0 + config["electricity"]["SAFE_reservemargin"]
     reserve_margin = peakdemand * margin
     # TODO: do not take this from the plotting config!
     conv_techs = config["plotting"]["conv_techs"]
@@ -675,10 +675,16 @@ if __name__ == "__main__":
     else:
         n = pypsa.Network(snakemake.input.network)
 
-    n = prepare_network(n, solve_opts, config=snakemake.config, param=snakemake.params["config_parts"])
+    n = prepare_network(
+        n, solve_opts, config=snakemake.config, param=snakemake.params["config_parts"]
+    )
 
     n = solve_network(
-        n, config=snakemake.config, solving_param=snakemake.params["solving"], opts=opts, log_fn=snakemake.log.solver
+        n,
+        config=snakemake.config,
+        solving_param=snakemake.params["solving"],
+        opts=opts,
+        log_fn=snakemake.log.solver,
     )
 
     n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -141,7 +141,14 @@ def add_co2_sequestration_limit(n, limit=200):
     )
 
 
-def prepare_network(n, solve_opts=None, config=None, foresight_param=None, planning_horizons_param=None, co2_sequestration_potential=None):
+def prepare_network(
+    n,
+    solve_opts=None,
+    config=None,
+    foresight_param=None,
+    planning_horizons_param=None,
+    co2_sequestration_potential=None,
+):
     if "clip_p_max_pu" in solve_opts:
         for df in (
             n.generators_t.p_max_pu,
@@ -681,7 +688,7 @@ if __name__ == "__main__":
         config=snakemake.config,
         foresight_param=snakemake.params["foresight"],
         planning_horizons_param=snakemake.params["planning_horizons"],
-        co2_sequestration_potential=snakemake.params["co2_sequestration_potential"]
+        co2_sequestration_potential=snakemake.params["co2_sequestration_potential"],
     )
 
     n = solve_network(

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -688,7 +688,9 @@ if __name__ == "__main__":
         config=snakemake.config,
         foresight_param=snakemake.params["foresight"],
         planning_horizons_param=snakemake.params["planning_horizons"],
-        co2_sequestration_potential_param=snakemake.params["co2_sequestration_potential"],
+        co2_sequestration_potential_param=snakemake.params[
+            "co2_sequestration_potential"
+        ],
     )
 
     n = solve_network(

--- a/scripts/solve_operations_network.py
+++ b/scripts/solve_operations_network.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
 
     opts = (snakemake.wildcards.opts + "-" + snakemake.wildcards.sector_opts).split("-")
     opts = [o for o in opts if o != ""]
-    solve_opts = snakemake.params["options"]
+    solve_opts = snakemake.params.options
 
     np.random.seed(solve_opts.get("seed", 123))
 

--- a/scripts/solve_operations_network.py
+++ b/scripts/solve_operations_network.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
 
     opts = (snakemake.wildcards.opts + "-" + snakemake.wildcards.sector_opts).split("-")
     opts = [o for o in opts if o != ""]
-    solve_opts = snakemake.params["solving"]["options"]
+    solve_opts = snakemake.params["options"]
 
     np.random.seed(solve_opts.get("seed", 123))
 

--- a/scripts/solve_operations_network.py
+++ b/scripts/solve_operations_network.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
 
     opts = (snakemake.wildcards.opts + "-" + snakemake.wildcards.sector_opts).split("-")
     opts = [o for o in opts if o != ""]
-    solve_opts = snakemake.config["solving"]["options"]
+    solve_opts = snakemake.params["solving"]["options"]
 
     np.random.seed(solve_opts.get("seed", 123))
 


### PR DESCRIPTION
# This is a re-do for the pull request in #296.

## Changes proposed in this Pull Request

Use the `params:` section in rule definition to keep track of changed settings in `config.yaml`.

https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#non-file-parameters-for-rules

The goal is that rules for which parameters have changed rerun automatically.

This can currently be done with:

https://snakemake.readthedocs.io/en/stable/project_info/faq.html#how-do-i-trigger-re-runs-for-rules-with-updated-code-or-parameters

```sh
snakemake -n -R `snakemake --list-params-changes`
```

or

```sh
snakemake -R $(snakemake --list-params-changes)
```

This will be even more convenient, once this `snakemake` PR is released:

https://github.com/snakemake/snakemake/pull/1107

```sh
snakemake --rerun-params-changed
```

or 

```sh
snakemake --rerun-changed
```

(which would also include code changes)

It seems to work very nicely to pass lists/dicts as params, which would help us keep config "blocks".

This PR is not complete yet, but a proof-of-concept for a selection of config settings. We can discuss from here and complete later.

## Rules Checklist

- [x] Snakefile
- [x] build_electricity.smk
- [x] build_sector.smk
- [x] collect.smk
- [x] common.smk
- [x] postprocess.smk
- [x] retrieve.smk
- [x] solve_electricity.smk
- [x] solve_myopic.smk
- [x] solve overnight.smk


## Script Checklist

- [ ] _helpers.py 
- [x] add_brownfield.py
- [x] add_electricity.py
- [x] add_existing_baseyear.py
- [x] add_extra_components.py
- [x] base_network.py
- [x] build_ammonia_production.py
- [x] build_biomass_potentials.py
- [x] build_biomass_transport_costs.py
- [x] build_bus_regions.py
- [x] build_clustered_population_layouts.py
- [x] build_cop_profiles.py
- [x] build_cutout.py
- [x] build_electricity_demand.py
- [x] build_energy_totals.py
- [x] build_gas_input_locations.py
- [x] build_gas_network.py
- [x] build_heat_demand.py
- [x] build_hydro_profile.py
- [x] build_industrial_distribution_key.py
- [x] build_industrial_energy_demand_per_country_today.py
- [x] build_industrial_energy_demand_per_node_today.py
- [x] build_industrial_energy_demand_per_node.py
- [x] build_industrial_production_per_country_tomorrow.py
- [x] build_industrial_production_per_country.py
- [x] build_industrial_production_per_node.py
- [x] build_industry_sector_ratios.py
- [x] build_natura_raster.py
- [x] build_population_layouts.py
- [x] build_population_weighted_energy_totals.py
- [x] build_powerplants.py
- [x] build_renewable_profiles.py
- [x] build_retro_cost.py
- [x] build_salt_cavern_potentials.py
- [x] build_sequestration_potentials.py
- [x] build_shapes.py
- [x] build_ship_raster.py
- [x] build_shipping_demand.py
- [x] build_solar_thermal_profiles.py
- [x] build_temperature_profiles.py
- [x] build_transport_demand.py
- [x] cluster_gas_network.py
- [x] cluster_network.py
- [x] copy_config.py
- [x] make_summary.py
- [x] plot_network.py
- [x] plot_summary.py
- [x] prepare_links_p_nom.py
- [x] prepare_network.py
- [x] prepare_sector_network.py
- [x] retrieve_databundle.py
- [x] retrieve_gas_infrastructure_data.py
- [x] retrieve_sector_databundle.py
- [x] simplify_network.py
- [x] solve_network.py
- [x] solve_operations_network.py

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
