### PR TITLE
Distinguish sequestered and stored CO2

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -125,6 +125,7 @@ rule sync:
     shell:
         """
         rsync -uvarh --ignore-missing-args --files-from=.sync-send . {params.cluster}
+        rsync -uvarh --no-g {params.cluster}/resources . || echo "No resources directory, skipping rsync
         rsync -uvarh --no-g {params.cluster}/results . || echo "No results directory, skipping rsync"
         rsync -uvarh --no-g {params.cluster}/logs . || echo "No logs directory, skipping rsync"
         """

--- a/Snakefile
+++ b/Snakefile
@@ -125,7 +125,7 @@ rule sync:
     shell:
         """
         rsync -uvarh --ignore-missing-args --files-from=.sync-send . {params.cluster}
-        rsync -uvarh --no-g {params.cluster}/resources . || echo "No resources directory, skipping rsync
+        rsync -uvarh --no-g {params.cluster}/resources . || echo "No resources directory, skipping rsync"
         rsync -uvarh --no-g {params.cluster}/results . || echo "No results directory, skipping rsync"
         rsync -uvarh --no-g {params.cluster}/logs . || echo "No logs directory, skipping rsync"
         """

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -478,6 +478,7 @@ sector:
   co2_sequestration_lifetime: 50
   co2_spatial: false
   co2network: false
+  co2_network_cost_factor: 1
   cc_fraction: 0.9
   hydrogen_underground_storage: true
   hydrogen_underground_storage_locations:
@@ -985,6 +986,7 @@ plotting:
     CO2 sequestration: '#f29dae'
     DAC: '#ff5270'
     co2 stored: '#f2385a'
+    co2 sequestered: '#f2682f'
     co2: '#f29dae'
     co2 vent: '#ffd4dc'
     CO2 pipeline: '#f5627f'

--- a/doc/configtables/sector.csv
+++ b/doc/configtables/sector.csv
@@ -93,6 +93,7 @@ co2_sequestration_cost,currency/tCO2,float,The cost of sequestering a ton of CO2
 co2_spatial,--,"{true, false}","Add option to spatially resolve carrier representing stored carbon dioxide. This allows for more detailed modelling of CCUTS, e.g. regarding the capturing of industrial process emissions, usage as feedstock for electrofuels, transport of carbon dioxide, and geological sequestration sites."
 ,,,
 co2network,--,"{true, false}",Add option for planning a new carbon dioxide transmission network
+co2_network_cost_factor,p.u.,float,The cost factor for the capital cost of the carbon dioxide transmission network
 ,,,
 cc_fraction,--,float,The default fraction of CO2 captured with post-combustion capture
 hydrogen_underground _storage,--,"{true, false}",Add options for storing hydrogen underground. Storage potential depends regionally.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,13 @@ Release Notes
 Upcoming Release
 ================
 
+* Distinguish between stored and sequestered CO2. Stored CO2 is stored
+  overground in tanks and can be used for CCU (e.g. methanolisation).
+  Sequestered CO2 is stored underground and can no longer be used for CCU. This
+  distinction is made because storage in tanks is more expensive than
+  underground storage. The link that connects stored and sequestered CO2 is
+  unidirectional.
+
 * Increase deployment density of solar to 5.1 MW/sqkm by default.
 
 * Default to full electrification of land transport by 2050.

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -4,7 +4,7 @@
 
 import os, sys, glob
 
-helper_source_path = [match for match in glob.glob('**/_helpers.py', recursive=True)]
+helper_source_path = [match for match in glob.glob("**/_helpers.py", recursive=True)]
 
 for path in helper_source_path:
     path = os.path.dirname(os.path.abspath(path))

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -133,9 +133,7 @@ def disable_grid_expansion_if_LV_limit_hit(n):
 
     # allow small numerical differences
     if lv_limit - total_expansion < 1:
