### PR TITLE
disable windows machines in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
         os:
         - ubuntu-latest
         - macos-latest
-        - windows-latest
+#        - windows-latest
         inhouse:
         - stable
         - master


### PR DESCRIPTION
The CI on windows machines keeps failing due to some weird syntax problem in snakefiles, which we can't solve on our end it seems.
