### PR TITLE
madd oil generator to bus EU oil

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1556,24 +1556,7 @@ def add_land_transport(n, costs):
         )
 
     if ice_share > 0:
-        if "oil" not in n.buses.carrier.unique():
-            n.madd(
-                "Bus",
-                spatial.oil.nodes,
-                location=spatial.oil.locations,
-                carrier="oil",
-                unit="MWh_LHV",
-            )
-
-        if "oil" not in n.generators.carrier.unique():
-            n.madd(
-                "Generator",
-                spatial.oil.nodes,
-                bus=spatial.oil.nodes,
-                p_nom_extendable=True,
-                carrier="oil",
-                marginal_cost=costs.at["oil", "fuel"],
-            )
+        add_carrier_buses(n, "oil")
 
         ice_efficiency = options["transport_internal_combustion_efficiency"]
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1565,6 +1565,16 @@ def add_land_transport(n, costs):
                 unit="MWh_LHV",
             )
 
+        if "oil" not in n.generators.carrier.unique():
+            n.madd(
+            "Generator",
+            spatial.oil.nodes,
+            bus=spatial.oil.nodes,
+            p_nom_extendable=True,
+            carrier="oil",
+            marginal_cost=costs.at["oil", "fuel"],
+        )
+
         ice_efficiency = options["transport_internal_combustion_efficiency"]
 
         n.madd(

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1567,13 +1567,13 @@ def add_land_transport(n, costs):
 
         if "oil" not in n.generators.carrier.unique():
             n.madd(
-            "Generator",
-            spatial.oil.nodes,
-            bus=spatial.oil.nodes,
-            p_nom_extendable=True,
-            carrier="oil",
-            marginal_cost=costs.at["oil", "fuel"],
-        )
+                "Generator",
+                spatial.oil.nodes,
+                bus=spatial.oil.nodes,
+                p_nom_extendable=True,
+                carrier="oil",
+                marginal_cost=costs.at["oil", "fuel"],
+            )
 
         ice_efficiency = options["transport_internal_combustion_efficiency"]
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
Add a oil generator to bus `EU oil`, when adding the transport sector. Without it, existing loads lead to a LHS RHS imbalance in the LP file and the isolated transport sector model cannot be solved (`Error: ValueError: Empty LHS with non-zero RHS in nodal balance constraint`).

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
