### PR TITLE
Fix index for existing capacities in add_existing_baseyear

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -164,6 +164,8 @@ Upcoming Release
 
 * Fix duplicated years in `add_land_use_constraint_m`.
 
+* Fix index of existing capacities in `add_power_capacities_installed_before_baseyear` with `m` option.
+
 PyPSA-Eur 0.10.0 (19th February 2024)
 =====================================
 

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -257,13 +257,14 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
 
                     # for offshore the splitting only includes coastal regions
                     inv_ind = [
-                        i for i in inv_ind if (i + name_suffix) in n.generators.index
+                        i for i in inv_ind if (i + name_suffix) in n.generators.index.str
+                        .replace(str(baseyear), str(grouping_year))
                     ]
 
                     p_max_pu = n.generators_t.p_max_pu[
                         [i + name_suffix for i in inv_ind]
                     ]
-                    p_max_pu.columns = [i + name_suffix for i in inv_ind]
+                    p_max_pu.columns = [i + name_suffix.replace(str(grouping_year), str(baseyear)) for i in inv_ind]
 
                     n.madd(
                         "Generator",


### PR DESCRIPTION
When `m` option is enabled in `add_power_capacities_installed_before_baseyear`, the referenced index use `baseyear` in place of current year of installation (`grouping_year`). This leads to empty `inv_ind` and issue in the rest of the code.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
