### PR TITLE
document that resolution and segmentation config options are only for…

### DIFF
--- a/doc/configtables/snapshots.csv
+++ b/doc/configtables/snapshots.csv
@@ -2,5 +2,5 @@
 start,--,str or datetime-like; e.g. YYYY-MM-DD,Left bound of date range
 end,--,str or datetime-like; e.g. YYYY-MM-DD,Right bound of date range
 inclusive,--,"One of {'neither', 'both', ‘left’, ‘right’}","Make the time interval closed to the ``left``, ``right``, or both sides ``both`` or neither side ``None``."
-resolution ,--,"{false,``nH``; i.e. ``2H``-``6H``}",Resample the time-resolution by averaging over every ``n`` snapshots
-segmentation,--,"{false,``n``; e.g. ``4380``}","Apply time series segmentation with `tsam <https://tsam.readthedocs.io/en/latest/index.html>`_ package to ``n`` adjacent snapshots of varying lengths based on capacity factors of varying renewables, hydro inflow and load."
+resolution ,--,"{false,``nH``; i.e. ``2H``-``6H``}","Resample the time-resolution by averaging over every ``n`` snapshots in :mod:`prepare_network`. **Warning:** This option should currently only be used with electricity-only networks, not for sector-coupled networks."
+segmentation,--,"{false,``n``; e.g. ``4380``}","Apply time series segmentation with `tsam <https://tsam.readthedocs.io/en/latest/index.html>`_ package to ``n`` adjacent snapshots of varying lengths based on capacity factors of varying renewables, hydro inflow and load in :mod:`prepare_network`. **Warning:** This option should currently only be used with electricity-only networks, not for sector-coupled networks."


### PR DESCRIPTION
… electricity-only

Closes #897 

This is just the documentation warning hotfix.

The proper solution I would go for is to split the options for time aggregation in prepare_sector_network and prepare_network. This will be done in line with https://github.com/PyPSA/pypsa-eur/pull/617 where each wildcard option will get an equivalent item in the configuration file.