### PR TITLE
Retrieve GLC and WDPA to data directory, not resources

### DIFF
--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -208,10 +208,9 @@ rule build_ship_raster:
 
 rule determine_availability_matrix_MD_UA:
     input:
-        copernicus=RESOURCES
-        + "Copernicus_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif",
-        wdpa=RESOURCES + f"WDPA.gpkg",
-        wdpa_marine=RESOURCES + f"WDPA_WDOECM_marine.gpkg",
+        copernicus="data/Copernicus_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif",
+        wdpa="data/WDPA.gpkg",
+        wdpa_marine="data/WDPA_WDOECM_marine.gpkg",
         gebco=lambda w: (
             "data/bundle/GEBCO_2014_2D.nc"
             if "max_depth" in config["renewable"][w.technology].keys()

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -239,8 +239,7 @@ if config["enable"]["retrieve"]:
                 static=True,
             ),
         output:
-            RESOURCES
-            + "Copernicus_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif",
+            "data/Copernicus_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif",
         run:
             move(input[0], output[0])
 
@@ -286,10 +285,10 @@ if config["enable"]["retrieve"]:
                 keep_local=True,
             ),
         params:
-            zip=RESOURCES + f"WDPA_shp.zip",
-            folder=directory(RESOURCES + f"WDPA"),
+            zip="data/WDPA_shp.zip",
+            folder=directory("data/WDPA"),
         output:
-            gpkg=RESOURCES + f"WDPA.gpkg",
+            gpkg=protected("data/WDPA.gpkg"),
         run:
             shell("cp {input} {params.zip}")
             shell("unzip -o {params.zip} -d {params.folder}")
@@ -312,10 +311,10 @@ if config["enable"]["retrieve"]:
                 keep_local=True,
             ),
         params:
-            zip=RESOURCES + f"WDPA_WDOECM_marine.zip",
-            folder=directory(RESOURCES + f"WDPA_WDOECM_marine"),
+            zip="data/WDPA_WDOECM_marine.zip",
+            folder=directory("data/WDPA_WDOECM_marine"),
         output:
-            gpkg=RESOURCES + f"WDPA_WDOECM_marine.gpkg",
+            gpkg=protected("data/WDPA_WDOECM_marine.gpkg"),
         run:
             shell("cp {input} {params.zip}")
             shell("unzip -o {params.zip} -d {params.folder}")

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -113,7 +113,7 @@ if config["enable"]["retrieve"] and config["enable"].get(
                 static=True,
             ),
         output:
-            protected(RESOURCES + "natura.tiff"),
+            RESOURCES + "natura.tiff",
         log:
             LOGS + "retrieve_natura_raster.log",
         resources:


### PR DESCRIPTION
This is to avoid duplicate downloads of large files if resources are not shared across runs.

This can be done because files do not depend on configuration settings.