### PR TITLE
Fix typo in buses definition for oil boilers in add_industry in prepare_sectors_networks

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -40,6 +40,7 @@ Upcoming Release
 
 * A bug preventing custom powerplants specified in ``data/custom_powerplants.csv`` was fixed. (https://github.com/PyPSA/pypsa-eur/pull/732)
 * Fix nodal fraction in ``add_existing_year`` when using distributed generators
+* Fix typo in buses definition for oil boilers in ``add_industry`` in ``prepare_sector_network``
 
 
 PyPSA-Eur 0.8.1 (27th July 2023)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2709,7 +2709,7 @@ def add_industry(n, costs):
                 nodes_heat[name] + f" {name} oil boiler",
                 p_nom_extendable=True,
                 bus0=spatial.oil.nodes,
-                bus1=nodes_heat[name] + f" {name}  heat",
+                bus1=nodes_heat[name] + f" {name} heat",
                 bus2="co2 atmosphere",
                 carrier=f"{name} oil boiler",
                 efficiency=costs.at["decentral oil boiler", "efficiency"],


### PR DESCRIPTION
Fix typo in buses definition for oil boilers in add_industry in prepare sectors networks

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
