### PR TITLE
Prevent attempt to re-add existing carriers.

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -16,6 +16,8 @@ Upcoming Release
 
 * Bugfix: Correct typo in the CPLEX solver configuration in ``config.default.yaml``.
 
+* Bugfix: Error in ``add_electricity`` where carriers were added multiple times to the network, resulting in a non-unique carriers error.
+
 * Renamed script file from PyPSA-EUR ``build_load_data`` to ``build_electricity_demand`` and ``retrieve_load_data`` to ``retrieve_electricity_demand``.
 
 * Fix docs readthedocs built

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -122,6 +122,7 @@ def calculate_annuity(n, r):
     else:
         return 1 / n
 
+
 def add_missing_carriers(n, carriers):
     """
     Function to add missing carriers to the network without raising errors.
@@ -129,6 +130,7 @@ def add_missing_carriers(n, carriers):
     missing_carriers = set(carriers) - set(n.carriers.index)
     if len(missing_carriers) > 0:
         n.madd("Carrier", missing_carriers)
+
 
 def sanitize_carriers(n, config):
     """

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -122,6 +122,13 @@ def calculate_annuity(n, r):
     else:
         return 1 / n
 
+def add_missing_carriers(n, carriers):
+    """
+    Function to add missing carriers to the network without raising errors.
+    """
+    missing_carriers = set(carriers) - set(n.carriers.index)
+    if len(missing_carriers) > 0:
+        n.madd("Carrier", missing_carriers)
 
 def sanitize_carriers(n, config):
     """
@@ -152,9 +159,7 @@ def sanitize_carriers(n, config):
 
     for c in n.iterate_components():
         if "carrier" in c.df:
-            missing_carrier = set(c.df.carrier.unique()) - set(n.carriers.index) - {""}
-            if len(missing_carrier):
-                n.madd("Carrier", missing_carrier)
+            add_missing_carriers(n, c.df)
 
     carrier_i = n.carriers.index
     nice_names = (
@@ -354,7 +359,7 @@ def update_transmission_costs(n, costs, length_factor=1.0):
 def attach_wind_and_solar(
     n, costs, input_profiles, carriers, extendable_carriers, line_length_factor=1
 ):
-    n.madd("Carrier", carriers)
+    add_missing_carriers(n, carriers)
 
     for car in carriers:
         if car == "hydro":
@@ -416,7 +421,7 @@ def attach_conventional_generators(
     conventional_inputs,
 ):
     carriers = list(set(conventional_carriers) | set(extendable_carriers["Generator"]))
-    n.madd("Carrier", carriers)
+    add_missing_carriers(n, carriers)
     add_co2_emissions(n, costs, carriers)
 
     ppl = (
@@ -473,7 +478,7 @@ def attach_conventional_generators(
 
 
 def attach_hydro(n, costs, ppl, profile_hydro, hydro_capacities, carriers, **params):
-    n.madd("Carrier", carriers)
+    add_missing_carriers(n, carriers)
     add_co2_emissions(n, costs, carriers)
 
     ppl = (
@@ -606,7 +611,7 @@ def attach_extendable_generators(n, costs, ppl, carriers):
     logger.warning(
         "The function `attach_extendable_generators` is deprecated in v0.5.0."
     )
-    n.madd("Carrier", carriers)
+    add_missing_carriers(n, carriers)
     add_co2_emissions(n, costs, carriers)
 
     for tech in carriers:


### PR DESCRIPTION
`add_electricity.py` would throw an error:

```
ERROR:pypsa.io:Error, new components for Carrier are not unique
```

which this PR prevents.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [n/a] Changed dependencies are added to `envs/environment.yaml`.
- [n/a] Changes in configuration options are added in all of `config.default.yaml`.
- [n/a] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
