### PR TITLE
Fix gas input for existing heat gas boilers

### DIFF
--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -482,7 +482,7 @@ def add_heating_capacities_installed_before_baseyear(
                 "Link",
                 nodes,
                 suffix=f" {name} gas boiler-{grouping_year}",
-                bus0=spatial.gas.nodes,
+                bus0="EU gas" if "EU gas" in spatial.gas.nodes else nodes + " gas",
                 bus1=nodes + " " + name + " heat",
                 bus2="co2 atmosphere",
                 carrier=name + " gas boiler",


### PR DESCRIPTION
## Changes proposed in this Pull Request

There is a potential when existing heating is added where the nodes for existing heating are only those with any CHP capacities, but when a new link is added in `add_heating_capacities_installed_before_baseyear`, it uses `spatial.gas.nodes` as bus0, which (when gas is spatially resolved) has a gas node for _every_ node in the network, not just those with CHP capacities. This leads to an indexing error.

This PR is a simple fix for the problem. Feel free to modify if there's a better way, stylistically speaking, to address the problem.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
