### PR TITLE
add emissions links instead of loads

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1581,7 +1581,9 @@ def add_land_transport(n, costs):
             spatial.oil.land_transport,
             bus=spatial.oil.land_transport,
             carrier="land transport oil",
-            p_set=ice_share / ice_efficiency * transport[nodes].rename(columns=lambda x: x + " land transport oil"),
+            p_set=ice_share
+            / ice_efficiency
+            * transport[nodes].rename(columns=lambda x: x + " land transport oil"),
         )
 
         n.madd(
@@ -2644,7 +2646,10 @@ def add_industry(n, costs):
             bus2="co2 atmosphere",
             carrier="shipping methanol",
             p_nom_extendable=True,
-            efficiency2=1 / options["MWh_MeOH_per_tCO2"], # CO2 intensity methanol based on stoichiometric calculation with 22.7 GJ/t methanol (32 g/mol), CO2 (44 g/mol), 277.78 MWh/TJ = 0.218 t/MWh
+            efficiency2=1
+            / options[
+                "MWh_MeOH_per_tCO2"
+            ],  # CO2 intensity methanol based on stoichiometric calculation with 22.7 GJ/t methanol (32 g/mol), CO2 (44 g/mol), 277.78 MWh/TJ = 0.218 t/MWh
         )
 
     if "oil" not in n.buses.carrier.unique():
@@ -2761,7 +2766,15 @@ def add_industry(n, costs):
     # NB: CO2 gets released again to atmosphere when plastics decay
     # except for the process emissions when naphtha is used for petrochemicals, which can be captured with other industry process emissions
     # convert process emissions from feedstock from MtCO2 to energy demand
-    p_set = demand_factor * (industrial_demand.loc[nodes, "naphtha"] - industrial_demand.loc[nodes, "process emission from feedstock"] / costs.at["oil", "CO2 intensity"]).sum() / nhours
+    p_set = (
+        demand_factor
+        * (
+            industrial_demand.loc[nodes, "naphtha"]
+            - industrial_demand.loc[nodes, "process emission from feedstock"]
+            / costs.at["oil", "CO2 intensity"]
+        ).sum()
+        / nhours
+    )
 
     n.add(
         "Bus",

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2778,7 +2778,8 @@ def add_industry(n, costs):
 
     p_set_process_emissions = (
         demand_factor
-        * (industrial_demand.loc[nodes, "process emission from feedstock"]
+        * (
+            industrial_demand.loc[nodes, "process emission from feedstock"]
             / costs.at["oil", "CO2 intensity"]
         ).sum()
         / nhours


### PR DESCRIPTION
… for land transport oil (ICEs), naphtha for industry and kerosene for aviation (before summed as 'oil'), shipping oil, shipping methanol, agriculture machinery oil

## Changes proposed in this Pull Request
Add links and energy demand loads for the above-mentioned emissions sources instead of equal-and-opposite fuel/emissions loads on fuel bus/co2 atmosphere bus.

## Executed tests
Run current master vs. the proposed change, compare objective and co2 emissions from `statistics.energy_balance`.

Set config.yaml to:
```
scenario:
  clusters:
  - 37
  sector_opts:
  - Co2L0-365H-T-H-B-I-A-solar+p3-dist1
```

## Test results
obejctive diff < .1%
co2 emissions diffs <1Mt for each carrier

![grafik](https://github.com/PyPSA/pypsa-eur/assets/97453975/5e0669f2-39b1-4114-b4ce-809ac2b03455)

## Code snippet for test
```
import pypsa
import pandas as pd

run_master = "master"
run_change = "proposed-change"

### Load PyPSA-Eur networks
n0 = pypsa.Network(run_master +"/postnetworks/elec_s_37_lv1.5__Co2L0-365H-T-H-B-I-A-solar+p3-dist1_2050.nc")
n1 = pypsa.Network(run_change +"/postnetworks/elec_s_37_lv1.5__Co2L0-365H-T-H-B-I-A-solar+p3-dist1_2050.nc")

### Compare objective
print("Objective n0: ", n0.objective/1e9)
print("Objective n1: ", n1.objective/1e9)

### Make diff of co2 emissions in Mt from statistics module
print("CO2 emissions diff by carrier: ",(n0.statistics.energy_balance().loc[:, :, "co2"].groupby("carrier").sum() - n1.statistics.energy_balance().loc[:, :, "co2"].groupby("carrier").sum()).dropna()/1e6)

s1 = n0.statistics.energy_balance().loc[:, :, "co2"].groupby("carrier").sum()/1e6
s2 = n1.statistics.energy_balance().loc[:, :, "co2"].groupby("carrier").sum()/1e6
pd.concat([s1, s2], axis=1)

```
## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
