### PR TITLE
Add warning when negative bev availability profile values

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,7 +12,8 @@ Upcoming Release
 
 * New configuration option ``everywhere_powerplants`` to build conventional powerplants everywhere, irrespective of existing powerplants locations, in the network (https://github.com/PyPSA/pypsa-eur/pull/850).
 
-* Remove option for wave energy as technology data is not maintained. 
+* Remove option for wave energy as technology data is not maintained.
+* Add warning when BEV availability weekly profile has negative values in `build_transport_demand`.
 
 
 PyPSA-Eur 0.9.0 (5th January 2024)

--- a/scripts/build_transport_demand.py
+++ b/scripts/build_transport_demand.py
@@ -8,10 +8,16 @@ improvements due to drivetrain changes, time series for electric vehicle
 availability and demand-side management constraints.
 """
 
+import logging
+
 import numpy as np
 import pandas as pd
 import xarray as xr
+
+from _helpers import configure_logging
 from _helpers import generate_periodic_profiles
+
+logger = logging.getLogger(__name__)
 
 
 def build_nodal_transport_data(fn, pop_layout):
@@ -130,6 +136,10 @@ def bev_availability_profile(fn, snapshots, nodes, options):
         traffic.mean() - traffic.min()
     )
 
+    if not avail[avail < 0].empty:
+        logger.warning("The BEV availability weekly profile has negative values which can "
+                       "lead to infeasibility.")
+
     return generate_periodic_profiles(
         dt_index=snapshots,
         nodes=nodes,
@@ -160,6 +170,7 @@ if __name__ == "__main__":
             simpl="",
             clusters=48,
         )
+    configure_logging(snakemake)
 
     pop_layout = pd.read_csv(snakemake.input.clustered_pop_layout, index_col=0)
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Changing the `bev_avail_max` and `bev_avail_mean`  values could cause the profile to generate negative values. This leads to infeasibility. Raising a warning earlier in the process is useful to catch the configuration error sooner. This warning is raised in `build_transport_demand`.


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
