### PR TITLE
Fix fill missing in industry sector ratios intermediate

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -174,6 +174,8 @@ Upcoming Release
 
 * Fix index of existing capacities in `add_power_capacities_installed_before_baseyear` with `m` option.
 
+* Fix fill missing data in `build_industry_sector_ratios_intermediate`.
+
 PyPSA-Eur 0.10.0 (19th February 2024)
 =====================================
 

--- a/scripts/build_industry_sector_ratios_intermediate.py
+++ b/scripts/build_industry_sector_ratios_intermediate.py
@@ -54,8 +54,10 @@ def build_industry_sector_ratios_intermediate():
         today_sector_ratios_ct = (
             group.droplevel(0)
             .T.reindex_like(future_sector_ratios)
-            .fillna(future_sector_ratios)
         )
+        missing_mask = (today_sector_ratios_ct.isna().all())
+        today_sector_ratios_ct.loc[:, missing_mask] = future_sector_ratios.loc[:, missing_mask]
+        today_sector_ratios_ct.loc[:, ~missing_mask] = today_sector_ratios_ct.loc[:, ~missing_mask].fillna(0)
         intermediate_sector_ratios[ct] = (
             today_sector_ratios_ct * (1 - fraction_future)
             + future_sector_ratios * fraction_future


### PR DESCRIPTION
## Changes proposed in this Pull Request

I found a strange behaviour of `build_industry_sector_ratios_intermediate`. When looking to intermediate steps between current and futur industry, missing values were wrongly filled with futur data. 

I suggest to use futur data only when we miss the full description of the technology (carrier whise). 

Here is an example of Ammonia in Belgium where we see a mix of current and futur data.

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator: ;}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
-->
</head>

Ammonia / BE | new | new | new | old | old | old
-- | -- | -- | -- | -- | -- | --
MWh/tMaterial | 2020 | 2030 | 2050 | 2020 | 2030 | 2050
elec | 0.2473 | 0.17311 | 0 | 0.2473 | 0.17311 | 0
coal | 0 | 0 | 0 | 0 | 0 | 0
coke | 0 | 0 | 0 | 0 | 0 | 0
biomass | 0 | 0 | 0 | 0 | 0 | 0
methane | 0 | 0 | 0 | 0 | 0 | 0
hydrogen | 5.93 | 4.151 | 0 | 5.93 | 4.151 | 0
heat | 0 | 0 | 0 | 0 | 0 | 0
naphtha | 0 | 0 | 0 | 0 | 0 | 0
ammonia | 0 | 1.5498 | 5.166 | 5.166 | 5.166 | 5.166
process emission | 0 | 0 | 0 | 0 | 0 | 0
process emission from feedstock | 0 | 0 | 0 | 0 | 0 | 0

</body>

</html>

I used to following values for `sector_ratios_fraction_future`:
```yaml
  sector_ratios_fraction_future:
    2020: 0.0
    2025: 0.1
    2030: 0.3
    2035: 0.5
    2040: 0.7
    2045: 0.9
    2050: 1.0
```

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