-        logger.info(
-            f"LV is already reached, disabling expansion and LV limit"
-        )
+        logger.info(f"LV is already reached, disabling expansion and LV limit")
         extendable_acs = n.lines.query("s_nom_extendable").index
         n.lines.loc[extendable_acs, "s_nom_extendable"] = False
         n.lines.loc[extendable_acs, "s_nom"] = n.lines.loc[extendable_acs, "s_nom_min"]

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -591,7 +591,9 @@ def add_co2_tracking(n, costs, options):
     n.add("Carrier", "co2 stored")
 
     # this tracks CO2 sequestered, e.g. underground
-    sequestration_buses = pd.Index(spatial.co2.nodes).str.replace(" stored", " sequestered")
+    sequestration_buses = pd.Index(spatial.co2.nodes).str.replace(
+        " stored", " sequestered"
+    )
     n.madd(
         "Bus",
         sequestration_buses,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -549,7 +549,7 @@ def patch_electricity_network(n):
     n.loads_t.p_set.rename(lambda x: x.strip(), axis=1, inplace=True)
 
 
-def add_co2_tracking(n, options):
+def add_co2_tracking(n, costs, options):
     # minus sign because opposite to how fossil fuels used:
     # CH4 burning puts CH4 down, atmosphere up
     n.add("Carrier", "co2", co2_emissions=-1.0)
@@ -576,6 +576,37 @@ def add_co2_tracking(n, options):
         unit="t_co2",
     )
 
+    # add CO2 tanks
+    n.madd(
+        "Store",
+        spatial.co2.nodes,
+        e_nom_extendable=True,
+        capital_cost=costs.loc["CO2 storage tank"],
+        carrier="co2 stored",
+        bus=spatial.co2.nodes,
+    )
+    n.add("Carrier", "co2 stored")
+
+    # this tracks CO2 stored, e.g. underground
+    sequestration_buses = spatial.co2.nodes.str.replace(" stored", " sequestered")
+    n.madd(
+        "Bus",
+        sequestration_buses,
+        location=spatial.co2.locations,
+        carrier="co2 sequestered",
+        unit="t_co2",
+    )
+
+    n.madd(
+        "Link",
+        sequestration_buses,
+        bus0=spatial.co2.nodes,
+        bus1=sequestration_buses,
+        carrier="co2 sequestered",
+        efficiency=1.0,
+        p_nom_extendable=True,
+    )
+
     if options["regional_co2_sequestration_potential"]["enable"]:
         upper_limit = (
             options["regional_co2_sequestration_potential"]["max_size"] * 1e3
@@ -591,22 +622,22 @@ def add_co2_tracking(n, options):
             .mul(1e6)
             / annualiser
         )  # t
-        e_nom_max = e_nom_max.rename(index=lambda x: x + " co2 stored")
+        e_nom_max = e_nom_max.rename(index=lambda x: x + " co2 sequestered")
     else:
         e_nom_max = np.inf
 
     n.madd(
         "Store",
-        spatial.co2.nodes,
+        sequestration_buses,
         e_nom_extendable=True,
         e_nom_max=e_nom_max,
         capital_cost=options["co2_sequestration_cost"],
-        carrier="co2 stored",
-        bus=spatial.co2.nodes,
+        bus=sequestration_buses,
         lifetime=options["co2_sequestration_lifetime"],
+        carrier="co2 sequestered",
     )
 
-    n.add("Carrier", "co2 stored")
+    n.add("Carrier", "co2 sequestered")
 
     if options["co2_vent"]:
         n.madd(
@@ -635,6 +666,8 @@ def add_co2_network(n, costs):
         * co2_links.length
     )
     capital_cost = cost_onshore + cost_submarine
