### PR TITLE
Minor fixes for retrofit calculations

### DIFF
--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -203,7 +203,7 @@ def prepare_building_stock_data():
 
     # heated floor area ----------------------------------------------------------
     area = building_data[
-        (building_data.type == "Heated area [Mm²]") & (building_data.detail != "Total")
+        (building_data.type == "Heated area [Mm²]") & (building_data.subsector != "Total")
     ]
     area_tot = area[["country", "sector", "value"]].groupby(["country", "sector"]).sum()
     area = pd.concat(

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -169,7 +169,7 @@ def prepare_building_stock_data():
             "Construction features (U-value)": "Construction features (U-values)",
         },
         inplace=True,
-    )     
+    )
 
     building_data.country_code = building_data.country_code.str.upper()
     building_data["subsector"].replace(

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -155,7 +155,6 @@ def prepare_building_stock_data():
     building_data["type"].replace(
         {
             "Covered area: heated  [Mm²]": "Heated area [Mm²]",
-            "Construction features (U-value)": "Construction features (U-values)",
             "Windows ": "Window",
             "Windows": "Window",
             "Walls ": "Wall",
@@ -165,6 +164,12 @@ def prepare_building_stock_data():
         },
         inplace=True,
     )
+    building_data["feature"].replace(
+        {
+            "Construction features (U-value)": "Construction features (U-values)",
+        },
+        inplace=True,
+    )     
 
     building_data.country_code = building_data.country_code.str.upper()
     building_data["subsector"].replace(

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -155,6 +155,7 @@ def prepare_building_stock_data():
     building_data["type"].replace(
         {
             "Covered area: heated  [Mm²]": "Heated area [Mm²]",
+            "Construction features (U-value)": "Construction features (U-values)",
             "Windows ": "Window",
             "Windows": "Window",
             "Walls ": "Wall",


### PR DESCRIPTION
## Changes proposed in this Pull Request

Fixing some minor discrepancies for buildings area calculations in `build_retro_cost` script. In particular:
1) U-values for Poland are represented in hotmaps dataset as `Construction features (U-value)` instead of `Construction features (U-values)`;
2) "Total" feature is contained in `subsector` column, not in `detail` one.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
