### PR TITLE
Add tech_color for 'coal for industry' in config

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -799,6 +799,7 @@ plotting:
     Coal: '#545454'
     coal: '#545454'
     Coal marginal: '#545454'
+    coal for industry: '#343434'
     solid: '#545454'
     Lignite: '#826837'
     lignite: '#826837'


### PR DESCRIPTION
## Changes proposed in this Pull Request
Missing tech_color for "coal for industry" in config file to produce results/graphs/balances-coal.pdf. Picked #343434 (to complement #545454 for coal in same graph).