### PR TITLE
Add several map projection options

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -773,7 +773,13 @@ plotting:
     color_geomap:
       ocean: white
       land: white
-  projection: "EqualEarth"
+  projection:
+    name: "EqualEarth"
+    # See https://scitools.org.uk/cartopy/docs/latest/reference/projections.html for alternatives, for example:
+    # name: "LambertConformal"
+    # central_longitude: 10.
+    # central_latitude: 50.
+    # standard_parallels: [35, 65]
   eu_node_location:
     x: -5.5
     y: 46.

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -773,6 +773,7 @@ plotting:
     color_geomap:
       ocean: white
       land: white
+  projection: "EqualEarth"
   eu_node_location:
     x: -5.5
     y: 46.

--- a/doc/configtables/plotting.csv
+++ b/doc/configtables/plotting.csv
@@ -1,6 +1,7 @@
 ,Unit,Values,Description
 map,,,
 -- boundaries,°,"[x1,x2,y1,y2]",Boundaries of the map plots in degrees latitude (y) and longitude (x)
+projection,--,"{EqualEarth, EuroPP, LambertAzimuthalEqualArea, LambertConformal, Orthographic}",Projection to use for maps; default is EqualEarth. LambertConformal is recommended by the European Environmental Agency.
 costs_max,bn Euro,float,Upper y-axis limit in cost bar plots.
 costs_threshold,bn Euro,float,Threshold below which technologies will not be shown in cost bar plots.
 energy_max,TWh,float,Upper y-axis limit in energy bar plots.

--- a/doc/configtables/plotting.csv
+++ b/doc/configtables/plotting.csv
@@ -1,7 +1,9 @@
 ,Unit,Values,Description
 map,,,
 -- boundaries,°,"[x1,x2,y1,y2]",Boundaries of the map plots in degrees latitude (y) and longitude (x)
-projection,--,"{EqualEarth, EuroPP, LambertAzimuthalEqualArea, LambertConformal, Orthographic}",Projection to use for maps; default is EqualEarth. LambertConformal is recommended by the European Environmental Agency.
+projection,,,,
+-- name,--,"Valid Cartopy projection name","See https://scitools.org.uk/cartopy/docs/latest/reference/projections.html for list of available projections."
+-- args,--,--,"Other entries under 'projection' are passed as keyword arguments to the projection constructor, e.g. ``central_longitude: 10.``."
 costs_max,bn Euro,float,Upper y-axis limit in cost bar plots.
 costs_threshold,bn Euro,float,Threshold below which technologies will not be shown in cost bar plots.
 energy_max,TWh,float,Upper y-axis limit in energy bar plots.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -35,6 +35,8 @@ Upcoming Release
 
 * Add support for the linopy ``io_api`` option; set to ``"direct"`` to increase model reading and writing performance for the highs and gurobi solvers.
 
+* Add several map projection options for plotting.
+
 
 PyPSA-Eur 0.9.0 (5th January 2024)
 ==================================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -35,7 +35,7 @@ Upcoming Release
 
 * Add support for the linopy ``io_api`` option; set to ``"direct"`` to increase model reading and writing performance for the highs and gurobi solvers.
 
-* Add several map projection options for plotting.
+* Add the option to customise map projection in plotting config.
 
 
 PyPSA-Eur 0.9.0 (5th January 2024)

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -1081,25 +1081,9 @@ if __name__ == "__main__":
     if map_opts["boundaries"] is None:
         map_opts["boundaries"] = regions.total_bounds[[0, 2, 1, 3]] + [-1, 1, -1, 1]
 
-    proj_str = snakemake.params.plotting.get("projection", "EqualEarth")
-    central_coords = dict(central_longitude=10.0, central_latitude=50.0)
-    if proj_str == "EqualEarth":
-        # Equal area but large distortions towards the poles.
-        proj = ccrs.EqualEarth()
-    elif proj_str == "EuroPP":
-        # UTM Zone 32 projection
-        proj = ccrs.EuroPP()
-    elif proj_str == "LambertConformal":
-        # The European Environment Agency recommends using this
-        # projection for conformal pan-European mapping
-        proj = ccrs.LambertConformal(standard_parallels=(35, 65), **central_coords)
-    elif proj_str == "Orthographic":
-        proj = ccrs.Orthographic(**central_coords)
-    else:
-        logger.warning(
-            f"Plotting project {proj_str} not recognised; falling back on EqualEarth"
-        )
-        proj = ccrs.EqualEarth()
+    proj_kwargs = snakemake.params.plotting.get("projection", dict(name="EqualEarth"))
+    proj_func = getattr(ccrs, proj_kwargs.pop("name"))
+    proj = proj_func(**proj_kwargs)
 
     if snakemake.params["foresight"] == "perfect":
         plot_map_perfect(


### PR DESCRIPTION
It's quite petty but being based in the north of Norway I can't really deal with the default EqualEarth projections and its wild distortions. I say give the user some (limited) choice in projection without them having to do surgery on the `plot_network.py` script. Do feel free to discard (I will just keep it for personal use) if this kind of "feature creep" isn't really desired.

## Changes proposed in this Pull Request

Added a `config["plotting"]["projection"]` option with a few different preset choices. Falls back to the old default of EqualEarth if not specified.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
