### PR TITLE
Make data retrieval rules use their own minimal conda env

### DIFF
--- a/envs/retrieve.yaml
+++ b/envs/retrieve.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: : 2017-2024 The PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: MIT
+
+name: pypsa-eur-retrieve
+channels:
+- conda-forge
+- bioconda
+dependencies:
+- python>=3.8
+- snakemake-minimal>=7.7.0,<8.0.0
+- pandas>=2.1
+- tqdm

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -191,7 +191,7 @@ if config["enable"]["retrieve"]:
         input:
             HTTP.remote(
                 "data.open-power-system-data.org/time_series/{version}/time_series_60min_singleindex.csv".format(
-                version="2019-06-05"
+                    version="2019-06-05"
                     if config["snapshots"]["end"] < "2019"
                     else "2020-10-06"
                 ),

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -37,7 +37,7 @@ if config["enable"]["retrieve"] and config["enable"].get("retrieve_databundle", 
             mem_mb=1000,
         retries: 2
         conda:
-            "../envs/environment.yaml"
+            "../envs/retrieve.yaml"
         script:
             "../scripts/retrieve_databundle.py"
 
@@ -55,7 +55,7 @@ if config["enable"].get("retrieve_irena"):
             mem_mb=1000,
         retries: 2
         conda:
-            "../envs/environment.yaml"
+            "../envs/retrieve.yaml"
         script:
             "../scripts/retrieve_irena.py"
 
@@ -157,7 +157,7 @@ if config["enable"]["retrieve"] and config["enable"].get(
             LOGS + "retrieve_sector_databundle.log",
         retries: 2
         conda:
-            "../envs/environment.yaml"
+            "../envs/retrieve.yaml"
         script:
             "../scripts/retrieve_sector_databundle.py"
 
@@ -180,7 +180,7 @@ if config["enable"]["retrieve"]:
             LOGS + "retrieve_gas_infrastructure_data.log",
         retries: 2
         conda:
-            "../envs/environment.yaml"
+            "../envs/retrieve.yaml"
         script:
             "../scripts/retrieve_gas_infrastructure_data.py"
 
@@ -191,7 +191,7 @@ if config["enable"]["retrieve"]:
         input:
             HTTP.remote(
                 "data.open-power-system-data.org/time_series/{version}/time_series_60min_singleindex.csv".format(
-                    version="2019-06-05"
+                version="2019-06-05"
                     if config["snapshots"]["end"] < "2019"
                     else "2020-10-06"
                 ),
@@ -316,7 +316,7 @@ if config["enable"]["retrieve"]:
                 layer_path = (
                     f"/vsizip/{params.folder}/WDPA_{bYYYY}_Public_shp_{i}.zip"
                 )
-                print(f"Adding layer {i+1} of 3 to combined output file.")
+                print(f"Adding layer {i + 1} of 3 to combined output file.")
                 shell("ogr2ogr -f gpkg -update -append {output.gpkg} {layer_path}")
 
     rule download_wdpa_marine:
@@ -340,7 +340,7 @@ if config["enable"]["retrieve"]:
             for i in range(3):
                 # vsizip is special driver for directly working with zipped shapefiles in ogr2ogr
                 layer_path = f"/vsizip/{params.folder}/WDPA_WDOECM_{bYYYY}_Public_marine_shp_{i}.zip"
-                print(f"Adding layer {i+1} of 3 to combined output file.")
+                print(f"Adding layer {i + 1} of 3 to combined output file.")
                 shell("ogr2ogr -f gpkg -update -append {output.gpkg} {layer_path}")
 
 
@@ -376,6 +376,6 @@ if config["enable"]["retrieve"]:
             mem_mb=5000,
         retries: 2
         conda:
-            "../envs/environment.yaml"
+            "../envs/retrieve.yaml"
         script:
             "../scripts/retrieve_monthly_fuel_prices.py"


### PR DESCRIPTION
I usually use the default snakemake options for when to re-run rules; including when the software environment changes. This means, however, that even data-retrieval rules would re-run when changing some dependency version in `environment.yaml`. Such re-runs have become especially painful now that the output files from these data retrieval rules are being marked as protected: this prevents the rule from re-running, and I have to `sudo rm -rf` the databundles! Not great.

The present PR just creates a separate, minimal conda env for the retrieval rules. Just a quality-of-life improvement.

(And it seems some snakefmt fixed have sneaked their way in.)

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
