### PR TITLE
Fix custom busmap read in cluster network

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -174,6 +174,8 @@ Upcoming Release
 
 * Fix index of existing capacities in `add_power_capacities_installed_before_baseyear` with `m` option.
 
+* Fix custom busmap read in `cluster_network`.
+
 PyPSA-Eur 0.10.0 (19th February 2024)
 =====================================
 

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -519,8 +519,8 @@ if __name__ == "__main__":
         custom_busmap = params.custom_busmap
         if custom_busmap:
             custom_busmap = pd.read_csv(
-                snakemake.input.custom_busmap, index_col=0, squeeze=True
-            )
+                snakemake.input.custom_busmap, index_col=0
+            ).squeeze()
             custom_busmap.index = custom_busmap.index.astype(str)
             logger.info(f"Imported custom busmap from {snakemake.input.custom_busmap}")
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

In pandas 2.2.1, `squeeze` option is not more available for `read_csv`.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
