### PR TITLE
Add decommissioning of renewables assets

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -68,6 +68,8 @@ Upcoming Release
   (https://github.com/PyPSA/pypsa-eur/pull/958). Added additional grouping years
   before 1980.
 
+* Add decommissioning of renewables assets in `add_existing_baseyear`.
+
 * The Eurostat data was updated to the 2023 version in :mod:`build_energy_totals`.
 
 * The latest `Swiss energy totals


### PR DESCRIPTION
In `add_existing_baseyear`, decommissioning of assets is computed before the addition of renewables in the dataframe. This leads to issues with for e.g. onwind assets with a lifetime of 30y and a baseyear of 2030. In this case, `DateOut` is 2029 and those assets should be decommissioned before the `solve_network`.


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
