### PR TITLE
Fix error with symbol of buses in simplify_network

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -164,6 +164,8 @@ Upcoming Release
 
 * Fix duplicated years in `add_land_use_constraint_m`.
 
+* Fix error with `symbol` of `buses` in `simplify_network`.
+
 PyPSA-Eur 0.10.0 (19th February 2024)
 =====================================
 

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -594,18 +594,6 @@ if __name__ == "__main__":
             )
             busmaps.append(busmap_hac)
 
-    if snakemake.wildcards.simpl:
-        n, cluster_map = cluster(
-            n,
-            int(snakemake.wildcards.simpl),
-            params.focus_weights,
-            solver_name,
-            params.simplify_network["algorithm"],
-            params.simplify_network["feature"],
-            params.aggregation_strategies,
-        )
-        busmaps.append(cluster_map)
-
     # some entries in n.buses are not updated in previous functions, therefore can be wrong. as they are not needed
     # and are lost when clustering (for example with the simpl wildcard), we remove them for consistency:
     remove = [
@@ -620,6 +608,18 @@ if __name__ == "__main__":
     ]
     n.buses.drop(remove, axis=1, inplace=True, errors="ignore")
     n.lines.drop(remove, axis=1, errors="ignore", inplace=True)
+
+    if snakemake.wildcards.simpl:
+        n, cluster_map = cluster(
+            n,
+            int(snakemake.wildcards.simpl),
+            params.focus_weights,
+            solver_name,
+            params.simplify_network["algorithm"],
+            params.simplify_network["feature"],
+            params.aggregation_strategies,
+        )
+        busmaps.append(cluster_map)
 
     update_p_nom_max(n)
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

When option `simpl` is set, an error is raised due to mismatch on `symbol` when applying `get_clustering_from_busmap`. This is due to the fact that the given busmap raise an error in `consense` aggregation function. 

It should not be an issue because `symbol` column is dropped later on in the script. This is why this PR suggest to invert the order of `cluster` function and the drop of unused columns.

Fix following raised error in `simplify_network` : 

```
AssertionError: In Bus cluster symbol, the values of attribute symbol do not agree
```

Relates with : https://groups.google.com/g/pypsa/c/HkKBySQFrK8


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
