### PR TITLE
Land transport fix

### DIFF
--- a/scripts/build_transport_demand.py
+++ b/scripts/build_transport_demand.py
@@ -19,13 +19,16 @@ logger = logging.getLogger(__name__)
 
 
 def build_nodal_transport_data(fn, pop_layout):
+    # get numbers of car and fuel efficieny per country
     transport_data = pd.read_csv(fn, index_col=0)
-
+    
+    # break number of cars down to nodal level based on population density
     nodal_transport_data = transport_data.loc[pop_layout.ct].fillna(0.0)
     nodal_transport_data.index = pop_layout.index
     nodal_transport_data["number cars"] = (
         pop_layout["fraction"] * nodal_transport_data["number cars"]
     )
+    # fill missing fuel efficiency with average data
     nodal_transport_data.loc[
         nodal_transport_data["average fuel efficiency"] == 0.0,
         "average fuel efficiency",
@@ -35,25 +38,20 @@ def build_nodal_transport_data(fn, pop_layout):
 
 
 def build_transport_demand(traffic_fn, airtemp_fn, nodes, nodal_transport_data):
-    ## Get overall demand curve for all vehicles
-
-    traffic = pd.read_csv(traffic_fn, skiprows=2, usecols=["count"]).squeeze("columns")
-
+    """
+    returns transport demand per bus in unit kinetic energy.
+    """
+    # averaged weekly counts from the year 2010-2015
+    traffic = pd.read_csv(traffic_fn, skiprows=2,
+                          usecols=["count"]).squeeze("columns")
+    
+    # create annual profile take account time zone + summer time
     transport_shape = generate_periodic_profiles(
         dt_index=snapshots,
         nodes=nodes,
         weekly_profile=traffic.values,
     )
     transport_shape = transport_shape / transport_shape.sum()
-
-    # electric motors are more efficient, so alter transport demand
-
-    plug_to_wheels_eta = options["bev_plug_to_wheel_efficiency"]
-    battery_to_wheels_eta = plug_to_wheels_eta * options["bev_charge_efficiency"]
-
-    efficiency_gain = (
-        nodal_transport_data["average fuel efficiency"] / battery_to_wheels_eta
-    )
 
     # get heating demand for correction to demand time series
     temperature = xr.open_dataarray(airtemp_fn).to_pandas()
@@ -67,16 +65,8 @@ def build_transport_demand(traffic_fn, airtemp_fn, nodes, nodal_transport_data):
         options["ICE_upper_degree_factor"],
     )
 
-    dd_EV = transport_degree_factor(
-        temperature,
-        options["transport_heating_deadband_lower"],
-        options["transport_heating_deadband_upper"],
-        options["EV_lower_degree_factor"],
-        options["EV_upper_degree_factor"],
-    )
-
+    
     # divide out the heating/cooling demand from ICE totals
-    # and multiply back in the heating/cooling demand for EVs
     ice_correction = (transport_shape * (1 + dd_ICE)).sum() / transport_shape.sum()
 
     energy_totals_transport = (
@@ -87,8 +77,7 @@ def build_transport_demand(traffic_fn, airtemp_fn, nodes, nodal_transport_data):
 
     return (
         (transport_shape.multiply(energy_totals_transport) * 1e6 * nyears)
-        .divide(efficiency_gain * ice_correction)
-        .multiply(1 + dd_EV)
+        .divide(nodal_transport_data["average fuel efficiency"] * ice_correction)
     )
 
 
@@ -125,11 +114,14 @@ def bev_availability_profile(fn, snapshots, nodes, options):
     """
     Derive plugged-in availability for passenger electric vehicles.
     """
+    # car count in typical week
     traffic = pd.read_csv(fn, skiprows=2, usecols=["count"]).squeeze("columns")
-
+    # maximum share plugged-in availability for passenger electric vehicles
     avail_max = options["bev_avail_max"]
+    # average share plugged-in availability for passenger electric vehicles
     avail_mean = options["bev_avail_mean"]
 
+    # linear scaling, highest when traffic is lowest, decreases if traffic increases
     avail = avail_max - (avail_max - avail_mean) * (traffic - traffic.min()) / (
         traffic.mean() - traffic.min()
     )
@@ -149,7 +141,9 @@ def bev_availability_profile(fn, snapshots, nodes, options):
 
 def bev_dsm_profile(snapshots, nodes, options):
     dsm_week = np.zeros((24 * 7,))
-
+    
+    # assuming that at a certain time ("bev_dsm_restriction_time") EVs have to
+    # be charged to a minimum value (defined in bev_dsm_restriction_value)
     dsm_week[(np.arange(0, 7, 1) * 24 + options["bev_dsm_restriction_time"])] = options[
         "bev_dsm_restriction_value"
     ]
@@ -160,7 +154,7 @@ def bev_dsm_profile(snapshots, nodes, options):
         weekly_profile=dsm_week,
     )
 
