### PR TITLE
Fix type error in cluster_network with "m" configuration

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -164,6 +164,8 @@ Upcoming Release
 
 * Fix duplicated years in `add_land_use_constraint_m`.
 
+* Fix type error with `m` option in `cluster_network`.
+
 PyPSA-Eur 0.10.0 (19th February 2024)
 =====================================
 

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -471,7 +471,7 @@ if __name__ == "__main__":
     conventional_carriers = set(params.conventional_carriers)
     if snakemake.wildcards.clusters.endswith("m"):
         n_clusters = int(snakemake.wildcards.clusters[:-1])
-        aggregate_carriers = params.conventional_carriers & aggregate_carriers
+        aggregate_carriers = conventional_carriers & aggregate_carriers
     elif snakemake.wildcards.clusters.endswith("c"):
         n_clusters = int(snakemake.wildcards.clusters[:-1])
         aggregate_carriers = aggregate_carriers - conventional_carriers


### PR DESCRIPTION
## Changes proposed in this Pull Request

Fix type error when using "m" option. 

Raised error : 

```
    aggregate_carriers = params.conventional_carriers & aggregate_carriers
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for &: 'list' and 'set'
```

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
