### PR TITLE
Fix link to licenses.rst in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,6 @@ We strongly welcome anyone interested in contributing to this project. If you ha
 # Licence
 
 The code in PyPSA-Eur is released as free software under the
-[MIT License](https://opensource.org/licenses/MIT), see `LICENSE.txt`.
+[MIT License](https://opensource.org/licenses/MIT), see [`doc/licenses.rst`](doc/licenses.rst).
 However, different licenses and terms of use may apply to the various
 input data.


### PR DESCRIPTION
This is just a minor fix in the README.md file.

LICENSES.txt was never part of this repository, might have been copied accidentally from the README file in the main PyPSA repository.