### PR TITLE
compute lifetime after grouping DateIn

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -354,7 +354,7 @@ solar_thermal:
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#existing-capacities
 existing_capacities:
-  grouping_years_power: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025, 2030]
+  grouping_years_power: [1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025, 2030]
   grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019] # these should not extend 2020
   threshold_capacity: 10
   default_heating_lifetime: 20

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,6 +9,8 @@ Release Notes
 
 Upcoming Release
 ================
+* Corrected a bug leading to power plants operating after their DateOut (https://github.com/PyPSA/pypsa-eur/pull/958).
+
 * Upgrade default techno-economic assumptions to ``technology-data`` v0.8.1.
 
 * Linearly interpolate missing investment periods in year-dependent

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,7 +9,7 @@ Release Notes
 
 Upcoming Release
 ================
-* Corrected a bug leading to power plants operating after their DateOut 
+* Corrected a bug leading to power plants operating after their DateOut
   (https://github.com/PyPSA/pypsa-eur/pull/958). Added additional grouping years
   before 1980.
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,7 +9,9 @@ Release Notes
 
 Upcoming Release
 ================
-* Corrected a bug leading to power plants operating after their DateOut (https://github.com/PyPSA/pypsa-eur/pull/958).
+* Corrected a bug leading to power plants operating after their DateOut 
+  (https://github.com/PyPSA/pypsa-eur/pull/958). Added additional grouping years
+  before 1980.
 
 * Upgrade default techno-economic assumptions to ``technology-data`` v0.8.1.
 

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -171,9 +171,7 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
     phased_out = df_agg[df_agg["DateOut"] < baseyear].index
     df_agg.drop(phased_out, inplace=True)
 
-    # calculate remaining lifetime before phase-out (+1 because assuming
-    # phase out date at the end of the year)
-    df_agg["lifetime"] = df_agg.DateOut - df_agg.DateIn + 1
+
 
     # assign clustered bus
     busmap_s = pd.read_csv(snakemake.input.busmap_s, index_col=0).squeeze()
@@ -194,6 +192,10 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
     df_agg["grouping_year"] = np.take(
         grouping_years, np.digitize(df_agg.DateIn, grouping_years, right=True)
     )
+
+    # calculate (adjusted) remaining lifetime before phase-out (+1 because assuming
+    # phase out date at the end of the year)
+    df_agg["lifetime"] = df_agg.DateOut - df_agg["grouping_year"]  + 1
 
     df = df_agg.pivot_table(
         index=["grouping_year", "Fueltype"],

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -171,8 +171,6 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
     phased_out = df_agg[df_agg["DateOut"] < baseyear].index
     df_agg.drop(phased_out, inplace=True)
 
-
-
     # assign clustered bus
     busmap_s = pd.read_csv(snakemake.input.busmap_s, index_col=0).squeeze()
     busmap = pd.read_csv(snakemake.input.busmap, index_col=0).squeeze()
@@ -195,7 +193,7 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
 
     # calculate (adjusted) remaining lifetime before phase-out (+1 because assuming
     # phase out date at the end of the year)
-    df_agg["lifetime"] = df_agg.DateOut - df_agg["grouping_year"]  + 1
+    df_agg["lifetime"] = df_agg.DateOut - df_agg["grouping_year"] + 1
 
     df = df_agg.pivot_table(
         index=["grouping_year", "Fueltype"],


### PR DESCRIPTION
Closes # (if applicable).

The problem is described in https://github.com/PyPSA/pypsa-ariadne/pull/29.

The lifetime is computed as DateOut - DateIn + 1. At the moment, the model considers not DateIn as start of the lifetime but the grouping year. The grouping year may be up to 5 years later than DateIn, and thus some power plants live up to 5 years longer than they should. 

## Changes proposed in this Pull Request

Fixes the issue by computing lifetime based on the grouping year.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
