### PR TITLE
update xarray in environment.yaml

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -27,7 +27,7 @@ dependencies:
 - numpy
 - pandas>=1.4
 - geopandas>=0.11.0
-- xarray<=2023.8.0
+- xarray
 - rioxarray
 - netcdf4
 - networkx


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day, here I propose changes into `environment.yaml` file. In particular, I am proposing to set `xarray` without any version specific. Currently it is set as `xarray<=2023.8.0`. It was causing the issue very recently. I am attaching the error message below. I have tried several time installing from the fresh and creating new environments, but the issue persisted. The error appeared in tutorials either. The error was reproduced by @ekatef. Moreover, @ekatef suggested to using `xarray` instead of `xarray<=2023.8.0` during environment creation. It resolved the issue (in my version `xarray=2023.10.1`.
![image](https://github.com/PyPSA/pypsa-eur/assets/113768325/11a68dfa-5dc4-4ce7-b65b-ad7421788091)
[error (2).txt](https://github.com/PyPSA/pypsa-eur/files/13339369/error.2.txt)


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [ ] A release note `doc/release_notes.rst` is added.
