### PR TITLE
[DNMY] Remove pre- and post- prefixes in sector coupled networks

### DIFF
--- a/doc/foresight.rst
+++ b/doc/foresight.rst
@@ -206,21 +206,21 @@ The myopic code solves the network for the time steps included in
    baseyear=2020, capacities installed before 2020 are added. In addition, the
    network comprises additional generator, storage, and link capacities with
    p_nom_extendable=True. The non-solved network is saved in
-   ``results/run_name/networks/prenetworks-brownfield``.
+   ``resources/run_name/networks/networks-brownfield``.
 
 The base year is the first element in ``planning_horizons``. Step 1 is
 implemented with the rule add_baseyear for the base year and with the rule
 add_brownfield for the remaining planning_horizons.
 
 2. The 2020 network is optimized. The solved network is saved in
-   ``results/run_name/networks/postnetworks``
+   ``results/run_name/networks/networks``
 
 3. For the next planning horizon, e.g. 2030, the capacities from a previous time
    step are added if they are still in operation (i.e., if they fulfil planning
    horizon <= commissioned year + lifetime). In addition, the network comprises
    additional generator, storage, and link capacities with
    p_nom_extendable=True. The non-solved network is saved in
-   ``results/run_name/networks/prenetworks-brownfield``.
+   ``resources/run_name/networks/networks-brownfield``.
 
 Steps 2 and 3 are solved recursively for all the planning_horizons included in
 ``config/config.yaml``.
@@ -260,12 +260,12 @@ Rule overview
   2045.
 
   Then, the resulting network is saved in
-  ``results/run_name/networks/prenetworks-brownfield``.
+  ``resources/run_name/networks/networks-brownfield``.
 
 - rule add_brownfield
 
   The rule add_brownfield loads the network in
-  ``results/run_name/networks/prenetworks`` and performs the following
+  ``resources/run_name/networks/networks`` and performs the following
   operation:
 
   1. Read the capacities optimized in the previous time step and add them to the
@@ -273,4 +273,4 @@ Rule overview
      horizon < commissioned year + lifetime)
 
   Then, the resulting network is saved in
-  ``results/run_name/networks/prenetworks_brownfield``.
+  ``resources/run_name/networks/networks_brownfield``.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,10 @@ Release Notes
 Upcoming Release
 ================
 
+* Networks that are stored in results/prenetworks are now stored in resources/networks. 
+  Remove the prefix of post- and pre- in network names originating from PyPSA-Eur-Sec to match PyPSA-Eur conventions. 
+  Brownfield networks are appended with the word _brownfield in their filename and placed in resources/networks.
+
 * Updated Global Energy Monitor LNG terminal data to March 2023 version.
 
 PyPSA-Eur 0.8.1 (27th July 2023)

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,8 +10,8 @@ Release Notes
 Upcoming Release
 ================
 
-* Networks that are stored in results/prenetworks are now stored in resources/networks. 
-  Remove the prefix of post- and pre- in network names originating from PyPSA-Eur-Sec to match PyPSA-Eur conventions. 
+* Networks that are stored in results/prenetworks are now stored in resources/networks.
+  Remove the prefix of post- and pre- in network names originating from PyPSA-Eur-Sec to match PyPSA-Eur conventions.
   Brownfield networks are appended with the word _brownfield in their filename and placed in resources/networks.
 
 * Updated Global Energy Monitor LNG terminal data to March 2023 version.

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -777,8 +777,8 @@ rule prepare_sector_network:
         if config["sector"]["solar_thermal"]
         else [],
     output:
-        RESULTS
-        + "prenetworks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
+        RESOURCES
+        + "networks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
     threads: 1
     resources:
         mem_mb=2000,

--- a/rules/collect.smk
+++ b/rules/collect.smk
@@ -43,8 +43,8 @@ rule prepare_elec_networks:
 rule prepare_sector_networks:
     input:
         expand(
-            RESULTS
-            + "prenetworks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
+            RESOURCES
+            + "networks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
             **config["scenario"]
         ),
 
@@ -61,7 +61,7 @@ rule solve_sector_networks:
     input:
         expand(
             RESULTS
-            + "postnetworks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
+            + "networks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
             **config["scenario"]
         ),
 

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -51,7 +51,7 @@ def solved_previous_horizon(wildcards):
     planning_horizon_p = str(planning_horizons[i - 1])
     return (
         RESULTS
-        + "postnetworks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_"
+        + "networks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_"
         + planning_horizon_p
         + ".nc"
     )

