### PR TITLE
Fix in co2_emissions_year function and correspondingly in plot_summary.py and snakemake postprocess.smk

### DIFF
--- a/rules/postprocess.smk
+++ b/rules/postprocess.smk
@@ -106,6 +106,8 @@ rule plot_summary:
         countries=config["countries"],
         planning_horizons=config["scenario"]["planning_horizons"],
         sector_opts=config["scenario"]["sector_opts"],
+        emissions_scope=config["energy"]["emissions"],
+        eurostat_report_year=config["energy"]["eurostat_report_year"],
         plotting=config["plotting"],
         RDIR=RDIR,
     input:
@@ -113,6 +115,7 @@ rule plot_summary:
         energy=RESULTS + "csvs/energy.csv",
         balances=RESULTS + "csvs/supply_energy.csv",
         eurostat=input_eurostat,
+        co2="data/eea/UNFCCC_v23.csv",
     output:
         costs=RESULTS + "graphs/costs.pdf",
         energy=RESULTS + "graphs/energy.pdf",

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -387,6 +387,19 @@ def historical_emissions(countries):
         countries.remove("GB")
         countries.append("UK")
 
+    # Albania (AL) and Bosnia Herzegovina (BA), Montenegro (ME), Macedonia (MK) and  Serbia (RS)
+    # not included in eea historical emission dataset
+    if "AL" in countries:
+        countries.remove("AL")
+    if "BA" in countries:
+        countries.remove("BA")
+    if "ME" in countries:
+        countries.remove("ME")
+    if "MK" in countries:
+        countries.remove("MK")
+    if "RS" in countries:
+        countries.remove("RS")
+
     year = np.arange(1990, 2018).tolist()
 
     idx = pd.IndexSlice
@@ -457,9 +470,12 @@ def plot_carbon_budget_distribution(input_eurostat):
     ax1.set_ylim([0, 5])
     ax1.set_xlim([1990, snakemake.params.planning_horizons[-1] + 1])
 
-    path_cb = "results/" + snakemake.params.RDIR + "/csvs/"
+    path_cb = "results/" + snakemake.params.RDIR + "csvs/"
     countries = snakemake.params.countries
-    e_1990 = co2_emissions_year(countries, input_eurostat, opts, year=1990)
+    emissions_scope = snakemake.params.emissions_scope
+    report_year = snakemake.params.eurostat_report_year
+    input_co2 = snakemake.input.co2
+    e_1990 = co2_emissions_year(countries, input_eurostat, opts, emissions_scope, report_year, input_co2, year=1990)
     CO2_CAP = pd.read_csv(path_cb + "carbon_budget_distribution.csv", index_col=0)
 
     ax1.plot(e_1990 * CO2_CAP[o], linewidth=3, color="dodgerblue", label=None)

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -387,19 +387,9 @@ def historical_emissions(countries):
         countries.remove("GB")
         countries.append("UK")
 
-    # Albania (AL) and Bosnia Herzegovina (BA), Montenegro (ME), Macedonia (MK) and  Serbia (RS)
-    # not included in eea historical emission dataset
-    if "AL" in countries:
-        countries.remove("AL")
-    if "BA" in countries:
-        countries.remove("BA")
-    if "ME" in countries:
-        countries.remove("ME")
-    if "MK" in countries:
-        countries.remove("MK")
-    if "RS" in countries:
-        countries.remove("RS")
-
+    # remove countries which are not included in eea historical emission dataset
+    countries_to_remove = {"AL", "BA", "ME", "MK", "RS"}
+    countries = list(set(countries) - countries_to_remove)
     year = np.arange(1990, 2018).tolist()
 
     idx = pd.IndexSlice

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -475,7 +475,15 @@ def plot_carbon_budget_distribution(input_eurostat):
     emissions_scope = snakemake.params.emissions_scope
     report_year = snakemake.params.eurostat_report_year
     input_co2 = snakemake.input.co2
-    e_1990 = co2_emissions_year(countries, input_eurostat, opts, emissions_scope, report_year, input_co2, year=1990)
+    e_1990 = co2_emissions_year(
+        countries,
+        input_eurostat,
+        opts,
+        emissions_scope,
+        report_year,
+        input_co2,
+        year=1990,
+    )
     CO2_CAP = pd.read_csv(path_cb + "carbon_budget_distribution.csv", index_col=0)
 
     ax1.plot(e_1990 * CO2_CAP[o], linewidth=3, color="dodgerblue", label=None)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -191,17 +191,15 @@ def get(item, investment_year=None):
 
 
 def co2_emissions_year(
-    countries, input_eurostat, opts, emissions_scope, report_year, year
+    countries, input_eurostat, opts, emissions_scope, report_year, input_co2, year
 ):
     """
     Calculate CO2 emissions in one specific year (e.g. 1990 or 2018).
     """
-    emissions_scope = snakemake.params.energy["emissions"]
-    eea_co2 = build_eea_co2(snakemake.input.co2, year, emissions_scope)
+    eea_co2 = build_eea_co2(input_co2, year, emissions_scope)
 
     # TODO: read Eurostat data from year > 2014
     # this only affects the estimation of CO2 emissions for BA, RS, AL, ME, MK
-    report_year = snakemake.params.energy["eurostat_report_year"]
     if year > 2014:
         eurostat_co2 = build_eurostat_co2(
             input_eurostat, countries, report_year, year=2014
@@ -240,12 +238,12 @@ def build_carbon_budget(o, input_eurostat, fn, emissions_scope, report_year):
     countries = snakemake.params.countries
 
     e_1990 = co2_emissions_year(
-        countries, input_eurostat, opts, emissions_scope, report_year, year=1990
+        countries, input_eurostat, opts, emissions_scope, report_year, input_co2, year=1990
     )
 
     # emissions at the beginning of the path (last year available 2018)
     e_0 = co2_emissions_year(
-        countries, input_eurostat, opts, emissions_scope, report_year, year=2018
+        countries, input_eurostat, opts, emissions_scope, report_year, input_co2, year=2018
     )
 
     planning_horizons = snakemake.params.planning_horizons
@@ -3396,6 +3394,7 @@ if __name__ == "__main__":
         if not os.path.exists(fn):
             emissions_scope = snakemake.params.emissions_scope
             report_year = snakemake.params.eurostat_report_year
+            input_co2 = snakemake.input.co2
             build_carbon_budget(
                 o, snakemake.input.eurostat, fn, emissions_scope, report_year
             )

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -238,12 +238,24 @@ def build_carbon_budget(o, input_eurostat, fn, emissions_scope, report_year):
     countries = snakemake.params.countries
 
     e_1990 = co2_emissions_year(
-        countries, input_eurostat, opts, emissions_scope, report_year, input_co2, year=1990
+        countries,
+        input_eurostat,
+        opts,
+        emissions_scope,
+        report_year,
+        input_co2,
+        year=1990,
     )
 
     # emissions at the beginning of the path (last year available 2018)
     e_0 = co2_emissions_year(
-        countries, input_eurostat, opts, emissions_scope, report_year, input_co2, year=2018
+        countries,
+        input_eurostat,
+        opts,
+        emissions_scope,
+        report_year,
+        input_co2,
+        year=2018,
     )
 
     planning_horizons = snakemake.params.planning_horizons


### PR DESCRIPTION
fix in co2_emissions_year function and correspondingly in plot_summary and snakemake rule. `emissions_scope` and `report_year` were not properly assigned. Also input_co2 function parameter was added for usage of `co2_emissions_year` function outside of `prepare_sector_network` script.
Also changes to historical_emissions in plot_summary since some countries are not in eea dataset. Remove these countries from countries list.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
