### PR TITLE
fix clustering bug due to missing countries in n.buses

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,7 +12,7 @@ Upcoming Release
 
 * New configuration option ``everywhere_powerplants`` to build conventional powerplants everywhere, irrespective of existing powerplants locations, in the network (https://github.com/PyPSA/pypsa-eur/pull/850).
 
-* Remove option for wave energy as technology data is not maintained. 
+* Remove option for wave energy as technology data is not maintained.
 
 
 PyPSA-Eur 0.9.0 (5th January 2024)

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -560,7 +560,7 @@ def _set_countries_and_substations(n, config, country_shapes, offshore_shapes):
         ~buses["under_construction"]
     )
 
-    c_nan_b = buses.country == "na"
+    c_nan_b = buses.country.isna()
     if c_nan_b.sum() > 0:
         c_tag = _get_country(buses.loc[c_nan_b])
         c_tag.loc[~c_tag.isin(countries)] = np.nan


### PR DESCRIPTION
## Changes proposed in this Pull Request
filter looking for empty values in n.buses.countries is not working anymore. This leads to errors later on in the `cluster_network` script. for 37 nodes, the error in the cluster script was that there are more combinations of subnetworks and countries than 37 and for higher cluster numbers this lead to a problem due to a division by 0.

The CI did not catch the mistake in the current master, because we only consider one country for the test CI 

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
