### PR TITLE
Fix min capacity myopic

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -14,6 +14,8 @@ Upcoming Release
 
 * For industry distribution, use EPRTR as fallback if ETS data is not available.
 
+* The minimum capacity for renewable generators when using the myopic option has been fixed.
+
 PyPSA-Eur 0.8.1 (27th July 2023)
 ================================
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -63,18 +63,18 @@ def _add_land_use_constraint(n):
         existing.index += " " + carrier + "-" + snakemake.wildcards.planning_horizons
         n.generators.loc[existing.index, "p_nom_max"] -= existing
 
-    # # check if existing capacities are larger than technical potential
-    # existing_large = n.generators[
-    #     n.generators["p_nom_min"] > n.generators["p_nom_max"]
-    # ].index
-    # if len(existing_large):
-    #     logger.warning(
-    #         f"Existing capacities larger than technical potential for {existing_large},\
-    #                    adjust technical potential to existing capacities"
-    #     )
-    #     n.generators.loc[existing_large, "p_nom_max"] = n.generators.loc[
-    #         existing_large, "p_nom_min"
-    #     ]
+    # check if existing capacities are larger than technical potential
+    existing_large = n.generators[
+        n.generators["p_nom_min"] > n.generators["p_nom_max"]
+    ].index
+    if len(existing_large):
+        logger.warning(
+            f"Existing capacities larger than technical potential for {existing_large},\
+                        adjust technical potential to existing capacities"
+        )
+        n.generators.loc[existing_large, "p_nom_max"] = n.generators.loc[
+            existing_large, "p_nom_min"
+        ]
 
     n.generators.p_nom_max.clip(lower=0, inplace=True)
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -51,6 +51,9 @@ def _add_land_use_constraint(n):
     # warning: this will miss existing offwind which is not classed AC-DC and has carrier 'offwind'
 
     for carrier in ["solar", "onwind", "offwind-ac", "offwind-dc"]:
+        extendable_i = (n.generators.carrier == carrier) & n.generators.p_nom_extendable
+        n.generators.loc[extendable_i, "p_nom_min"] = 0
+        
         ext_i = (n.generators.carrier == carrier) & ~n.generators.p_nom_extendable
         existing = (
             n.generators.loc[ext_i, "p_nom"]
@@ -60,18 +63,18 @@ def _add_land_use_constraint(n):
         existing.index += " " + carrier + "-" + snakemake.wildcards.planning_horizons
         n.generators.loc[existing.index, "p_nom_max"] -= existing
 
-    # check if existing capacities are larger than technical potential
-    existing_large = n.generators[
-        n.generators["p_nom_min"] > n.generators["p_nom_max"]
-    ].index
-    if len(existing_large):
-        logger.warning(
-            f"Existing capacities larger than technical potential for {existing_large},\
-                       adjust technical potential to existing capacities"
-        )
-        n.generators.loc[existing_large, "p_nom_max"] = n.generators.loc[
-            existing_large, "p_nom_min"
-        ]
+    # # check if existing capacities are larger than technical potential
+    # existing_large = n.generators[
+    #     n.generators["p_nom_min"] > n.generators["p_nom_max"]
+    # ].index
+    # if len(existing_large):
+    #     logger.warning(
+    #         f"Existing capacities larger than technical potential for {existing_large},\
+    #                    adjust technical potential to existing capacities"
+    #     )
+    #     n.generators.loc[existing_large, "p_nom_max"] = n.generators.loc[
+    #         existing_large, "p_nom_min"
+    #     ]
 
     n.generators.p_nom_max.clip(lower=0, inplace=True)
 


### PR DESCRIPTION
Closes https://github.com/PyPSA/pypsa-eur/issues/727

## Changes proposed in this Pull Request
Fix the minimum capacity set for renewable generators when running the myopic configuration. 

I commented out the current code that imposes p_nom_min over p_nom_max. 
I think we don't need it anymore, but I'm not sure if I'm missing anything

## Checklist
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