+    cost_factor = snakemake.config["sector"]["co2_network_cost_factor"]
+    capital_cost *= cost_factor
 
     n.madd(
         "Link",
@@ -3626,7 +3659,7 @@ if __name__ == "__main__":
         for carrier in conventional:
             add_carrier_buses(n, carrier)
 
-    add_co2_tracking(n, options)
+    add_co2_tracking(n, costs, options)
 
     add_generation(n, costs)
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -591,7 +591,7 @@ def add_co2_tracking(n, costs, options):
     n.add("Carrier", "co2 stored")
 
     # this tracks CO2 sequestered, e.g. underground
-    sequestration_buses = spatial.co2.nodes.str.replace(" stored", " sequestered")
+    sequestration_buses = pd.Index(spatial.co2.nodes).str.replace(" stored", " sequestered")
     n.madd(
         "Bus",
         sequestration_buses,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2330,6 +2330,14 @@ def add_biomass(n, costs):
             marginal_cost=costs.at["solid biomass", "fuel"]
             + bus_transport_costs * average_distance,
         )
+        n.add(
+            "GlobalConstraint",
+            "biomass limit",
+            carrier_attribute="solid biomass",
+            sense="<=",
+            constant=biomass_potentials["solid biomass"].sum(),
+            type="operational_limit",
+        )
 
     # AC buses with district heating
     urban_central = n.buses.index[n.buses.carrier == "urban central heat"]

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2736,7 +2736,6 @@ def add_industry(n, costs):
             carrier="methanolisation",
             p_nom_extendable=True,
             p_min_pu=options.get("min_part_load_methanolisation", 0),
-            marginal_cost=options["MWh_MeOH_per_MWh_H2"] * costs.at["fuel cell", "VOM"],
             capital_cost=costs.at["methanolisation", "fixed"]
             * options["MWh_MeOH_per_MWh_H2"],  # EUR/MW_H2/a
             marginal_cost=options["MWh_MeOH_per_MWh_H2"]

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3043,8 +3043,9 @@ def add_industry(n, costs):
 
     if options["co2_spatial"] or options["co2network"]:
         p_set = (
-            -industrial_demand.loc[nodes, "process emission"]
-            .rename(index=lambda x: x + " process emissions")
+            -industrial_demand.loc[nodes, "process emission"].rename(
+                index=lambda x: x + " process emissions"
+            )
             / nhours
         )
     else:
@@ -3457,6 +3458,7 @@ def cluster_heat_buses(n):
         pnl = c.pnl
         agg = define_clustering(pd.Index(pnl.keys()), aggregate_dict)
         for k in pnl.keys():
+
             def renamer(s):
                 return s.replace("residential ", "").replace("services ", "")
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -587,7 +587,7 @@ def add_co2_tracking(n, costs, options):
     )
     n.add("Carrier", "co2 stored")
 
-    # this tracks CO2 stored, e.g. underground
+    # this tracks CO2 sequestered, e.g. underground
     sequestration_buses = spatial.co2.nodes.str.replace(" stored", " sequestered")
     n.madd(
         "Bus",

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -567,7 +567,7 @@ def add_co2_tracking(n, costs, options):
         bus="co2 atmosphere",
     )
 
-    # this tracks CO2 stored, e.g. underground
+    # add CO2 tanks
     n.madd(
         "Bus",
         spatial.co2.nodes,
@@ -576,13 +576,13 @@ def add_co2_tracking(n, costs, options):
         unit="t_co2",
     )
 
-    # add CO2 tanks
     n.madd(
         "Store",
         spatial.co2.nodes,
         e_nom_extendable=True,
-        capital_cost=costs.loc["CO2 storage tank"],
+        capital_cost=costs.at["CO2 storage tank", "fixed"],
         carrier="co2 stored",
+        e_cyclic=True,
         bus=spatial.co2.nodes,
     )
     n.add("Carrier", "co2 stored")

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -102,7 +102,10 @@ def define_spatial(nodes, options):
         spatial.gas.biogas = ["EU biogas"]
         spatial.gas.industry = ["gas for industry"]
         spatial.gas.biogas_to_gas = ["EU biogas to gas"]
