### PR TITLE
Avoid the use use of `workflow.source_path`

### DIFF
--- a/rules/common.smk
+++ b/rules/common.smk
@@ -43,7 +43,7 @@ def memory(w):
 def input_custom_extra_functionality(w):
     path = config["solving"]["options"].get("custom_extra_functionality", False)
     if path:
-        return workflow.source_path(path)
+        return os.path.join(os.path.dirname(workflow.snakefile), path)
     return []
 
 


### PR DESCRIPTION
The above function returns a path to a cached source file, which changes for every run, causing the resulting parameter to change and the solve_network rule to re-run every time. The problem was introduced in https://github.com/PyPSA/pypsa-eur/commit/d145758fb7ff4bf126ddada8eec6d8f942c93f4f

I have tested the solution, and also tested to make sure this works when pypsa-eur is used as a module.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
