### PR TITLE
fix in add_heating_capacities_installed_before_baseyear

### DIFF
--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -439,6 +439,11 @@ def add_heating_capacities_installed_before_baseyear(
                     + n.loads_t.p_set.sum()[f"{node} services rural heat"]
                 )
             )
+            # if rural heating demand for one of the nodes doesn't exist,
+            # then columns were dropped before and heating demand share should be 0.0
+            if (f"{node} residential rural heat" in n.loads_t.p_set.sum().index)
+               & (f"{node} services rural heat" in n.loads_t.p_set.sum().index)
+            else 0.0
             for node in nodal_df.index
         ],
         index=nodal_df.index,

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -442,7 +442,7 @@ def add_heating_capacities_installed_before_baseyear(
             # if rural heating demand for one of the nodes doesn't exist,
             # then columns were dropped before and heating demand share should be 0.0
             if (f"{node} residential rural heat" in n.loads_t.p_set.sum().index)
-               & (f"{node} services rural heat" in n.loads_t.p_set.sum().index)
+            & (f"{node} services rural heat" in n.loads_t.p_set.sum().index)
             else 0.0
             for node in nodal_df.index
         ],


### PR DESCRIPTION
fix in add_heating_capacities_installed_before_baseyear to account for case when there is no rural heating demand for some nodes in network.

Closes # (if applicable).

## Changes proposed in this Pull Request
if-else check in list-comprehension on l.444 to avoid error because rural heating demand does not exist for that region, i.e. is zero.


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
