### PR TITLE
Fixing energy totals rescale function

### DIFF
--- a/scripts/build_energy_totals.py
+++ b/scripts/build_energy_totals.py
@@ -842,7 +842,7 @@ def rescale_idees_from_eurostat(
             "total": [
                 "total agriculture heat",
                 "total agriculture machinery",
-                "total agriculture", # = sum of all other agriculture categories
+                "total agriculture",  # = sum of all other agriculture categories
             ],
             "elec": [
                 "total agriculture electricity",
@@ -850,7 +850,7 @@ def rescale_idees_from_eurostat(
         },
         "Road": {
             "total": [
-                "total road", # = sum of all other road categories
+                "total road",  # = sum of all other road categories
                 "total passenger cars",
                 "total other road passenger",
                 "total light duty road freight",
@@ -942,15 +942,30 @@ def rescale_idees_from_eurostat(
             ).values
 
     # set the total of agriculture/road to the sum of all agriculture/road categories (corresponding to the IDEES data)
-    energy.loc[country, "total agriculture"] = energy.loc[country, ["total agriculture electricity", "total agriculture heat", "total agriculture machinery"]].sum(axis=1)
+    energy.loc[country, "total agriculture"] = energy.loc[
+        country,
+        [
+            "total agriculture electricity",
+            "total agriculture heat",
+            "total agriculture machinery",
+        ],
+    ].sum(axis=1)
 
-    energy.loc[country, :]["total road"] = energy[["total passenger cars",
+    energy.loc[country, :]["total road"] = (
+        energy[
+            [
+                "total passenger cars",
                 "total other road passenger",
                 "total light duty road freight",
                 "electricity road",
                 "electricity passenger cars",
                 "electricity other road passenger",
-                "electricity light duty road freight"]].loc[country, :].sum(axis=1)
+                "electricity light duty road freight",
+            ]
+        ]
+        .loc[country, :]
+        .sum(axis=1)
+    )
 
     return energy
 

--- a/scripts/build_energy_totals.py
+++ b/scripts/build_energy_totals.py
@@ -842,7 +842,7 @@ def rescale_idees_from_eurostat(
             "total": [
                 "total agriculture heat",
                 "total agriculture machinery",
-                "total agriculture",
+                "total agriculture", # = sum of all other agriculture categories
             ],
             "elec": [
                 "total agriculture electricity",
@@ -850,7 +850,7 @@ def rescale_idees_from_eurostat(
         },
         "Road": {
             "total": [
-                "total road",
+                "total road", # = sum of all other road categories
                 "total passenger cars",
                 "total other road passenger",
                 "total light duty road freight",
@@ -891,6 +891,7 @@ def rescale_idees_from_eurostat(
     navigation = [
         "total domestic navigation",
     ]
+    # international navigation is already read in from the eurostat data directly
 
     for country in idees_countries:
         filling_years = [(2015, slice(2016, 2021)), (2000, slice(1990, 1999))]
@@ -939,6 +940,17 @@ def rescale_idees_from_eurostat(
                 nav.loc[target_years],
                 energy.loc[slicer_source, navigation].squeeze(axis=0),
             ).values
+
+    # set the total of agriculture/road to the sum of all agriculture/road categories (corresponding to the IDEES data)
+    energy.loc[country, "total agriculture"] = energy.loc[country, ["total agriculture electricity", "total agriculture heat", "total agriculture machinery"]].sum(axis=1)
+
+    energy.loc[country, :]["total road"] = energy[["total passenger cars",
+                "total other road passenger",
+                "total light duty road freight",
+                "electricity road",
+                "electricity passenger cars",
+                "electricity other road passenger",
+                "electricity light duty road freight"]].loc[country, :].sum(axis=1)
 
     return energy
 

--- a/scripts/build_energy_totals.py
+++ b/scripts/build_energy_totals.py
@@ -951,7 +951,7 @@ def rescale_idees_from_eurostat(
         ],
     ].sum(axis=1)
 
-    energy.loc[country, :]["total road"] = (
+    energy.loc[country, "total road"] = (
         energy[
             [
                 "total passenger cars",


### PR DESCRIPTION
## Changes proposed in this Pull Request
Closes https://github.com/PyPSA/pypsa-eur/issues/985.
Bug fix in the function `rescale_idees_from_eurostat()`: 
So far, the sum of agriculture and transport did not add up to `total agriculture` and `total transport` since there are two different rescaling factors for `electricity` and `total`.

@lindnemi: the sectors `residential` and `services` is not adding up since it's taking data from JRC IDEES from multiple sheets.

Minor changes so no change in the environment, configuration and release notes.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
