### PR TITLE
Allow CPLEX for MIQP in cluster_network

### DIFF
--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -267,7 +267,7 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name="scip"):
     m.objective = (clusters * clusters - 2 * clusters * L * n_clusters).sum()
     if solver_name == "gurobi":
         logging.getLogger("gurobipy").propagate = False
-    elif solver_name != "scip":
+    elif solver_name != "scip" and solver_name != "cplex":
         logger.info(
             f"The configured solver `{solver_name}` does not support quadratic objectives. Falling back to `scip`."
         )

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -267,7 +267,7 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name="scip"):
     m.objective = (clusters * clusters - 2 * clusters * L * n_clusters).sum()
     if solver_name == "gurobi":
         logging.getLogger("gurobipy").propagate = False
-    elif solver_name != "scip" and solver_name != "cplex":
+    elif solver_name not in ["scip", "cplex"]:
         logger.info(
             f"The configured solver `{solver_name}` does not support quadratic objectives. Falling back to `scip`."
         )


### PR DESCRIPTION
## Changes proposed in this Pull Request

The title basically says it all. CPLEX can also solve MIQP. This configures `cluster_network` not to fall back to `scip` if `solve_name = cplex`.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
