### PR TITLE
Fix grouping year reference in add_land_use_constraint_m

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -162,7 +162,7 @@ Upcoming Release
 
 * Adapt the disabling of transmission expansion in myopic foresight optimisations when limit is already reached to also handle cost limits.
 
-* Fix duplicated years in `add_land_use_constraint_m`.
+* Fix duplicated years and grouping years reference in `add_land_use_constraint_m`.
 
 PyPSA-Eur 0.10.0 (19th February 2024)
 =====================================

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -155,7 +155,7 @@ def _add_land_use_constraint(n):
 def _add_land_use_constraint_m(n, planning_horizons, config):
     # if generators clustering is lower than network clustering, land_use accounting is at generators clusters
 
-    grouping_years = config["existing_capacities"]["grouping_years"]
+    grouping_years = config["existing_capacities"]["grouping_years_power"]
     current_horizon = snakemake.wildcards.planning_horizons
 
     for carrier in ["solar", "onwind", "offwind-ac", "offwind-dc"]:


### PR DESCRIPTION
Fix grouping year reference from `grouping_years` to `grouping_years_power` in `add_land_use_constraint_m`.


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
