### PR TITLE
provide Path object as input to ConfigSettings

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,8 @@ Release Notes
 Upcoming Release
 ================
 
+* bugfix: convert Strings to pathlib.Path objects as input to ConfigSettings
+
 * Allow the use of more solvers in clustering (Xpress, COPT, Gurobi, CPLEX, SCIP, MOSEK).
 
 * Enhanced support for choosing different weather years

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -427,7 +427,7 @@ def mock_snakemake(
             configfiles = [configfiles]
 
         resource_settings = ResourceSettings()
-        config_settings = ConfigSettings(configfiles=configfiles)
+        config_settings = ConfigSettings(configfiles=map(Path, configfiles))
         workflow_settings = WorkflowSettings()
         storage_settings = StorageSettings()
         dag_settings = DAGSettings(rerun_triggers=[])


### PR DESCRIPTION
snakemake.ConfigSettings expects a sequence  of pathlib.Path, but right now gets a list of strings, leading to a cryptic error. This PR fixes this

![image](https://github.com/PyPSA/pypsa-eur/assets/56298440/3e9b2e02-62ca-4566-bd0b-d4440313e091)



## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
