### PR TITLE
address geopandas future warning

### DIFF
--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -234,7 +234,7 @@ def nuts3(country_shapes, nuts3, nuts3pop, nuts3gdp, ch_cantons, ch_popgdp):
     manual = gpd.GeoDataFrame(
         [["BA1", "BA", 3871.0], ["RS1", "RS", 7210.0], ["AL1", "AL", 2893.0]],
         columns=["NUTS_ID", "country", "pop"],
-        geometry=gpd.GeoSeries()
+        geometry=gpd.GeoSeries(),
     )
     manual["geometry"] = manual["country"].map(country_shapes)
     manual = manual.dropna()

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -234,6 +234,7 @@ def nuts3(country_shapes, nuts3, nuts3pop, nuts3gdp, ch_cantons, ch_popgdp):
     manual = gpd.GeoDataFrame(
         [["BA1", "BA", 3871.0], ["RS1", "RS", 7210.0], ["AL1", "AL", 2893.0]],
         columns=["NUTS_ID", "country", "pop"],
+        geometry=gpd.GeoSeries()
     )
     manual["geometry"] = manual["country"].map(country_shapes)
     manual = manual.dropna()


### PR DESCRIPTION
```
.build_shapes.py:242: FutureWarning: You are adding a column named 'geometry' to a GeoDataFrame constructed without an active geometry column. Currently, this automatically sets the active geometry column to 'geometry' but in the future that will no longer happen. Instead, either provide geometry to the GeoDataFrame constructor (GeoDataFrame(... geometry=GeoSeries()) or use `set_geometry('geometry')` to explicitly set the active geometry column.