### PR TITLE
replace value of shadow in snakemake rules

### DIFF
--- a/rules/solve_electricity.smk
+++ b/rules/solve_electricity.smk
@@ -31,7 +31,7 @@ rule solve_network:
         mem_mb=memory,
         runtime=config_provider("solving", "runtime", default="6h"),
     shadow:
-        "minimal"
+        "shallow"
     conda:
         "../envs/environment.yaml"
     script:
@@ -62,7 +62,7 @@ rule solve_operations_network:
         mem_mb=(lambda w: 10000 + 372 * int(w.clusters)),
         runtime=config_provider("solving", "runtime", default="6h"),
     shadow:
-        "minimal"
+        "shallow"
     conda:
         "../envs/environment.yaml"
     script:


### PR DESCRIPTION
On my machine, I encountered an error when solving only the electricity networks. This was because the shadow directory was set to "minimal". When I changed it to "shallow", it started working again. Since we set it to "shallow" in the other solving rules, I did the same for the solve_electricity rules.

## Changes proposed in this Pull Request


## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
