### PR TITLE
Fix typo in reading input to build_sequestration_potentials rule

### DIFF
--- a/scripts/build_sequestration_potentials.py
+++ b/scripts/build_sequestration_potentials.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
 
     cf = snakemake.params.sequestration_potential
 
-    gdf = gpd.read_file(snakemake.input.sequestration_potential[0])
+    gdf = gpd.read_file(snakemake.input.sequestration_potential)
 
     regions = gpd.read_file(snakemake.input.regions_offshore)
     if cf["include_onshore"]:


### PR DESCRIPTION
Presumably needed since the transition to snakemake 8 storage providers

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