-
+#%%
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
@@ -168,7 +162,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "build_transport_demand",
             simpl="",
-            clusters=48,
+            clusters=37,
         )
     configure_logging(snakemake)
     set_scenario_config(snakemake)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1627,24 +1627,22 @@ def add_ice_cars(n, nodes, p_set, ice_share, temperature):
 
     ice_efficiency = options["transport_internal_combustion_efficiency"]
     
-    if not options["regional_oil_demand"]:
-        p_nom = ice_share * p_set.sum(axis=1).max() / ice_efficiency
-    else:
-        p_nom =  ice_share * p_set.max() / ice_efficiency
+    p_nom =  ice_share * p_set.max() / ice_efficiency
+    suffix = " land transport ICE"
+    p_nom.rename(lambda x: x + suffix, inplace=True)
        
     
     n.madd(
         "Link",
-        nodes + " land transport ICE",
+        nodes + suffix,
         bus0=spatial.oil.nodes,
         bus1=nodes + " land transport",
         bus2=["co2 atmosphere"],
         carrier="land transport oil",
         efficiency=ice_efficiency,
         efficiency2=costs.at["oil", "CO2 intensity"],
-        p_nom_extendable=True,
-        # p_nom=p_nom,
-        capital_cost=1e4,
+        p_nom_extendable=False,
+        p_nom=p_nom,
     )
     
 def add_land_transport(n, costs):

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1535,8 +1535,13 @@ def add_EVs(n, nodes, avail_profile, dsm_profile, p_set, electric_share,
         options["EV_upper_degree_factor"],
     )
     
+    temp_eff = 1 / (1+dd_EV)
+    
     profile = p_set/p_set.max()
