### PR TITLE
group storage with duplicate labels

### DIFF
--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -1069,10 +1069,9 @@ if __name__ == "__main__":
             "plot_network",
             simpl="",
             opts="",
-            clusters="22",
-            ll="v1.2",
-            sector_opts="365H-T-H-B-I-A-solar+p3-linemaxext15",
-            planning_horizons="2040",
+            clusters="37",
+            ll="v1.0",
+            sector_opts="4380H-T-H-B-I-A-solar+p3-dist1",
         )
 
     logging.basicConfig(level=snakemake.config["logging"]["level"])

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -271,10 +271,11 @@ def plot_h2_map(network, regions):
     assign_location(n)
 
     h2_storage = n.stores.query("carrier == 'H2'")
-    regions["H2"] = h2_storage.rename(
-        index=h2_storage.bus.map(n.buses.location)
-    ).e_nom_opt.groupby(level=0).sum().div(
-        1e6
+    regions["H2"] = (
+        h2_storage.rename(index=h2_storage.bus.map(n.buses.location))
+        .e_nom_opt.groupby(level=0)
+        .sum()
+        .div(1e6)
     )  # TWh
     regions["H2"] = regions["H2"].where(regions["H2"] > 0.1)
 

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -273,7 +273,7 @@ def plot_h2_map(network, regions):
     h2_storage = n.stores.query("carrier == 'H2'")
     regions["H2"] = h2_storage.rename(
         index=h2_storage.bus.map(n.buses.location)
-    ).e_nom_opt.div(
+    ).e_nom_opt.groupby(level=0).sum().div(
         1e6
     )  # TWh
     regions["H2"] = regions["H2"].where(regions["H2"] > 0.1)
@@ -1068,9 +1068,10 @@ if __name__ == "__main__":
             "plot_network",
             simpl="",
             opts="",
-            clusters="37",
-            ll="v1.0",
-            sector_opts="4380H-T-H-B-I-A-solar+p3-dist1",
+            clusters="22",
+            ll="v1.2",
+            sector_opts="365H-T-H-B-I-A-solar+p3-linemaxext15",
+            planning_horizons="2040",
         )
 
     logging.basicConfig(level=snakemake.config["logging"]["level"])


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

fixes an error that occurs when h2 storage is built at the same bus but at different snapshots

```
Traceback (most recent call last):
  File "/home/micha/git/pypsa-ariadne/.snakemake/scripts/tmp53wos82s.plot_network.py", line 1105, in <module>
    plot_h2_map(n, regions)
  File "/home/micha/git/pypsa-ariadne/.snakemake/scripts/tmp53wos82s.plot_network.py", line 278, in plot_h2_map
    regions["H2"] = h2_storage.rename(
  File "/home/micha/micromamba/envs/pypsa-ariadne/lib/python3.10/site-packages/geopandas/geodataframe.py", line 1543, in __setitem__
    super().__setitem__(key, value)
  File "/home/micha/micromamba/envs/pypsa-ariadne/lib/python3.10/site-packages/pandas/core/frame.py", line 4091, in __setitem__
    self._set_item(key, value)
  File "/home/micha/micromamba/envs/pypsa-ariadne/lib/python3.10/site-packages/pandas/core/frame.py", line 4300, in _set_item
    value, refs = self._sanitize_column(value)
  File "/home/micha/micromamba/envs/pypsa-ariadne/lib/python3.10/site-packages/pandas/core/frame.py", line 5036, in _sanitize_column
    return _reindex_for_setitem(value, self.index)
  File "/home/micha/micromamba/envs/pypsa-ariadne/lib/python3.10/site-packages/pandas/core/frame.py", line 12309, in _reindex_for_setitem
    raise err
  File "/home/micha/micromamba/envs/pypsa-ariadne/lib/python3.10/site-packages/pandas/core/frame.py", line 12304, in _reindex_for_setitem
    reindexed_value = value.reindex(index)._values
  File "/home/micha/micromamba/envs/pypsa-ariadne/lib/python3.10/site-packages/pandas/core/series.py", line 4981, in reindex
    return super().reindex(
  File "/home/micha/micromamba/envs/pypsa-ariadne/lib/python3.10/site-packages/pandas/core/generic.py", line 5521, in reindex
    return self._reindex_axes(
  File "/home/micha/micromamba/envs/pypsa-ariadne/lib/python3.10/site-packages/pandas/core/generic.py", line 5544, in _reindex_axes
    new_index, indexer = ax.reindex(
  File "/home/micha/micromamba/envs/pypsa-ariadne/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 4434, in reindex
    raise ValueError("cannot reindex on an axis with duplicate labels")
ValueError: cannot reindex on an axis with duplicate labels
```

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
