### PR TITLE
Decorrelate electrical load year from weather year

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -283,6 +283,7 @@ transformers:
 
 # docs-load in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#load
 load:
+  load_year: 2018
   power_statistics: true
   interpolate_limit: 3
   time_shift_for_large_gaps: 1w

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -283,7 +283,7 @@ transformers:
 
 # docs-load in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#load
 load:
-  load_year: 2018
+  load_year: false
   power_statistics: true
   interpolate_limit: 3
   time_shift_for_large_gaps: 1w

--- a/doc/configtables/load.csv
+++ b/doc/configtables/load.csv
@@ -1,5 +1,5 @@
 ,Unit,Values,Description
-load_year,-,YYYY; e.g. 2018,The year for the electrical load. The year must be available in the OPSD data.
+load_year,-,{'false'; YYYY; e.g. 2018},Optionally define the year for the electrical load. The year must be available in the OPSD data.
 power_statistics,bool,"{true, false}",Whether to load the electricity consumption data of the ENTSOE power statistics (only for files from 2019 and before) or from the ENTSOE transparency data (only has load data from 2015 onwards).
 interpolate_limit,hours,integer,"Maximum gap size (consecutive nans) which interpolated linearly."
 time_shift_for_large_gaps,string,string,"Periods which are used for copying time-slices in order to fill large gaps of nans. Have to be valid ``pandas`` period strings."

--- a/doc/configtables/load.csv
+++ b/doc/configtables/load.csv
@@ -1,4 +1,5 @@
 ,Unit,Values,Description
+load_year,-,YYYY; e.g. 2018,The year for the electrical load. The year must be available in the OPSD data.
 power_statistics,bool,"{true, false}",Whether to load the electricity consumption data of the ENTSOE power statistics (only for files from 2019 and before) or from the ENTSOE transparency data (only has load data from 2015 onwards).
 interpolate_limit,hours,integer,"Maximum gap size (consecutive nans) which interpolated linearly."
 time_shift_for_large_gaps,string,string,"Periods which are used for copying time-slices in order to fill large gaps of nans. Have to be valid ``pandas`` period strings."

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,7 +11,7 @@ Upcoming Release
 ================
 
 * New configuration option ``everywhere_powerplants`` to build conventional powerplants everywhere, irrespective of existing powerplants locations, in the network (https://github.com/PyPSA/pypsa-eur/pull/850).
-* Decorrelate electrical load year from weather year in `build_electricity_demand`.
+* Optionally decorrelate electrical load year from weather year in `build_electricity_demand`.
 
 PyPSA-Eur 0.9.0 (5th January 2024)
 ==================================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,7 @@ Upcoming Release
 ================
 
 * New configuration option ``everywhere_powerplants`` to build conventional powerplants everywhere, irrespective of existing powerplants locations, in the network (https://github.com/PyPSA/pypsa-eur/pull/850).
+* Decorrelate electrical load year from weather year in `build_electricity_demand`.
 
 PyPSA-Eur 0.9.0 (5th January 2024)
 ==================================

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -16,9 +16,8 @@ Relevant Settings
 
 .. code:: yaml
 
-    snapshots:
-
     load:
+        load_year:
         interpolate_limit:
         time_shift_for_large_gaps:
         manual_adjustments:
@@ -301,7 +300,8 @@ if __name__ == "__main__":
     interpolate_limit = snakemake.params.load["interpolate_limit"]
     countries = snakemake.params.countries
     snapshots = pd.date_range(freq="h", **snakemake.params.snapshots)
-    years = slice(snapshots[0], snapshots[-1])
+    years = slice(pd.Timestamp(f'{snakemake.config["load"]["load_year"]}-01-01'),
+                  pd.Timestamp(f'{snakemake.config["load"]["load_year"]}-12-31'))
     time_shift = snakemake.params.load["time_shift_for_large_gaps"]
 
     load = load_timeseries(snakemake.input[0], years, countries, powerstatistics)

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -302,8 +302,11 @@ if __name__ == "__main__":
     interpolate_limit = snakemake.params.load["interpolate_limit"]
     countries = snakemake.params.countries
     snapshots = pd.date_range(freq="h", **snakemake.params.snapshots)
-    years = slice(pd.Timestamp(f'{snakemake.config["load"]["load_year"]}-01-01 00:00:00'),
-                  pd.Timestamp(f'{snakemake.config["load"]["load_year"]}-12-31 23:00:00'))
+    load_year = snakemake.config["load"]["load_year"]
+    if load_year:
+        years = slice(snapshots[0].replace(year=load_year), snapshots[-1].replace(year=load_year))
+    else:
+        years = slice(snapshots[0], snapshots[-1])
     time_shift = snakemake.params.load["time_shift_for_large_gaps"]
 
     load = load_timeseries(snakemake.input[0], years, snapshots, countries, powerstatistics)


### PR DESCRIPTION
## Changes proposed in this Pull Request

I suggest to decorrelate the electrical load year from the weather year. Up to now, we are using the `snapshots` as reference configuration to choose the electrical load from OPSD data. But because this load is also used to determine the not modeled part of the electrical load, we need this value to be as accurate as possible. Therefor, we should use a more recent value than the default 2013 value for cutouts.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
