### PR TITLE
Change default energy totals year to 2013

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -314,7 +314,7 @@ pypsa_eur:
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#energy
 energy:
-  energy_totals_year: 2011
+  energy_totals_year: 2013
   base_emissions_year: 1990
   eurostat_report_year: 2016
   emissions: CO2

--- a/data/switzerland-new_format-all_years.csv
+++ b/data/switzerland-new_format-all_years.csv
@@ -1,0 +1,25 @@
+country,item,2010,2011,2012,2013,2014,2015
+CH,total residential,268.2,223.4,243.4,261.3,214.2,229.1
+CH,total residential space,192.2,149.0,168.1,185.5,139.7,154.4
+CH,total residential water,32.2,31.6,31.9,32.2,31.7,31.9
+CH,total residential cooking,9.3,9.3,9.3,9.4,9.5,9.6
+CH,electricity residential,67.9,63.7,65.7,67.6,63.0,64.4
+CH,electricity residential space,15.9,12.8,14.3,15.8,12.3,13.5
+CH,electricity residential water,8.8,8.5,8.5,8.6,8.5,8.6
+CH,electricity residential cooking,4.9,4.9,4.9,4.9,5.0,5.0
+CH,total services,145.9,127.4,136.7,144.0,124.5,132.5
+CH,total services space,80.0,62.2,70.8,77.4,58.3,64.3
+CH,total services water,10.1,10.0,10.1,10.1,10.0,10.0
+CH,total services cooking,2.5,2.4,2.3,2.3,2.4,2.3
+CH,electricity services,60.5,59.2,60.3,61.4,60.3,62.6
+CH,electricity services space,4.0,3.2,3.8,4.2,3.3,3.6
+CH,electricity services water,0.7,0.7,0.7,0.7,0.7,0.7
+CH,electricity services cooking,2.5,2.4,2.3,2.3,2.4,2.3
+CH,total rail,11.5,11.1,11.2,11.4,11.1,11.4
+CH,total road,199.4,200.4,200.4,201.2,202.0,203.1
+CH,electricity road,0.,0.,0.,0.,0.,0.
+CH,electricity rail,11.5,11.1,11.2,11.4,11.1,11.4
+CH,total domestic aviation,3.3,3.2,3.4,3.4,3.5,3.5
+CH,total international aviation,58.0,62.0,63.5,64.2,64.5,66.8
+CH,total domestic navigation,1.6,1.6,1.6,1.6,1.6,1.6
+CH,total international navigation,0.,0.,0.,0.,0.,0.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -113,6 +113,8 @@ Upcoming Release
   workflows with foresight "myopic" and still needs to be added foresight option
   "perfect".
 
+* Swiched the energy totals year from 2011 to 2013 to comply with the assumed default weather year.
+
 
 PyPSA-Eur 0.9.0 (5th January 2024)
 ==================================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -113,7 +113,7 @@ Upcoming Release
   workflows with foresight "myopic" and still needs to be added foresight option
   "perfect".
 
-* Swiched the energy totals year from 2011 to 2013 to comply with the assumed default weather year.
+* Switched the energy totals year from 2011 to 2013 to comply with the assumed default weather year.
 
 
 PyPSA-Eur 0.9.0 (5th January 2024)

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -248,7 +248,7 @@ rule build_energy_totals:
     input:
         nuts3_shapes=RESOURCES + "nuts3_shapes.geojson",
         co2="data/bundle-sector/eea/UNFCCC_v23.csv",
-        swiss="data/bundle-sector/switzerland-sfoe/switzerland-new_format.csv",
+        swiss="data/switzerland-new_format-all_years.csv",
         idees="data/bundle-sector/jrc-idees-2015",
         district_heat_share="data/district_heat_share.csv",
         eurostat=input_eurostat,


### PR DESCRIPTION
## Changes proposed in this Pull Request

Add new data on energy totals to `data/ ` that contains information for additional years for Switzerland, originally in the `pypsa-eur-sec` data-bundle (and containing only information for the year 2011).
Make use of the new data-bundle for calculating the energy totals.
Switch the default energy totals year to 2013.


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
