### PR TITLE
Restrict snakemake version

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,9 @@ Release Notes
 Upcoming Release
 ================
 
+* Pin ``snakemake`` version to below 8.0.0, as the new version is not yet
+  supported by ``pypsa-eur``.
+
 * Updated Global Energy Monitor LNG terminal data to March 2023 version.
 
 * For industry distribution, use EPRTR as fallback if ETS data is not available.

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -20,7 +20,7 @@ dependencies:
 - openpyxl!=3.1.1
 - pycountry
 - seaborn
-- snakemake-minimal>=7.7.0
+- snakemake-minimal>=7.7.0,<8.0.0
 - memory_profiler
 - yaml
 - pytables

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -20,6 +20,7 @@ dependencies:
 - openpyxl!=3.1.1
 - pycountry
 - seaborn
+  # snakemake 8 introduced a number of breaking changes which the workflow has yet to be made compatible with
 - snakemake-minimal>=7.7.0,<8.0.0
 - memory_profiler
 - yaml


### PR DESCRIPTION
Temporary measure, `snakemake>=8.0.0` requires a number of adjustments.