### PR TITLE
cluster nice names as well

### DIFF
--- a/rules/postprocess.smk
+++ b/rules/postprocess.smk
@@ -45,7 +45,7 @@ if config["foresight"] != "perfect":
             (
                 LOGS
                 + "plot_power_network/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.log"
-            )
+            ),
         benchmark:
             (
                 BENCHMARKS
@@ -74,7 +74,7 @@ if config["foresight"] != "perfect":
             (
                 LOGS
                 + "plot_hydrogen_network/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.log"
-            )
+            ),
         benchmark:
             (
                 BENCHMARKS
@@ -102,7 +102,7 @@ if config["foresight"] != "perfect":
             (
                 LOGS
                 + "plot_gas_network/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.log"
-            )
+            ),
         benchmark:
             (
                 BENCHMARKS

--- a/scripts/build_ammonia_production.py
+++ b/scripts/build_ammonia_production.py
@@ -7,8 +7,8 @@ Build historical annual ammonia production per country in ktonNH3/a.
 """
 
 import country_converter as coco
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 cc = coco.CountryConverter()
 
@@ -33,9 +33,7 @@ if __name__ == "__main__":
     years = [str(i) for i in range(2013, 2018)]
 
     ammonia = ammonia[years]
-    ammonia.replace("--",
-                    np.nan,
-                    inplace=True)
+    ammonia.replace("--", np.nan, inplace=True)
     ammonia = ammonia.astype(float)
 
     # convert from ktonN to ktonNH3

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3422,7 +3422,11 @@ def cluster_heat_buses(n):
 
     for c in n.iterate_components(components):
         df = c.df
-        cols = df.columns[df.columns.str.contains("bus") | (df.columns == "carrier")]
+        cols = df.columns[
+            df.columns.str.contains("bus") 
+            | (df.columns == "carrier")
+            | (df.columns == "nice_name")
+        ]
 
         # rename columns and index
         df[cols] = df[cols].apply(

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3071,8 +3071,7 @@ def add_industry(n, costs):
             + mwh_coal_per_mwh_coke * industrial_demand["coke"]
         ) / nhours
 
-        p_set.rename(lambda x: x + " coal for industry",
-                     inplace=True)
+        p_set.rename(lambda x: x + " coal for industry", inplace=True)
 
         if not options["regional_coal_demand"]:
             p_set = p_set.sum()
@@ -3103,7 +3102,6 @@ def add_industry(n, costs):
             p_nom_extendable=True,
             efficiency2=costs.at["coal", "CO2 intensity"],
         )
-
 
 
 def add_waste_heat(n):
@@ -3423,7 +3421,7 @@ def cluster_heat_buses(n):
     for c in n.iterate_components(components):
         df = c.df
         cols = df.columns[
-            df.columns.str.contains("bus") 
+            df.columns.str.contains("bus")
             | (df.columns == "carrier")
             | (df.columns == "nice_name")
         ]


### PR DESCRIPTION
I noticed that in the myopic optimisation for the pypsa-ariadne project, the carriers returned by 
```python
n.statistics.withdrawal(
        bus_carrier="rural heat", 
        groupby=n.statistics.groupers.get_name_bus_and_carrier,
    ).filter(
        like="DE",
        axis=0,
    ).groupby("carrier").sum()
 ```
will differ between the 2020 network and the 2030 network. In the 2020 baseyear a carrier will, e.g., be named `residential urban decentral heat` , whereas in the 2030 network it will  simply be ` urban decentral heat `. In both cases all links in the network actually have `urban decentral heat` as carrier - it's just the names that are different.

I traced the bug to the `n.carriers.nice_name` column, on which n.statistics relies. 

![image](https://github.com/PyPSA/pypsa-eur/assets/56298440/6eea8ef8-057e-4bbf-88a4-52d71b8b0ff2)

It's clearly visible that the name's didn't get updated correctly alongside the carrier. It's a bit strange that this occurs only for 2020 and not for 2030, and is probably related to how `cluster_heat_buses` is called. It happens either in `prepare_sector_network` (for later years) or in `add_existing_baseyear` (for 2020). In all cases the `sanitize_carriers` function is called, but fails to correctly rename the clustered heat carriers. Instead of looking into the details of why `sanitized_carriers` fails, the easy fix that i propose is to rename the `nice_name` column directly in `cluster_heat_buses`.

## Changes proposed in this Pull Request

rename the `nice_name` column directly in `cluster_heat_buses`


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
