### PR TITLE
fix f weighting for retro cost

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1991,7 +1991,7 @@ def add_heat(n, costs):
             elif "urban decentral" in name:
                 f = urban_fraction[node] - dist_fraction[node]
             else:
-                f = 1 - urban_fraction[node]            
+                f = 1 - urban_fraction[node]
             if f == 0:
                 continue
             # get sector name ("residential"/"services"/or both "tot" for urban central)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1986,7 +1986,12 @@ def add_heat(n, costs):
             ct = pop_layout.loc[node, "ct"]
 
             # weighting 'f' depending on the size of the population at the node
-            f = urban_fraction[node] if "urban" in name else (1 - urban_fraction[node])
+            if "urban central" in name:
+                f = dist_fraction[node]
+            elif "urban decentral" in name:
+                f = urban_fraction[node] - dist_fraction[node]
+            else:
+                f = 1 - urban_fraction[node]            
             if f == 0:
                 continue
             # get sector name ("residential"/"services"/or both "tot" for urban central)


### PR DESCRIPTION
## Changes proposed in this Pull Request
Here, I propose fixing the `f weighting` to account both `urban central` and `urban decentral` fractions.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] A release note `doc/release_notes.rst` is added.