-        spatial.gas.biogas_to_gas_cc = ["EU biogas to gas CC"]
+        if options.get("biomass_spatial", options["biomass_transport"]):
+            spatial.gas.biogas_to_gas_cc = nodes + " biogas to gas CC"
+        else:
+            spatial.gas.biogas_to_gas_cc = ["EU biogas to gas CC"]
         if options.get("co2_spatial", options["co2network"]):
             spatial.gas.industry_cc = nodes + " gas for industry CC"
         else:
@@ -2257,13 +2260,12 @@ def add_biomass(n, costs):
         # Assuming for costs that the CO2 from upgrading is pure, such as in amine scrubbing. I.e., with and without CC is
         # equivalent. Adding biomass CHP capture because biogas is often small-scale and decentral so further
         # from e.g. CO2 grid or buyers. This is a proxy for the added cost for e.g. a raw biogas pipeline to a central upgrading facility
-
         n.madd(
             "Link",
             spatial.gas.biogas_to_gas_cc,
             bus0=spatial.gas.biogas,
             bus1=spatial.gas.nodes,
-            bus2="co2 stored",
+            bus2=spatial.co2.nodes,
             bus3="co2 atmosphere",
             carrier="biogas to gas CC",
             capital_cost=costs.at["biogas CC", "fixed"]
@@ -2734,6 +2736,7 @@ def add_industry(n, costs):
             carrier="methanolisation",
             p_nom_extendable=True,
             p_min_pu=options.get("min_part_load_methanolisation", 0),
+            marginal_cost=options["MWh_MeOH_per_MWh_H2"] * costs.at["fuel cell", "VOM"],
             capital_cost=costs.at["methanolisation", "fixed"]
             * options["MWh_MeOH_per_MWh_H2"],  # EUR/MW_H2/a
             marginal_cost=options["MWh_MeOH_per_MWh_H2"]

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -853,7 +853,7 @@ def solve_network(n, config, solving, opts="", **kwargs):
     kwargs["assign_all_duals"] = cf_solving.get("assign_all_duals", False)
 
     if kwargs["solver_name"] == "gurobi":
-        logging.getLogger('gurobipy').setLevel(logging.CRITICAL)
+        logging.getLogger("gurobipy").setLevel(logging.CRITICAL)
 
     rolling_horizon = cf_solving.pop("rolling_horizon", False)
     skip_iterations = cf_solving.pop("skip_iterations", False)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -202,10 +202,10 @@ def add_co2_sequestration_limit(n, config, limit=200):
     n.madd(
         "GlobalConstraint",
         names,
-        sense="<=",
-        constant=limit,
-        type="primary_energy",
-        carrier_attribute="co2_absorptions",
+        sense=">=",
+        constant=-limit,
+        type="operational_limit",
+        carrier_attribute="co2 sequestered",
         investment_period=periods,
     )
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -182,9 +182,6 @@ def add_co2_sequestration_limit(n, config, limit=200):
     """
     Add a global constraint on the amount of Mt CO2 that can be sequestered.
     """
-    n.carriers.loc["co2 stored", "co2_absorptions"] = -1
-    n.carriers.co2_absorptions = n.carriers.co2_absorptions.fillna(0)
-
     limit = limit * 1e6
     for o in opts:
         if "seq" not in o:
@@ -396,7 +393,7 @@ def prepare_network(
         if snakemake.params["sector"]["limit_max_growth"]["enable"]:
             n = add_max_growth(n, config)
 
-    if n.stores.carrier.eq("co2 stored").any():
+    if n.stores.carrier.eq("co2 sequestered").any():
         limit = co2_sequestration_potential
         add_co2_sequestration_limit(n, config, limit=limit)
 


### PR DESCRIPTION
- stored CO2 can be used for CCU
- sequestered CO2 is stored for a long time and cannot be used for CCU

The link between stored and sequestered CO2 is a one-way street.

The cost of overground CO2 storage in tanks is more expensive than underground sequestration.