### PR TITLE
Update calculations of retrofit costs

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
 - pip
 
 - atlite>=0.2.9
-- dask<=2023.9.1
+- dask
 
   # Dependencies of the workflow itself
 - xlrd

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
 - pip
 
 - atlite>=0.2.9
-- dask
+- dask<=2023.9.1
 
   # Dependencies of the workflow itself
 - xlrd
@@ -27,7 +27,7 @@ dependencies:
 - numpy
 - pandas>=1.4
 - geopandas>=0.11.0
-- xarray
+- xarray<=2023.8.0
 - rioxarray
 - netcdf4
 - networkx

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -609,7 +609,7 @@ if config["sector"]["retrofitting"]["retro_endogen"]:
             countries=config["countries"],
         input:
             building_stock="data/retro/data_building_stock.csv",
-            data_tabula="data/retro/tabula-calculator-calcsetbuilding.csv",
+            data_tabula="data/bundle-sector/retro/tabula-calculator-calcsetbuilding.csv",
             air_temperature=RESOURCES + "temp_air_total_elec_s{simpl}_{clusters}.nc",
             u_values_PL="data/retro/u_values_poland.csv",
             tax_w="data/retro/electricity_taxes_eu.csv",

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -198,6 +198,8 @@ def prepare_building_stock_data():
         }
     )
 
+    building_data["country_code"] = building_data["country"].map(country_iso_dic)    
+
     # heated floor area ----------------------------------------------------------
     area = building_data[
         (building_data.type == "Heated area [Mm²]")

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -987,7 +987,7 @@ def sample_dE_costs_area(
     # drop not considered countries
     cost_dE = cost_dE.reindex(countries, level=0)
     # get share of residential and service floor area
-    sec_w = area_tot.value / area_tot.value.groupby(level=0).sum()
+    sec_w = area_tot.div(area_tot.groupby(level=0).transform('sum'))
     # get the total cost-energy-savings weight by sector area
     tot = (
         cost_dE.mul(sec_w, axis=0)

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -223,7 +223,7 @@ def prepare_building_stock_data():
         usecols=[0, 1, 2, 3],
         encoding="ISO-8859-1",
     )
-    area_tot = area_tot.append(area_missing.unstack(level=-1).dropna().stack())
+    area_tot = pd.concat([area_tot, area_missing.unstack(level=-1).dropna().stack()])
     area_tot = area_tot.loc[~area_tot.index.duplicated(keep="last")]
 
     # for still missing countries calculate floor area by population size
@@ -246,7 +246,7 @@ def prepare_building_stock_data():
         averaged_data.index = index
         averaged_data["estimated"] = 1
         if ct not in area_tot.index.levels[0]:
-            area_tot = area_tot.append(averaged_data, sort=True)
+            area_tot = pd.concat([area_tot, averaged_data], sort=True)
         else:
             area_tot.loc[averaged_data.index] = averaged_data
 
@@ -272,7 +272,7 @@ def prepare_building_stock_data():
             ][x["bage"]].iloc[0],
             axis=1,
         )
-        data_PL_final = data_PL_final.append(data_PL)
+        data_PL_final = pd.concat([data_PL_final, data_PL])
 
     u_values = pd.concat([u_values, data_PL_final]).reset_index(drop=True)
 
@@ -966,7 +966,7 @@ def sample_dE_costs_area(
             .mean(level=1)
             .set_index(pd.MultiIndex.from_product([[ct], cost_dE.index.levels[1]]))
         )
-        cost_dE = cost_dE.append(averaged_data)
+        cost_dE = pd.concat(cost_dE, averaged_data)
 
     # weights costs after construction index
     if construction_index:
@@ -995,12 +995,12 @@ def sample_dE_costs_area(
             )
         )
     )
-    cost_dE = cost_dE.append(tot).unstack().stack()
+    cost_dE = pd.concat(cost_dE, tot).unstack().stack()
 
     summed_area = pd.DataFrame(area_tot.groupby("country").sum()).set_index(
         pd.MultiIndex.from_product([area_tot.index.unique(level="country"), ["tot"]])
     )