--- a/rules/postprocess.smk
+++ b/rules/postprocess.smk
@@ -14,7 +14,7 @@ rule plot_network:
         plotting=config["plotting"],
     input:
         network=RESULTS
-        + "postnetworks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
+        + "networks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
         regions=RESOURCES + "regions_onshore_elec_s{simpl}_{clusters}.geojson",
     output:
         map=RESULTS
@@ -61,7 +61,7 @@ rule make_summary:
     input:
         networks=expand(
             RESULTS
-            + "postnetworks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
+            + "networks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
             **config["scenario"]
         ),
         costs="data/costs_{}.csv".format(config["costs"]["year"])

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -10,8 +10,8 @@ rule add_existing_baseyear:
         existing_capacities=config["existing_capacities"],
         costs=config["costs"],
     input:
-        network=RESULTS
-        + "prenetworks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
+        network=RESOURCES
+        + "networks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
         powerplants=RESOURCES + "powerplants.csv",
         busmap_s=RESOURCES + "busmap_elec_s{simpl}.csv",
         busmap=RESOURCES + "busmap_elec_s{simpl}_{clusters}.csv",
@@ -24,8 +24,8 @@ rule add_existing_baseyear:
         existing_onwind="data/existing_infrastructure/onwind_capacity_IRENA.csv",
         existing_offwind="data/existing_infrastructure/offwind_capacity_IRENA.csv",
     output:
-        RESULTS
-        + "prenetworks-brownfield/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
+        RESOURCES
+        + "networks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}_brownfield.nc",
     wildcard_constraints:
         planning_horizons=config["scenario"]["planning_horizons"][0],  #only applies to baseyear
     threads: 1
@@ -51,15 +51,15 @@ rule add_brownfield:
         H2_retrofit_capacity_per_CH4=config["sector"]["H2_retrofit_capacity_per_CH4"],
         threshold_capacity=config["existing_capacities"]["threshold_capacity"],
     input:
-        network=RESULTS
-        + "prenetworks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
+        network=RESOURCES
+        + "networks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
         network_p=solved_previous_horizon,  #solved network at previous time step
         costs="data/costs_{planning_horizons}.csv",
         cop_soil_total=RESOURCES + "cop_soil_total_elec_s{simpl}_{clusters}.nc",
         cop_air_total=RESOURCES + "cop_air_total_elec_s{simpl}_{clusters}.nc",
     output:
-        RESULTS
-        + "prenetworks-brownfield/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
+        RESOURCES
+        + "networks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}_brownfield.nc",
     threads: 4
     resources:
         mem_mb=10000,
@@ -89,13 +89,13 @@ rule solve_sector_network_myopic:
             "co2_sequestration_potential", 200
         ),
     input:
-        network=RESULTS
-        + "prenetworks-brownfield/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
+        network=RESOURCES
+        + "networks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}_brownfield.nc",
         costs="data/costs_{planning_horizons}.csv",
         config=RESULTS + "config.yaml",
     output:
         RESULTS
-        + "postnetworks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
+        + "networks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
     shadow:
         "shallow"
     log:

--- a/rules/solve_overnight.smk
+++ b/rules/solve_overnight.smk
@@ -12,12 +12,12 @@ rule solve_sector_network:
             "co2_sequestration_potential", 200
         ),
     input:
-        network=RESULTS
-        + "prenetworks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
+        network=RESOURCES
+        + "networks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
         config=RESULTS + "config.yaml",
     output:
         RESULTS
-        + "postnetworks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
+        + "networks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
     shadow:
         "shallow"
     log:

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -685,7 +685,7 @@ if __name__ == "__main__":
     networks_dict = {
         (cluster, ll, opt + sector_opt, planning_horizon): "results/"
         + snakemake.params.RDIR
-        + f"/postnetworks/elec_s{simpl}_{cluster}_l{ll}_{opt}_{sector_opt}_{planning_horizon}.nc"
+        + f"/networks/elec_s{simpl}_{cluster}_l{ll}_{opt}_{sector_opt}_{planning_horizon}.nc"
         for simpl in snakemake.params.scenario["simpl"]
         for cluster in snakemake.params.scenario["clusters"]
         for opt in snakemake.params.scenario["opts"]


### PR DESCRIPTION
Closes #708.

## Changes proposed in this Pull Request

Networks that are stored in `results/prenetworks` are placed in `resources/networks`. Remove the prefix of post- and pre- to suit pypsa-eur conventions. Brownfield networks are added with the word _brownfield in their name.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] A release note `doc/release_notes.rst` is added.
