### PR TITLE
Update cluster_network to avoid adding deleted links in clustered net…

### DIFF
--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -424,7 +424,10 @@ def clustering_for_n_clusters(
             n.links.eval("underwater_fraction * length").div(nc.links.length).dropna()
         )
         nc.links["capital_cost"] = nc.links["capital_cost"].add(
-            (nc.links.length - n.links.length).clip(lower=0).mul(extended_link_costs),
+            (nc.links.length - n.links.length)
+            .clip(lower=0)
+            .mul(extended_link_costs)
+            .dropna(),
             fill_value=0,
         )
 


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

While testing PyPSA-Earth, I found a bug in the links clustering detailed in https://github.com/pypsa-meets-earth/pypsa-earth/issues/735.
In particular, in the specific case, I clustered the LT network into 5 nodes and after the clustering, the unique link was connected to the same bus, so it was dropped and no links where available.
However, in performing the calculation to add the underground water, the old link was added with nan values because no dropna() was added.
This PR fixes that.

I don't think this needs a release_note, though, let me know

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
