### PR TITLE
Check if scenario file exists before attempting to load

### DIFF
--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -43,10 +43,11 @@ def get_scenarios(run):
     scenario_config = run.get("scenarios", {})
     if run["name"] and scenario_config.get("enable"):
         fn = Path(scenario_config["file"])
-        scenarios = yaml.safe_load(fn.read_text())
-        if run["name"] == "all":
-            run["name"] = list(scenarios.keys())
-        return scenarios
+        if fn.exists():
+            scenarios = yaml.safe_load(fn.read_text())
+            if run["name"] == "all":
+                run["name"] = list(scenarios.keys())
+            return scenarios
     return {}
 
 


### PR DESCRIPTION
A very simple quality of life improvement. Useful when running the `create_scenarios` rule the first time.

When wishing to generate a new scenarios files (say, "scenarios2.yaml"), one could change the corresponding config option (`run/scenarios/file`) and run the `create_scenarios` rule. However, if say "scenarios2.yaml" doesn't exist yet, the `get_scenarios` function fails. An awkward solution is to first create "scenarios2.yaml" manually (and put in some mock scenarios, otherwise `scenarios.keys()` fails!), and then run `create_scenarios`. With this check, that's not necessary anymore.


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
