### PR TITLE
Correction to GB hydropower capacity of ~5GW

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -31,6 +31,8 @@ Upcoming Release
 
 * Split configuration to enable SMR and SMR CC.
 
+* Corrected estimation of hydropower generation in GB by ~5 GW.
+
 
 **Bugs and Compatibility**
 

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -165,4 +165,20 @@ if __name__ == "__main__":
     cumcount = ppl.groupby(["bus", "Fueltype"]).cumcount() + 1
     ppl.Name = ppl.Name.where(cumcount == 1, ppl.Name + " " + cumcount.astype(str))
 
+    # Data used for GB hydropower appears to be faulty, overestimating capacity by ~5GW.
+    # The following lines correct the major issues.
+    logger.warning("Hard coded correction of GB hydro powerplants.")
+
+    # default 2016, see https://en.wikipedia.org/wiki/Dinorwig_Power_Station
+    ppl.loc[ppl.EIC == "{'48WSTN10000DINOQ'}", "Capacity"] = 1728
+    # according to data source has 1.80 GW capacity, however based on coords, there is
+    # no ppl of this size, true value could not be found dropping more correct than keeping.
+    ppl.drop(ppl.loc[ppl.EIC == "{'48WSTN00000STVEO'}"].index, inplace=True)
+    # from 999, see https://openinframap.org/stats/area/United%20Kingdom/plants/956053729 
+    ppl.loc[ppl.EIC == "{'48WSTN00000LOCGL'}", "Capacity"] = 6.
+    # from 999, see https://www.scottish-places.info/features/featurefirst3844.html
+    ppl.loc[ppl.EIC == "{'48WSTN00000GAURQ'}", "Capacity"] = 6.4
+    # from 999, see https://en.wikipedia.org/wiki/Shira_Hydro-Electric_Scheme
+    ppl.loc[ppl.EIC == "{'48WSTN00000SROM0'}", "Capacity"] = 40.
+
     ppl.reset_index(drop=True).to_csv(snakemake.output[0])

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -169,16 +169,16 @@ if __name__ == "__main__":
     # The following lines correct the major issues.
     logger.warning("Hard coded correction of GB hydro powerplants.")
 
-    # default 2016, see https://en.wikipedia.org/wiki/Dinorwig_Power_Station
-    ppl.loc[ppl.EIC == "{'48WSTN10000DINOQ'}", "Capacity"] = 1728
-    # according to data source has 1.80 GW capacity, however based on coords, there is
-    # no ppl of this size, true value could not be found dropping more correct than keeping.
-    ppl.drop(ppl.loc[ppl.EIC == "{'48WSTN00000STVEO'}"].index, inplace=True)
-    # from 999, see https://openinframap.org/stats/area/United%20Kingdom/plants/956053729 
+    # is 2016, but see https://en.wikipedia.org/wiki/Dinorwig_Power_Station
+    ppl.loc[ppl.EIC == "{'48WSTN10000DINOQ'}", "Capacity"] = 1728.
+    # is 999, but see https://openinframap.org/stats/area/United%20Kingdom/plants/956053729 
     ppl.loc[ppl.EIC == "{'48WSTN00000LOCGL'}", "Capacity"] = 6.
-    # from 999, see https://www.scottish-places.info/features/featurefirst3844.html
+    # is 999, but see https://www.scottish-places.info/features/featurefirst3844.html
     ppl.loc[ppl.EIC == "{'48WSTN00000GAURQ'}", "Capacity"] = 6.4
-    # from 999, see https://en.wikipedia.org/wiki/Shira_Hydro-Electric_Scheme
+    # is 999, but see https://en.wikipedia.org/wiki/Shira_Hydro-Electric_Scheme
     ppl.loc[ppl.EIC == "{'48WSTN00000SROM0'}", "Capacity"] = 40.
+    # according to data source has 1.80 GW capacity, however based on coords, there is
+    # no plant of this size, true value could not be found; dropping more correct than keeping.
+    ppl.drop(ppl.loc[ppl.EIC == "{'48WSTN00000STVEO'}"].index, inplace=True)
 
     ppl.reset_index(drop=True).to_csv(snakemake.output[0])


### PR DESCRIPTION

## Correcting Faulty Underlying Data on GB Hydropower Capacity

Across different data portals the capacity of around 5 hydropower plants in the UK is vastly overestimated. In most cases a capacity (hand-checked via geolocation) of typically 40 MW is reported as 999 MW. The errors accumulate to ~ 5GW of overestimation of capacity.

This PR adds a set of hard-coded corrections to `build_powerplants.py` fixing the most relevant errors in underlying data. Naturally, a more upstream solution in `powerplantmatching` would be desirable, please let me know if there is a good way to tackle this within `pm`.


## Checklist

- [X] I tested my contribution locally and it seems to work fine.
- [X] Code and workflow changes are sufficiently documented.
- [X] Changed dependencies are added to `envs/environment.yaml`.
- [X] A release note `doc/release_notes.rst` is added.
