### PR TITLE
Don't include triple solar potential option by default

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -44,7 +44,7 @@ scenario:
   opts:
   - ''
   sector_opts:
-  - Co2L0-3H-T-H-B-I-A-solar+p3-dist1
+  - Co2L0-3H-T-H-B-I-A-dist1
   planning_horizons:
   # - 2020
   # - 2030


### PR DESCRIPTION
## Changes proposed in this Pull Request

A trivial change in default `{sector_opts}` wildcard. I know that it's very much the intention that users will inform themselves about each wildcard and option and change them to fit their needs. However, defaults do carry some weight, and arguably the `solar+p3` option was a sensible default. After a0f43aee, however, this is no longer the case! I would remove the option from the default `{sector_opts}` wildcard to avoid confusion.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