-    efficiency = costs.at['Battery electric (passenger cars)', 'efficiency']
+    
+    car_efficiency = costs.at['Battery electric (passenger cars)', 'efficiency']
+    
+    efficiency = car_efficiency * temp_eff
     
     n.madd(
         "Link",
@@ -1602,9 +1607,21 @@ def add_EVs(n, nodes, avail_profile, dsm_profile, p_set, electric_share,
         
 def add_fuel_cell_cars(n, nodes, p_set, fuel_cell_share, temperature):
     
-    efficiency = options["transport_fuel_cell_efficiency"]
+    # correction factors for vehicle heating + cooling
+    dd_ICE = transport_degree_factor(
+        temperature,
+        options["transport_heating_deadband_lower"],
+        options["transport_heating_deadband_upper"],
+        options["ICE_lower_degree_factor"],
+        options["ICE_upper_degree_factor"],
+    )
+    temp_eff = 1 / (1+dd_ICE)
+    car_efficiency = options["transport_fuel_cell_efficiency"]
+    efficiency = car_efficiency * temp_eff
+    
+    
     profile = p_set / p_set.max()
-    p_nom = fuel_cell_share * p_set / efficiency
+    p_nom = fuel_cell_share * p_set / car_efficiency
     
     n.madd(
         "Link",
@@ -1624,10 +1641,22 @@ def add_fuel_cell_cars(n, nodes, p_set, fuel_cell_share, temperature):
 def add_ice_cars(n, nodes, p_set, ice_share, temperature):
     
     add_carrier_buses(n, "oil")
-
-    ice_efficiency = options["transport_internal_combustion_efficiency"]
     
-    p_nom =  ice_share * p_set.max() / ice_efficiency
+    # correction factors for vehicle heating + cooling
+    dd_ICE = transport_degree_factor(
+        temperature,
+        options["transport_heating_deadband_lower"],
+        options["transport_heating_deadband_upper"],
+        options["ICE_lower_degree_factor"],
+        options["ICE_upper_degree_factor"],
+    )
+    temp_eff = 1 / (1+dd_ICE)
+
+    car_efficiency = options["transport_internal_combustion_efficiency"]
+    
+    efficiency = car_efficiency * temp_eff
+    
+    p_nom =  ice_share * p_set.max() / car_efficiency
     suffix = " land transport ICE"
     p_nom.rename(lambda x: x + suffix, inplace=True)
        
@@ -1639,7 +1668,7 @@ def add_ice_cars(n, nodes, p_set, ice_share, temperature):
         bus1=nodes + " land transport",
         bus2=["co2 atmosphere"],
         carrier="land transport oil",
-        efficiency=ice_efficiency,
+        efficiency=efficiency,
         efficiency2=costs.at["oil", "CO2 intensity"],
         p_nom_extendable=False,
         p_nom=p_nom,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1553,20 +1553,23 @@ def add_EVs(n, nodes, avail_profile, dsm_profile, p_set, electric_share,
                                     options["transport_heating_deadband_upper"],
                                     options["EV_lower_degree_factor"],
                                     options["EV_upper_degree_factor"])
+    suffix = " land transport EV"
     
-    profile = p_set/p_set.max()
+    p_nom = electric_share * p_set.div(efficiency).max()
+    
+    profile = p_set.div(efficiency)/p_set.div(efficiency).max()
     
     n.madd(
         "Link",
         nodes,
-        suffix=" land transport EV",
+        suffix=suffix,
         bus0=nodes + " EV battery",                              
         bus1=nodes + " land transport",
         carrier="land transport EV",
         efficiency=efficiency,     
         p_min_pu=profile,
         p_max_pu=profile,
-        p_nom=electric_share*p_set.max()/car_efficiency,
+        p_nom=p_nom,
         p_nom_extendable=False,
     )
     
@@ -1629,14 +1632,16 @@ def add_fuel_cell_cars(n, nodes, p_set, fuel_cell_share, temperature):
                                     options["ICE_lower_degree_factor"],
                                     options["ICE_upper_degree_factor"])
     
+    suffix = " land transport fuel cell"
+        
+    p_nom = fuel_cell_share * p_set.div(efficiency).max()
     
-    profile = p_set / p_set.max()
-    p_nom = fuel_cell_share * p_set.max() / car_efficiency
+    profile = p_set.div(efficiency)/p_set.div(efficiency).max()
     
     n.madd(
         "Link",
         nodes,
-        suffix=" land transport fuel cell",
+        suffix=suffix,
         bus0=spatial.h2.nodes,
         bus1=nodes + " land transport",
         carrier="land transport fuel cell", 
@@ -1660,15 +1665,15 @@ def add_ice_cars(n, nodes, p_set, ice_share, temperature):
                                     options["transport_heating_deadband_upper"],
                                     options["ICE_lower_degree_factor"],
                                     options["ICE_upper_degree_factor"])
-    
-    p_nom =  ice_share * p_set.max() / car_efficiency
     suffix = " land transport ICE"
-    p_nom.rename(lambda x: x + suffix, inplace=True)
-       
     
+    p_nom =  ice_share * p_set.div(efficiency).max()
+    
+     
     n.madd(
         "Link",
-        nodes + suffix,
+        nodes,
+        suffix=suffix,
         bus0=spatial.oil.nodes,
         bus1=nodes + " land transport",
         bus2=["co2 atmosphere"],

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -921,19 +921,19 @@ def solve_network(n, config, solving, **kwargs):
 
     return n
 
-
+#%%
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "solve_sector_network",
-            configfiles="../config/test/config.perfect.yaml",
+            # configfiles="../config/test/config.perfect.yaml",
             simpl="",
             opts="",
             clusters="37",
             ll="v1.0",
-            sector_opts="CO2L0-1H-T-H-B-I-A-dist1",
+            sector_opts="730H-T-H-B-I-A-dist1",
             planning_horizons="2030",
         )
     configure_logging(snakemake)


### PR DESCRIPTION

## Changes proposed in this Pull Request
This PR converts all land transport demand to one single node and adds the different land transport options (EV, fuel cell, internal combustion car) as links. 

This is a bug fix since currently efficiency are adjusted with the assumptions that all cars would be EVs (what is not the case for myopic optimisation) and is a preparation for endogenousing the land transport.

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
