### PR TITLE
change coords name co2 limit per country

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1603,7 +1603,9 @@ def add_land_transport(n, costs):
             spatial.oil.land_transport,
             bus=spatial.oil.land_transport,
             carrier="land transport oil",
-            p_set=ice_share / ice_efficiency * transport[nodes].rename(columns=lambda x: x + " land transport oil"),
+            p_set=ice_share
+            / ice_efficiency
+            * transport[nodes].rename(columns=lambda x: x + " land transport oil"),
         )
 
         n.madd(
@@ -2445,7 +2447,7 @@ def add_industry(n, costs):
         efficiency=1.0,
     )
 
-    if len(spatial.biomass.industry_cc)<=1 and len(spatial.co2.nodes)>1:
+    if len(spatial.biomass.industry_cc) <= 1 and len(spatial.co2.nodes) > 1:
         link_names = nodes + " " + spatial.biomass.industry_cc
     else:
         link_names = spatial.biomass.industry_cc
@@ -2671,7 +2673,10 @@ def add_industry(n, costs):
             bus2="co2 atmosphere",
             carrier="shipping methanol",
             p_nom_extendable=True,
-            efficiency2=1 / options["MWh_MeOH_per_tCO2"], # CO2 intensity methanol based on stoichiometric calculation with 22.7 GJ/t methanol (32 g/mol), CO2 (44 g/mol), 277.78 MWh/TJ = 0.218 t/MWh
+            efficiency2=1
+            / options[
+                "MWh_MeOH_per_tCO2"
+            ],  # CO2 intensity methanol based on stoichiometric calculation with 22.7 GJ/t methanol (32 g/mol), CO2 (44 g/mol), 277.78 MWh/TJ = 0.218 t/MWh
         )
 
     if "oil" not in n.buses.carrier.unique():
@@ -2789,21 +2794,40 @@ def add_industry(n, costs):
     # convert process emissions from feedstock from MtCO2 to energy demand
     # need to aggregate potentials if oil not nodally resolved
     if options["co2_budget_national"]:
-        p_set_plastics = demand_factor * (industrial_demand.loc[nodes, "naphtha"] - industrial_demand.loc[nodes, "process emission from feedstock"] / costs.at["oil", "CO2 intensity"]) / nhours
+        p_set_plastics = (
+            demand_factor
+            * (
+                industrial_demand.loc[nodes, "naphtha"]
+                - industrial_demand.loc[nodes, "process emission from feedstock"]
+                / costs.at["oil", "CO2 intensity"]
+            )
+            / nhours
+        )
     else:
