### PR TITLE
Don't use log path function in IRENA retrieval rule

### DIFF
--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -50,7 +50,7 @@ if config["enable"].get("retrieve_irena"):
             onwind="data/existing_infrastructure/onwind_capacity_IRENA.csv",
             solar="data/existing_infrastructure/solar_capacity_IRENA.csv",
         log:
-            logs("retrieve_irena.log"),
+            "logs/retrieve_irena.log",
         resources:
             mem_mb=1000,
         retries: 2


### PR DESCRIPTION
The `logs` function returns a path with a {run} wildcard which is not present in the output of the retrieval rule. Follows f50ee2f2.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
