### PR TITLE
bugfix: include all countries in ammonia production resource

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,10 @@ Release Notes
 Upcoming Release
 ================
 
+* Include all countries in ammonia production resource. This is so that the full
+  EU28 ammonia demand can be correctly subtracted in the rule
+  :mod:`build_industry_sector_ratios`.
+
 * The default configuration ``config/config.default.yaml`` is now automatically
   used as a base configuration file and no longer copied to
   ``config/config.yaml`` on first use. The file ``config/config.yaml`` should be

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -392,8 +392,6 @@ rule build_salt_cavern_potentials:
 
 
 rule build_ammonia_production:
-    params:
-        countries=config["countries"],
     input:
         usgs="data/bundle-sector/myb1-2017-nitro.xls",
     output:

--- a/scripts/build_ammonia_production.py
+++ b/scripts/build_ammonia_production.py
@@ -7,7 +7,6 @@ Build historical annual ammonia production per country in ktonNH3/a.
 """
 
 import country_converter as coco
-import numpy as np
 import pandas as pd
 
 cc = coco.CountryConverter()
@@ -26,6 +25,7 @@ if __name__ == "__main__":
         header=0,
         index_col=0,
         skipfooter=19,
+        na_values=["--"],
     )
 
     ammonia.index = cc.convert(ammonia.index, to="iso2")
@@ -33,8 +33,6 @@ if __name__ == "__main__":
     years = [str(i) for i in range(2013, 2018)]
 
     ammonia = ammonia[years]
-    ammonia.replace("--", np.nan, inplace=True)
-    ammonia = ammonia.astype(float)
 
     # convert from ktonN to ktonNH3
     ammonia *= 17 / 14

--- a/scripts/build_ammonia_production.py
+++ b/scripts/build_ammonia_production.py
@@ -8,6 +8,7 @@ Build historical annual ammonia production per country in ktonNH3/a.
 
 import country_converter as coco
 import pandas as pd
+import numpy as np
 
 cc = coco.CountryConverter()
 
@@ -30,8 +31,12 @@ if __name__ == "__main__":
     ammonia.index = cc.convert(ammonia.index, to="iso2")
 
     years = [str(i) for i in range(2013, 2018)]
-    countries = ammonia.index.intersection(snakemake.params.countries)
-    ammonia = ammonia.loc[countries, years].astype(float)
+
+    ammonia = ammonia[years]
+    ammonia.replace("--",
+                    np.nan,
+                    inplace=True)
+    ammonia = ammonia.astype(float)
 
     # convert from ktonN to ktonNH3
     ammonia *= 17 / 14

--- a/scripts/build_ammonia_production.py
+++ b/scripts/build_ammonia_production.py
@@ -7,8 +7,8 @@ Build historical annual ammonia production per country in ktonNH3/a.
 """
 
 import country_converter as coco
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 cc = coco.CountryConverter()
 
@@ -33,9 +33,7 @@ if __name__ == "__main__":
     years = [str(i) for i in range(2013, 2018)]
 
     ammonia = ammonia[years]
-    ammonia.replace("--",
-                    np.nan,
-                    inplace=True)
+    ammonia.replace("--", np.nan, inplace=True)
     ammonia = ammonia.astype(float)
 
     # convert from ktonN to ktonNH3


### PR DESCRIPTION
This is so that the full EU28 ammonia demand can be correctly subtracted in the build_industry_sector_ratios.py script.

No other downstream scripts are affected by this change.

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
