### PR TITLE
sanitize_carriers: do not invent nice names, use carrier where not av…

### DIFF
--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -165,7 +165,7 @@ def sanitize_carriers(n, config):
     nice_names = (
         pd.Series(config["plotting"]["nice_names"])
         .reindex(carrier_i)
-        .fillna(carrier_i.to_series().str.title())
+        .fillna(carrier_i.to_series())
     )
     n.carriers["nice_name"] = n.carriers.nice_name.where(
         n.carriers.nice_name != "", nice_names


### PR DESCRIPTION
…ailable

The implicit title formatting causes weird names: "Offwind-Dc".

In case nice names are not given, the preferable solution is to keep the original name "offwind-dc".
