### PR TITLE
Only sanitize locations when there are buses with a location

### DIFF
--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -184,12 +184,13 @@ def sanitize_carriers(n, config):
 
 
 def sanitize_locations(n):
-    n.buses["x"] = n.buses.x.where(n.buses.x != 0, n.buses.location.map(n.buses.x))
-    n.buses["y"] = n.buses.y.where(n.buses.y != 0, n.buses.location.map(n.buses.y))
-    n.buses["country"] = n.buses.country.where(
-        n.buses.country.ne("") & n.buses.country.notnull(),
-        n.buses.location.map(n.buses.country),
-    )
+    if "location" in n.buses.columns:
+        n.buses["x"] = n.buses.x.where(n.buses.x != 0, n.buses.location.map(n.buses.x))
+        n.buses["y"] = n.buses.y.where(n.buses.y != 0, n.buses.location.map(n.buses.y))
+        n.buses["country"] = n.buses.country.where(
+            n.buses.country.ne("") & n.buses.country.notnull(),
+            n.buses.location.map(n.buses.country),
+        )
 
 
 def add_co2_emissions(n, costs, carriers):


### PR DESCRIPTION
Fixes an edge case when no buses with a location are added in add_extra_components; a rather trivial little fix.

## Changes proposed in this Pull Request


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
