### PR TITLE
snakefile: move copy_default_files and process_run_config to helpers

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -4,8 +4,8 @@
 
 from pathlib import Path
 import yaml
-from os.path import normpath
-from shutil import move, rmtree
+from os.path import normpath, exists
+from shutil import copyfile, move, rmtree
 from snakemake.utils import min_version
 
 min_version("8.5")

--- a/Snakefile
+++ b/Snakefile
@@ -10,7 +10,7 @@ from snakemake.utils import min_version
 
 min_version("8.5")
 
-from scripts._helpers import path_provider, copy_default_files, process_run_config
+from scripts._helpers import path_provider, copy_default_files, get_scenarios, get_rdir
 
 
 copy_default_files(workflow)
@@ -21,7 +21,8 @@ configfile: "config/config.yaml"
 
 
 run = config["run"]
-RDIR = process_run_config(run)
+scenarios = get_scenarios(run)
+RDIR = get_rdir(run)
 
 logs = path_provider("logs/", RDIR, run["shared_resources"])
 benchmarks = path_provider("benchmarks/", RDIR, run["shared_resources"])

--- a/Snakefile
+++ b/Snakefile
@@ -2,26 +2,18 @@
 #
 # SPDX-License-Identifier: MIT
 
-from os.path import normpath, exists
-from shutil import copyfile, move, rmtree
 from pathlib import Path
 import yaml
-
+from os.path import normpath
+from shutil import move, rmtree
 from snakemake.utils import min_version
 
 min_version("8.5")
 
-from scripts._helpers import path_provider
+from scripts._helpers import path_provider, copy_default_files, process_run_config
 
-default_files = {
-    "config/config.default.yaml": "config/config.yaml",
-    "config/scenarios.template.yaml": "config/scenarios.yaml",
-}
-for template, target in default_files.items():
-    target = os.path.join(workflow.current_basedir, target)
-    template = os.path.join(workflow.current_basedir, template)
-    if not exists(target) and exists(template):
-        copyfile(template, target)
+
+copy_default_files(workflow)
 
 
 configfile: "config/config.default.yaml"
@@ -29,17 +21,7 @@ configfile: "config/config.yaml"
 
 
 run = config["run"]
-scenarios = run.get("scenarios", {})
-if run["name"] and scenarios.get("enable"):
-    fn = Path(scenarios["file"])
-    scenarios = yaml.safe_load(fn.read_text())
-    RDIR = "{run}/"
-    if run["name"] == "all":
-        config["run"]["name"] = list(scenarios.keys())
-elif run["name"]:
-    RDIR = run["name"] + "/"
-else:
-    RDIR = ""
+RDIR = process_run_config(run)
 
 logs = path_provider("logs/", RDIR, run["shared_resources"])
 benchmarks = path_provider("benchmarks/", RDIR, run["shared_resources"])

--- a/rules/solve_perfect.smk
+++ b/rules/solve_perfect.smk
@@ -110,7 +110,8 @@ rule solve_sector_network_perfect:
     output:
         network=RESULTS
         + "postnetworks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_brownfield_all_years.nc",
-        config="configs/config.elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_brownfield_all_years.yaml",
+        config=RESULTS
+        + "configs/config.elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_brownfield_all_years.yaml",
     threads: solver_threads
     resources:
         mem_mb=config_provider("solving", "mem"),

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -39,14 +39,21 @@ def copy_default_files(workflow):
             copyfile(template, target)
 
 
-def process_run_config(run):
-    scenarios = run.get("scenarios", {})
-    if run["name"] and scenarios.get("enable"):
-        fn = Path(scenarios["file"])
+def get_scenarios(run):
+    scenario_config = run.get("scenarios", {})
+    if run["name"] and scenario_config.get("enable"):
+        fn = Path(scenario_config["file"])
         scenarios = yaml.safe_load(fn.read_text())
-        RDIR = "{run}/"
         if run["name"] == "all":
             run["name"] = list(scenarios.keys())
+        return scenarios
+    return {}
+
+
+def get_rdir(run):
+    scenario_config = run.get("scenarios", {})
+    if run["name"] and scenario_config.get("enable"):
+        RDIR = "{run}/"
     elif run["name"]:
         RDIR = run["name"] + "/"
     else:


### PR DESCRIPTION
In the current master, the CI on windows fails due to some weird syntax error (probably something wrong in snakemake >= 8, but hard to track). Took the opportunity and moved some snippets from the Snakefile header into dedicated functions.  