### PR TITLE
adding regions to network.shapes

### DIFF
--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -431,7 +431,7 @@ def clustering_for_n_clusters(
 def cluster_regions(busmaps, input=None, output=None):
     busmap = reduce(lambda x, y: x.map(y), busmaps[1:], busmaps[0])
 
-    clustered_regions=[]
+    clustered_regions = []
     for which in ("regions_onshore", "regions_offshore"):
         regions = gpd.read_file(getattr(input, which))
         regions = regions.reindex(columns=["name", "geometry"]).set_index("name")
@@ -439,18 +439,19 @@ def cluster_regions(busmaps, input=None, output=None):
         regions_c.index.name = "name"
         regions_c = regions_c.reset_index()
         regions_c.to_file(getattr(output, which))
-        # 
+        #
         # logger.info(f'{regions_c}')
         # logger.info(f'{regions_c.index}')
         # logger.info(f'{regions_c.index.name}')
         # logger.info(f"{regions_c.columns}")
-        # 
-        regions_c.rename(columns={'name': 'idx'})
-        regions_c["component"]=which
-        regions_c["type"]="country_shape"
+        #
+        regions_c.rename(columns={"name": "idx"})
+        regions_c["component"] = which
+        regions_c["type"] = "country_shape"
         clustered_regions.append(regions_c)
 
-    return pd.concat(clustered_regions,ignore_index=True)
+    return pd.concat(clustered_regions, ignore_index=True)
+
 
 def plot_busmap_for_n_clusters(n, n_clusters, fn=None):
     busmap = busmap_for_n_clusters(n, n_clusters)
@@ -560,25 +561,29 @@ if __name__ == "__main__":
     clustering.network.meta = dict(
         snakemake.config, **dict(wildcards=dict(snakemake.wildcards))
     )
-    
+
     for attr in (
         "busmap",
         "linemap",
     ):  # also available: linemap_positive, linemap_negative
         getattr(clustering, attr).to_csv(snakemake.output[attr])
 
-    clustered_regions = cluster_regions((clustering.busmap,), snakemake.input, snakemake.output)
-    
+    clustered_regions = cluster_regions(
+        (clustering.busmap,), snakemake.input, snakemake.output
+    )
+
     # logger.info(f"{clustering.network.shapes}")
     # logger.info(f"{clustering.network.shapes.index}")
     # logger.info(f"{clustering.network.shapes.index.name}")
     # logger.info(f"{clustering.network.shapes.columns}")
-    
-    index_name=clustering.network.shapes.index.name
-    
-    clustering.network.shapes=pd.concat([clustering.network.shapes,clustered_regions], ignore_index=True)
-    
+
+    index_name = clustering.network.shapes.index.name
+
+    clustering.network.shapes = pd.concat(
+        [clustering.network.shapes, clustered_regions], ignore_index=True
+    )
+
     clustering.network.shapes.reset_index()
-    clustering.network.shapes.index.name=index_name
-    
+    clustering.network.shapes.index.name = index_name
+
     clustering.network.export_to_netcdf(snakemake.output.network)


### PR DESCRIPTION
- Data has been transferred from `cluster_network.py` to `n.shapes` in a GeoPandas DataFrame.

The copied data appears as follows: 
![Screenshot from 2024-03-02 21-56-35](https://github.com/PyPSA/pypsa-eur/assets/93286254/526bd4f8-0eef-4aba-9f0e-ca4a0c650fbd.png)

For the file: 
![Screenshot from 2024-03-02 21-58-07](https://github.com/PyPSA/pypsa-eur/assets/93286254/8d09633d-4b6e-4449-ab3e-db9fce135a81.png)

The rule `build_bus_regions` uses `build_bus_regions.py` to produce `regions_offshore.geojson`, which is subsequently transformed into:

- `regions_offshore_elec_s{simpl}.geojson`
- `regions_offshore_elec_s{simpl}_{clusters}.geojson`

using `cluster_network.py`.

- I have copied data into `cluster_network.py`.
- Should we consider transferring data into `build_bus_regions.py` or earlier, remove `.geojson` files, and perform all subsequent operations in the `n.shapes` GeoPandas DataFrame?
- Or, should we maintain the functionality of transferring data from `regions_offshore_elec_s{simpl}_{clusters}.geojson` separately?
- Additionally, we need to determine if, when approach 1 is implemented, the data from `regions_offshore_elec_s{simpl}.geojson` is required by any other rule once the subsequent file (e.g., `regions_offshore_elec_s{simpl}_{clusters}.geojson`) is created. If operations are conducted in a GeoPandas DataFrame, the preceding information will not be available after transformations.

Please suggest how we should proceed.
