### PR TITLE
remove inefficient _helper.py file search

### DIFF
--- a/rules/common.smk
+++ b/rules/common.smk
@@ -4,11 +4,8 @@
 
 import os, sys, glob
 
-helper_source_path = workflow.source_path("scripts/_helpers.py")
-
-for path in helper_source_path:
-    path = os.path.dirname(os.path.abspath(path))
-    sys.path.insert(0, os.path.abspath(path))
+for path in ["../scripts", "./scripts"]:
+    sys.path.insert(0, os.path.abspath(path)
 
 from _helpers import validate_checksum
 

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -4,7 +4,7 @@
 
 import os, sys, glob
 
-helper_source_path = [match for match in glob.glob("**/_helpers.py", recursive=True)]
+helper_source_path = workflow.source_path("scripts/_helpers.py")
 
 for path in helper_source_path:
     path = os.path.dirname(os.path.abspath(path))

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -4,8 +4,8 @@
 
 import os, sys, glob
 
-for path in ["../scripts", "./scripts"]:
-    sys.path.insert(0, os.path.abspath(path)
+path = workflow.source_path("../scripts/_helpers.py")
+sys.path.insert(0, os.path.dirname(path))
 
 from _helpers import validate_checksum
 


### PR DESCRIPTION
closes #879 

To be seen how it works if the repository is used as module. But that's secondary.