### PR TITLE
update h2 pipe losses

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -538,8 +538,8 @@ sector:
       efficiency_static: 0.98
       efficiency_per_1000km: 0.977
     H2 pipeline:
-      efficiency_per_1000km: 1 # 0.979
-      compression_per_1000km: 0.019
+      efficiency_per_1000km: 0.996
+      compression_per_1000km: 0.018
     gas pipeline:
       efficiency_per_1000km: 1 #0.977
       compression_per_1000km: 0.01

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -538,8 +538,8 @@ sector:
       efficiency_static: 0.98
       efficiency_per_1000km: 0.977
     H2 pipeline:
-      efficiency_per_1000km: 0.9905
-      compression_per_1000km: 0.008
+      efficiency_per_1000km: 1 # 0.982
+      compression_per_1000km: 0.018
     gas pipeline:
       efficiency_per_1000km: 1 #0.977
       compression_per_1000km: 0.01

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -538,8 +538,8 @@ sector:
       efficiency_static: 0.98
       efficiency_per_1000km: 0.977
     H2 pipeline:
-      efficiency_per_1000km: 0.996
-      compression_per_1000km: 0.018
+      efficiency_per_1000km: 0.9905
+      compression_per_1000km: 0.008
     gas pipeline:
       efficiency_per_1000km: 1 #0.977
       compression_per_1000km: 0.01


### PR DESCRIPTION
Closes # (if applicable).
- in the German Kernnetz we have planned pipe capacities ranging between 1.2-17 GW_H2 with 70 bars
- [DEA](https://ens.dk/en/our-services/projections-and-models/technology-data/technology-data-transport-energy) (sheet name H2 70) assumes total pipe losses for this pipe size of 1.3-2.2%/1000 km (losses are higher with higher operating pressure).

I think that includes the energy demand of the compressors, which is in DEA data ranging between 0.7-0.9% for pipes operating at 70 bar.

I would suggest taking the mean value, so 0.8% energy demand for the compressors and 1.75%/1000 km total pipe losses. I subtracted in the PR now for the pipe losses without the compressors 100-(1.75-0.8)= 99.05 -> 0.9905
Do we assume that the compressors are installed

## Changes proposed in this Pull Request


## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
