### PR TITLE
Allow the selection of custom fork of technology-data

### DIFF
--- a/doc/configtables/costs.csv
+++ b/doc/configtables/costs.csv
@@ -1,6 +1,6 @@
 ,Unit,Values,Description
 year,--,YYYY; e.g. '2030',Year for which to retrieve cost assumptions of ``resources/costs.csv``.
-version,--,vX.X.X; e.g. 'v0.5.0',Version of ``technology-data`` repository to use.
+version,--,vX.X.X or <user>/<repo>/vX.X.X; e.g. 'v0.5.0',Version of ``technology-data`` repository to use. If this string is of the form <user>/<repo>/<version> then costs are instead retrieved from ``github.com/<user>/<repo>`` at the <version> tag.
 rooftop_share,--,float,Share of rooftop PV when calculating capital cost of solar (joint rooftop and utility-scale PV).
 social_discountrate,p.u.,float,Social discount rate to compare costs in different investment periods. 0.02 corresponds to a social discount rate of 2%.
 fill_values,--,float,Default values if not specified for a technology in ``resources/costs.csv``.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -82,6 +82,8 @@ Upcoming Release
 
 * Upgrade default techno-economic assumptions to ``technology-data`` v0.8.1.
 
+* Add possibility to download cost data from custom fork of ``technology-data``.
+
 * Linearly interpolate missing investment periods in year-dependent
   configuration options.
 

--- a/scripts/retrieve_cost_data.py
+++ b/scripts/retrieve_cost_data.py
@@ -25,9 +25,10 @@ if __name__ == "__main__":
     set_scenario_config(snakemake)
 
     version = snakemake.params.version
-    baseurl = (
-        f"https://raw.githubusercontent.com/PyPSA/technology-data/{version}/outputs/"
-    )
+    if "/" in version:
+        baseurl = f"https://raw.githubusercontent.com/{version}/outputs"
+    else:
+        baseurl = f"https://raw.githubusercontent.com/PyPSA/technology-data/{version}/outputs/"
     filepath = Path(snakemake.output[0])
     url = baseurl + filepath.name
 


### PR DESCRIPTION
Sometime like this seems to be necessary in order to use pypsa-eur with technology-data using a different configuration than default; for instance, using 2023 euros instead of 2020 euros ;)

Feel free to suggest alternative ways of doing this if my proposed solution seems a bit ad-hoc.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