-        p_set_plastics = demand_factor * (industrial_demand.loc[nodes, "naphtha"] - industrial_demand.loc[nodes, "process emission from feedstock"] / costs.at["oil", "CO2 intensity"]).sum() / nhours
+        p_set_plastics = (
+            demand_factor
+            * (
+                industrial_demand.loc[nodes, "naphtha"]
+                - industrial_demand.loc[nodes, "process emission from feedstock"]
+                / costs.at["oil", "CO2 intensity"]
+            ).sum()
+            / nhours
+        )
 
     if options["co2_budget_national"]:
         p_set_process_emissions = (
             demand_factor
-            * (industrial_demand.loc[nodes, "process emission from feedstock"]
-                / costs.at["oil", "CO2 intensity"])
+            * (
+                industrial_demand.loc[nodes, "process emission from feedstock"]
+                / costs.at["oil", "CO2 intensity"]
+            )
             / nhours
         )
     else:
         p_set_process_emissions = (
             demand_factor
-            * (industrial_demand.loc[nodes, "process emission from feedstock"]
+            * (
+                industrial_demand.loc[nodes, "process emission from feedstock"]
                 / costs.at["oil", "CO2 intensity"]
             ).sum()
             / nhours
@@ -3114,9 +3138,9 @@ def add_agriculture(n, costs):
             f"Total agriculture machinery shares sum up to {total_share:.2%}, corresponding to increased or decreased demand assumptions."
         )
 
-    machinery_nodal_energy = pop_weighted_energy_totals.loc[
-        nodes, "total agriculture machinery"
-    ] * 1e6
+    machinery_nodal_energy = (
+        pop_weighted_energy_totals.loc[nodes, "total agriculture machinery"] * 1e6
+    )
 
     if electric_share > 0:
         efficiency_gain = (
@@ -3130,10 +3154,7 @@ def add_agriculture(n, costs):
             suffix=" agriculture machinery electric",
             bus=nodes,
             carrier="agriculture machinery electric",
-            p_set=electric_share
-            / efficiency_gain
-            * machinery_nodal_energy
-            / nhours,
+            p_set=electric_share / efficiency_gain * machinery_nodal_energy / nhours,
         )
 
     if oil_share > 0:

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -841,10 +841,10 @@ def add_co2limit_country(n, limit_countries, nyears=1.0):
             lhs.append(expr)
 
     lhs = sum(lhs)  # dimension: (country)
-    lhs = lhs.rename({list(lhs.dims.keys())[0]: "country"})
+    lhs = lhs.rename({list(lhs.dims.keys())[0]: "snapshot"})
     rhs = pd.Series(co2_limit_countries)  # dimension: (country)
 
-    for ct in lhs.indexes["country"]:
+    for ct in lhs.indexes["snapshot"]:
         n.model.add_constraints(
             lhs.loc[ct] <= rhs[ct],
             name=f"GlobalConstraint-co2_limit_per_country{ct}",

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -39,9 +39,8 @@ from pypsa.descriptors import get_activity_mask
 
 logger = logging.getLogger(__name__)
 pypsa.pf.logger.setLevel(logging.WARNING)
-from pypsa.descriptors import get_switchable_as_dense as get_as_dense
-
 from prepare_sector_network import emission_sectors_from_opts
+from pypsa.descriptors import get_switchable_as_dense as get_as_dense
 
 
 def add_land_use_constraint(n, planning_horizons, config):
@@ -789,7 +788,9 @@ def add_co2limit_country(n, limit_countries, nyears=1.0):
     co2_totals = 1e6 * pd.read_csv(snakemake.input.co2_totals_name, index_col=0)
 
     co2_limit_countries = co2_totals.loc[countries, sectors].sum(axis=1)
-    co2_limit_countries = co2_limit_countries.loc[co2_limit_countries.index.isin(limit_countries.keys())]
+    co2_limit_countries = co2_limit_countries.loc[
+        co2_limit_countries.index.isin(limit_countries.keys())
+    ]
 
     co2_limit_countries *= co2_limit_countries.index.map(limit_countries) * nyears
 
@@ -831,13 +832,11 @@ def add_co2limit_country(n, limit_countries, nyears=1.0):
 
         if not grouping.isnull().all():
             expr = (
-                ((p.loc[:, idx] * efficiency[idx] * international[idx])
+                (p.loc[:, idx] * efficiency[idx] * international[idx])
                 .groupby(grouping, axis=1)
                 .sum()
-                *n.snapshot_weightings.generators
-                )
-                .sum(dims="snapshot")
-            )
+                * n.snapshot_weightings.generators
+            ).sum(dims="snapshot")
             lhs.append(expr)
 
     lhs = sum(lhs)  # dimension: (country)


### PR DESCRIPTION
Closes # (if applicable).
This PR should check the constraint CO2 limit per country

## Changes proposed in this Pull Request

- [x] rename coordinates of the constraint so that dual variables can be assigned correctly
- [ ] rework the constraint or the prepare_sector_network so that process emissions are accounted correctly
- [ ] adjust to decision made for oil carrier (if copper platted emissions should be accounted by index), if oil links are added between the nodes then nothing has to be changed in the constraint

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
