### PR TITLE
:bug: fix key_error in validation plots

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,8 @@ Release Notes
 Upcoming Release
 ================
 
+* Bugfix: Correct technology keys for the electricity production plotting to work out the box.
+
 * New configuration option ``everywhere_powerplants`` to build conventional powerplants everywhere, irrespective of existing powerplants locations, in the network (https://github.com/PyPSA/pypsa-eur/pull/850).
 
 * Remove option for wave energy as technology data is not maintained.

--- a/scripts/plot_validation_electricity_production.py
+++ b/scripts/plot_validation_electricity_production.py
@@ -45,6 +45,12 @@ if __name__ == "__main__":
         header=[0, 1],
         parse_dates=True,
     )
+    subset_technologies = ["Geothermal", "Nuclear", "Biomass", "Lignite", "Oil", "Coal"]
+    lowercase_technologies = [
+        technology.lower() if technology in subset_technologies else technology
+        for technology in historic.columns.levels[1]
+    ]
+    historic.columns = historic.columns.set_levels(lowercase_technologies, level=1)
 
     colors = n.carriers.set_index("nice_name").color.where(
         lambda s: s != "", "lightgrey"


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

Currently, running the validation workflow fails at the plot_validation_electricity_production rule due to a mismatch between historic data keys and the outputs of the pypsa network. The submitted code corrects technology keys for the rule to work out the box.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
