### PR TITLE
industry distribution: use EPRTR as fallback if ETS missing

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,6 +12,8 @@ Upcoming Release
 
 * Updated Global Energy Monitor LNG terminal data to March 2023 version.
 
+* For industry distribution, use EPRTR as fallback if ETS data is not available.
+
 PyPSA-Eur 0.8.1 (27th July 2023)
 ================================
 

--- a/scripts/build_industrial_distribution_key.py
+++ b/scripts/build_industrial_distribution_key.py
@@ -115,7 +115,9 @@ def build_nodal_distribution_key(hotmaps, regions, countries):
         facilities = hotmaps.query("country == @country and Subsector == @sector")
 
         if not facilities.empty:
-            emissions = facilities["Emissions_ETS_2014"].fillna(hotmaps["Emissions_EPRTR_2014"])
+            emissions = facilities["Emissions_ETS_2014"].fillna(
+                hotmaps["Emissions_EPRTR_2014"]
+            )
             if emissions.sum() == 0:
                 key = pd.Series(1 / len(facilities), facilities.index)
             else:

--- a/scripts/build_industrial_distribution_key.py
+++ b/scripts/build_industrial_distribution_key.py
@@ -115,7 +115,7 @@ def build_nodal_distribution_key(hotmaps, regions, countries):
         facilities = hotmaps.query("country == @country and Subsector == @sector")
 
         if not facilities.empty:
-            emissions = facilities["Emissions_ETS_2014"]
+            emissions = facilities["Emissions_ETS_2014"].fillna(hotmaps["Emissions_EPRTR_2014"])
             if emissions.sum() == 0:
                 key = pd.Series(1 / len(facilities), facilities.index)
             else:


### PR DESCRIPTION
This is for example the case in Switzerland.

Before

![image](https://github.com/PyPSA/pypsa-eur/assets/29101152/9e89e4e6-c122-4341-8e5e-99c4288f1543)

After

![image](https://github.com/PyPSA/pypsa-eur/assets/29101152/4dc7e0f5-b11b-47ec-868f-128fda2033ff)