-    area_tot = area_tot.append(summed_area).unstack().stack()
+    area_tot = pd.concat(area_tot, summed_area).unstack().stack()
 
     cost_per_saving = cost_dE["cost"] / (
         1 - cost_dE["dE"]

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -970,7 +970,7 @@ def sample_dE_costs_area(
             .mean()
             .set_index(pd.MultiIndex.from_product([[ct], cost_dE.index.levels[1]]))
         )
-        cost_dE = pd.concat(cost_dE, averaged_data)
+        cost_dE = pd.concat([cost_dE, averaged_data])
 
     # weights costs after construction index
     if construction_index:
@@ -999,12 +999,12 @@ def sample_dE_costs_area(
             )
         )
     )
-    cost_dE = pd.concat(cost_dE, tot).unstack().stack()
+    cost_dE = pd.concat([cost_dE, tot]).unstack().stack()
 
     summed_area = pd.DataFrame(area_tot.groupby("country").sum()).set_index(
         pd.MultiIndex.from_product([area_tot.index.unique(level="country"), ["tot"]])
     )
-    area_tot = pd.concat(area_tot, summed_area).unstack().stack()
+    area_tot = pd.concat([area_tot, summed_area]).unstack().stack()
 
     cost_per_saving = cost_dE["cost"] / (
         1 - cost_dE["dE"]

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -949,7 +949,8 @@ def sample_dE_costs_area(
             .rename(index=rename_sectors, level=2)
             .reset_index()
         )
-        .rename(columns={"country": "country_code"})
+        # if uncommented, leads to the second `country_code` column
+        # .rename(columns={"country": "country_code"})
         .set_index(["country_code", "subsector", "bage"])
     )
 

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -990,19 +990,22 @@ def sample_dE_costs_area(
     sec_w = area_tot.div(area_tot.groupby(level=0).transform('sum'))
     # get the total cost-energy-savings weight by sector area
     tot = (
-        cost_dE.mul(sec_w, axis=0)
-        .groupby(level="country_code")
+        # sec_w has columns "estimated" and "value"
+        cost_dE.mul(sec_w.value, axis=0)
+        # for some reasons names of the levels were lost somewhere
+        #.groupby(level="country_code")
+        .groupby(level=0)
         .sum()
         .set_index(
             pd.MultiIndex.from_product(
-                [cost_dE.index.unique(level="country_code"), ["tot"]]
+                [cost_dE.index.unique(level=0), ["tot"]]
             )
         )
     )
     cost_dE = pd.concat([cost_dE, tot]).unstack().stack()
 
-    summed_area = pd.DataFrame(area_tot.groupby("country").sum()).set_index(
-        pd.MultiIndex.from_product([area_tot.index.unique(level="country"), ["tot"]])
+    summed_area = pd.DataFrame(area_tot.groupby(level=0).sum()).set_index(
+        pd.MultiIndex.from_product([area_tot.index.unique(level=0), ["tot"]])
     )
     area_tot = pd.concat([area_tot, summed_area]).unstack().stack()
 

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -201,7 +201,7 @@ def prepare_building_stock_data():
     # heated floor area ----------------------------------------------------------
     area = building_data[
         (building_data.type == "Heated area [Mm²]")
-        & (building_data.subsector != "Total")
+        & (building_data.detail != "Total")
     ]
     area_tot = area.groupby(["country", "sector"]).sum()
     area = pd.concat(

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -966,7 +966,8 @@ def sample_dE_costs_area(
     for ct in set(countries).difference(cost_dE.index.levels[0]):
         averaged_data = (
             cost_dE.reindex(index=map_for_missings[ct], level=0)
-            .mean(level=1)
+            .groupby(level=1)
+            .mean()
             .set_index(pd.MultiIndex.from_product([[ct], cost_dE.index.levels[1]]))
         )
         cost_dE = pd.concat(cost_dE, averaged_data)

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -198,12 +198,11 @@ def prepare_building_stock_data():
         }
     )
 
-    building_data["country_code"] = building_data["country"].map(country_iso_dic)    
+    building_data["country_code"] = building_data["country"].map(country_iso_dic)
 
     # heated floor area ----------------------------------------------------------
     area = building_data[
-        (building_data.type == "Heated area [Mm²]")
-        & (building_data.detail != "Total")
+        (building_data.type == "Heated area [Mm²]") & (building_data.detail != "Total")
     ]
     area_tot = area[["country", "sector", "value"]].groupby(["country", "sector"]).sum()
     area = pd.concat(
@@ -983,20 +982,16 @@ def sample_dE_costs_area(
     # drop not considered countries
     cost_dE = cost_dE.reindex(countries, level=0)
     # get share of residential and service floor area
-    sec_w = area_tot.div(area_tot.groupby(level=0).transform('sum'))
+    sec_w = area_tot.div(area_tot.groupby(level=0).transform("sum"))
     # get the total cost-energy-savings weight by sector area
     tot = (
         # sec_w has columns "estimated" and "value"
         cost_dE.mul(sec_w.value, axis=0)
         # for some reasons names of the levels were lost somewhere
-        #.groupby(level="country_code")
+        # .groupby(level="country_code")
         .groupby(level=0)
         .sum()
-        .set_index(
-            pd.MultiIndex.from_product(
-                [cost_dE.index.unique(level=0), ["tot"]]
-            )
-        )
+        .set_index(pd.MultiIndex.from_product([cost_dE.index.unique(level=0), ["tot"]]))
     )
     cost_dE = pd.concat([cost_dE, tot]).unstack().stack()
 

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -203,7 +203,7 @@ def prepare_building_stock_data():
         (building_data.type == "Heated area [Mm²]")
         & (building_data.detail != "Total")
     ]
-    area_tot = area.groupby(["country", "sector"]).sum()
+    area_tot = area[["country", "sector", "value"]].groupby(["country", "sector"]).sum()
     area = pd.concat(
         [
             area,

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -963,7 +963,7 @@ def sample_dE_costs_area(
     )
 
     # map missing countries
-    for ct in countries.difference(cost_dE.index.levels[0]):
+    for ct in set(countries).difference(cost_dE.index.levels[0]):
         averaged_data = (
             cost_dE.reindex(index=map_for_missings[ct], level=0)
             .mean(level=1)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1960,7 +1960,7 @@ def add_heat(n, costs):
         # demand 'dE' [per unit of original heat demand] for each country and
         # different retrofitting strengths [additional insulation thickness in m]
         retro_data = pd.read_csv(
-            snakemake.input.retro_cost_energy,
+            snakemake.input.retro_cost,
             index_col=[0, 1],
             skipinitialspace=True,
             header=[0, 1],


### PR DESCRIPTION
The PR is aimed to update retrofit calculations to make the model work with `retro_endogen: false`. The main reasons why updates are needed is that data structure may have been altered and pandas version has changed.

## Changes proposed in this Pull Request

-  replace pandas.append() was deprecated for a while and has been removed since pandas 2.0;
-  fix structure of area_tot (= total area) grouped dataframe to avoid messed concatenated columns;
-  fix a column name which contains subsector names for a building dataset: building_data.detail currently contains only [nan 'insulation' 'low-e'], while the script looks for "Totals" value which is currently contained in building_data.subsector;
-  deal with AssertionError: Length of new_levels (2) must be same as self.nlevels (3) which is currently arisen by reindex() function for prepare_building_topology( ) and map_tabula_to_hotmaps( ). That seems to be caused https://github.com/pandas-dev/pandas/issues/54909 for operation on insertion of smaller MultiIndex into larger MultiIndex and has been fixed recently with https://github.com/pandas-dev/pandas/pull/54885, which is one of milestones of pandas 2.1.1;
-  fix country codes in building_data to avoid messing-up "GB" and "UK";
-  remove duplicated country column in area_reordered;
-  fix call of difference( ) function;
-  fix computation of grouped means and total averages;
-  replace a level name with a number of the level.

Apart of the code fixes, the datakit structure should be ajusted a bit: `tabula-calculator-calcsetbuilding.csv` should be moved to `/pypsa-eur/data/retro`, where the workflow expects to find it.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
