### PR TITLE
No gas generators

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -467,6 +467,9 @@ def add_carrier_buses(n, carrier, nodes=None):
         * costs.at[carrier, "discount rate"],  # preliminary value to avoid zeros
     )
 
+    if carrier == 'gas':
+        return
+
     n.madd(
         "Generator",
         nodes,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -467,7 +467,7 @@ def add_carrier_buses(n, carrier, nodes=None):
         * costs.at[carrier, "discount rate"],  # preliminary value to avoid zeros
     )
 
-    if carrier == 'gas':
+    if carrier == "gas":
         return
 
     n.madd(


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day, here I propose to remove generators with gas carrier from the network. Currently, presence of gas generators in each node means that the is some `natural gas production units are there, which might not be a case for Europe. It does not touch `OCGT` as it is in the links.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
