### PR TITLE
Fix bug preventing inclusion of custom_powerplants

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -20,6 +20,11 @@ Upcoming Release
 
 * Files extracted from sector-coupled data bundle have been moved from ``data/`` to ``data/sector-bundle``.
 
+
+**Bugs and Compatibility**
+
+* A bug preventing custom powerplants specified in ``data/custom_powerplants.csv`` was fixed. (https://github.com/PyPSA/pypsa-eur/pull/732)
+
 PyPSA-Eur 0.8.1 (27th July 2023)
 ================================
 

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -89,7 +89,7 @@ logger = logging.getLogger(__name__)
 def add_custom_powerplants(ppl, custom_powerplants, custom_ppl_query=False):
     if not custom_ppl_query:
         return ppl
-    add_ppls = pd.read_csv(custom_powerplants, index_col=0, dtype={"bus": "str"})
+    add_ppls = pd.read_csv(custom_powerplants, dtype={"bus": "str"})
     if isinstance(custom_ppl_query, str):
         add_ppls.query(custom_ppl_query, inplace=True)
     return pd.concat(


### PR DESCRIPTION
The first column of `custom_powerplants.csv` was read as index, but the `Name` column (non-index) was expected from the PPL. Maybe a breaking change caused by changes in PPM? I don't know. It worked in the past, but haven't used that feature in a while...

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
