### PR TITLE
for clustering fall back to ipopt when highs is solver

### DIFF
--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -271,7 +271,7 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name="cbc"):
     )
 
     opt = po.SolverFactory(solver_name)
-    if not opt.has_capability("quadratic_objective"):
+    if solver_name == "appsi_highs" or not opt.has_capability("quadratic_objective"):
         logger.warning(
             f"The configured solver `{solver_name}` does not support quadratic objectives. Falling back to `ipopt`."
         )
@@ -466,6 +466,7 @@ if __name__ == "__main__":
 
     params = snakemake.params
     solver_name = snakemake.config["solving"]["solver"]["name"]
+    solver_name = "appsi_highs" if solver_name == "highs" else solver_name
 
     n = pypsa.Network(snakemake.input.network)
 


### PR DESCRIPTION
In pyomo, "highs" is called "appsi_highs" which refers to a separate interface. This also means that the function "has_capability" is not available.

Using "highs" for the clustering optimisation problem also resulted in errors.