### PR TITLE
drop duplicates in prepare_hotmaps_database

### DIFF
--- a/scripts/build_industrial_distribution_key.py
+++ b/scripts/build_industrial_distribution_key.py
@@ -93,22 +93,16 @@ def prepare_hotmaps_database(regions):
     gdf.rename(columns={"index_right": "bus"}, inplace=True)
     gdf["country"] = gdf.bus.str[:2]
 
-    # the .sjoin can lead to duplicates if a geom is in two regions
+    # the .sjoin can lead to duplicates if a geom is in two overlapping regions
     if gdf.index.duplicated().any():
-        import pycountry
-
         # get all duplicated entries
         duplicated_i = gdf.index[gdf.index.duplicated()]
         # convert from raw data country name to iso-2-code
-        s = df.loc[duplicated_i, "Country"].apply(
-            lambda x: pycountry.countries.lookup(x).alpha_2
-        )
-        # Get a boolean mask where gdf's country column matches s's values for the same index
-        mask = gdf["country"] == gdf.index.map(s)
-        # Filter gdf using the mask
-        gdf_filtered = gdf[mask]
+        code = cc.convert(gdf.loc[duplicated_i, "Country"], to="iso2")
+        # screen out malformed country allocation
+        gdf_filtered = gdf.loc[duplicated_i].query("country == @code")
         # concat not duplicated and filtered gdf
-        gdf = pd.concat([gdf.drop(duplicated_i), gdf_filtered]).sort_index()
+        gdf = pd.concat([gdf.drop(duplicated_i), gdf_filtered])
 
     return gdf
 

--- a/scripts/build_industrial_distribution_key.py
+++ b/scripts/build_industrial_distribution_key.py
@@ -96,12 +96,15 @@ def prepare_hotmaps_database(regions):
     # the .sjoin can lead to duplicates if a geom is in two regions
     if gdf.index.duplicated().any():
         import pycountry
+
         # get all duplicated entries
         duplicated_i = gdf.index[gdf.index.duplicated()]
         # convert from raw data country name to iso-2-code
-        s = df.loc[duplicated_i, "Country"].apply(lambda x: pycountry.countries.lookup(x).alpha_2)
+        s = df.loc[duplicated_i, "Country"].apply(
+            lambda x: pycountry.countries.lookup(x).alpha_2
+        )
         # Get a boolean mask where gdf's country column matches s's values for the same index
-        mask = gdf['country'] == gdf.index.map(s)
+        mask = gdf["country"] == gdf.index.map(s)
         # Filter gdf using the mask
         gdf_filtered = gdf[mask]
         # concat not duplicated and filtered gdf

--- a/scripts/build_industrial_distribution_key.py
+++ b/scripts/build_industrial_distribution_key.py
@@ -93,6 +93,20 @@ def prepare_hotmaps_database(regions):
     gdf.rename(columns={"index_right": "bus"}, inplace=True)
     gdf["country"] = gdf.bus.str[:2]
 
+    # the .sjoin can lead to duplicates if a geom is in two regions
+    if gdf.index.duplicated().any():
+        import pycountry
+        # get all duplicated entries
+        duplicated_i = gdf.index[gdf.index.duplicated()]
+        # convert from raw data country name to iso-2-code
+        s = df.loc[duplicated_i, "Country"].apply(lambda x: pycountry.countries.lookup(x).alpha_2)
+        # Get a boolean mask where gdf's country column matches s's values for the same index
+        mask = gdf['country'] == gdf.index.map(s)
+        # Filter gdf using the mask
+        gdf_filtered = gdf[mask]
+        # concat not duplicated and filtered gdf
+        gdf = pd.concat([gdf.drop(duplicated_i), gdf_filtered]).sort_index()
+
     return gdf
 
 


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
The script `build_industrial_distribution_keys` breaks for some spatial resolution since there can appear duplicates in the hotmaps database because of a `.sjoin` function with the regions. In this PR the duplicated rows should be checked against the country in the original dataframe and all the duplicated sites which are set to the wrong country should be dropped.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
