### PR TITLE
Fix duplicated years in add_land_use_constraint_m

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -106,6 +106,8 @@ Upcoming Release
 
 * Adapt the disabling of transmission expansion in myopic foresight optimisations when limit is already reached to also handle cost limits.
 
+* Fix duplicated years in `add_land_use_constraint_m`.
+
 PyPSA-Eur 0.10.0 (19th February 2024)
 =====================================
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -165,7 +165,7 @@ def _add_land_use_constraint_m(n, planning_horizons, config):
 
         previous_years = [
             str(y)
-            for y in planning_horizons + grouping_years
+            for y in set(planning_horizons + grouping_years)
             if y < int(snakemake.wildcards.planning_horizons)
         ]
 


### PR DESCRIPTION
When `planning_horizons = 2030` and grouping_years also contains `2030`, `p_nom_max` for generators is reduced twice by the value of the current installed capacities. This PR ensure to remove duplicated values.


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
