### PR TITLE
Reformulate co2 constraint

### DIFF
--- a/config/config.perfect.yaml
+++ b/config/config.perfect.yaml
@@ -24,8 +24,11 @@ scenario:
   - 2p0-4380H-T-H-B-I-A-solar+p3-dist1
   planning_horizons:
   - 2020
+  - 2025
   - 2030
+  - 2035
   - 2040
+  - 2045
   - 2050
 
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,7 +12,7 @@ Upcoming Release
 
 * New configuration option ``everywhere_powerplants`` to build conventional powerplants everywhere, irrespective of existing powerplants locations, in the network (https://github.com/PyPSA/pypsa-eur/pull/850).
 
-* Remove option for wave energy as technology data is not maintained. 
+* Remove option for wave energy as technology data is not maintained.
 
 
 PyPSA-Eur 0.9.0 (5th January 2024)

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -14,6 +14,9 @@ Upcoming Release
 
 * Remove option for wave energy as technology data is not maintained.
 
+* Define global constraint for CO2 emissions on the final state of charge of the
+  CO2 atmosphere store. This gives a more sparse constraint that should improve
+  the performance of the solving process.
 
 PyPSA-Eur 0.9.0 (5th January 2024)
 ==================================

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -761,6 +761,7 @@ def add_co2limit(n, nyears=1.0, limit=0.0):
         "CO2Limit",
         carrier_attribute="co2_emissions",
         sense="<=",
+        type="co2_atmosphere",
         constant=co2_limit,
     )
 
@@ -3606,8 +3607,8 @@ if __name__ == "__main__":
             configfiles="test/config.overnight.yaml",
             simpl="",
             opts="",
-            clusters="5",
-            ll="v1.5",
+            clusters="37",
+            ll="v1.0",
             sector_opts="CO2L0-24H-T-H-B-I-A-solar+p3-dist1",
             planning_horizons="2030",
         )

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -796,8 +796,8 @@ def add_pipe_retrofit_constraint(n):
 
 
 def add_co2_atmosphere_constraint(n, snapshots):
-    glcs = n.global_constraints[n.global_constraints.type=="co2_atmosphere"]
-    
+    glcs = n.global_constraints[n.global_constraints.type == "co2_atmosphere"]
+
     if glcs.empty:
         return
     for name, glc in glcs.iterrows():
@@ -812,10 +812,11 @@ def add_co2_atmosphere_constraint(n, snapshots):
         stores = n.stores.query("carrier in @emissions.index and not e_cyclic")
         if not stores.empty:
             last_i = snapshots[-1]
-            lhs = n.model["Store-e"].loc[last_i, stores.index]        
+            lhs = n.model["Store-e"].loc[last_i, stores.index]
             rhs = glc.constant
-            
+
             n.model.add_constraints(lhs <= rhs, name=f"GlobalConstraint-{name}")
+
 
 def extra_functionality(n, snapshots):
     """


### PR DESCRIPTION
Closes # (if applicable).

## Change CO2 emission constraint for sector coupled models
Instead of using the `primary_energy`global constraint formulation this PR puts a constraint on the last snapshot of the co2 atmosphere bus.

TODO: haven't tested yet if performance improves for overnight scenarios
## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
