### PR TITLE
Correct co2 potentials

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -515,7 +515,7 @@ sector:
   regional_coal_demand: false
   regional_co2_sequestration_potential:
     enable: false
-    attribute: 'conservative estimate Mt'
+    attribute: ['conservative estimate Mt', 'conservative estimate GAS Mt', 'conservative estimate OIL Mt', 'conservative estimate aquifer Mt']
     include_onshore: false
     min_size: 3
     max_size: 25

--- a/scripts/build_sequestration_potentials.py
+++ b/scripts/build_sequestration_potentials.py
@@ -23,13 +23,13 @@ def area(gdf):
 def allocate_sequestration_potential(
     gdf, regions, attr="conservative estimate Mt", threshold=3
 ):
-    gdf = gdf.loc[gdf[attr] > threshold, [attr, "geometry"]]
+    gdf = gdf.loc[gdf[attr].sum(axis=1) > threshold, attr + ["geometry"]]
     gdf["area_sqkm"] = area(gdf)
     overlay = gpd.overlay(regions, gdf, keep_geom_type=True)
     overlay["share"] = area(overlay) / overlay["area_sqkm"]
     adjust_cols = overlay.columns.difference({"name", "area_sqkm", "geometry", "share"})
     overlay[adjust_cols] = overlay[adjust_cols].multiply(overlay["share"], axis=0)
-    return overlay.dissolve("name", aggfunc="sum")[attr]
+    return overlay.dissolve("name", aggfunc="sum")[attr].sum(axis=1)
 
 
 if __name__ == "__main__":
@@ -37,7 +37,7 @@ if __name__ == "__main__":
         from _helpers import mock_snakemake
 
         snakemake = mock_snakemake(
-            "build_sequestration_potentials", simpl="", clusters="181"
+            "build_sequestration_potentials", simpl="", clusters="128"
         )
 
     set_scenario_config(snakemake)


### PR DESCRIPTION
Closes # (if applicable).
#816 
## Changes proposed in this Pull Request
We use the CO2 sequestration potentials from the CO2 stop project of the European Commission

We should consider not only the column "conservative estimate Mt" done here since this is only storage potential for geological reservoirs suitable for CO2 storage not including hydrocarbon fields (gas + oil) or saline aquifers which are separately listed and in the dataset are called "daughter units" in ['conservative estimate GAS Mt', 'conservative estimate OIL Mt', 'conservative estimate aquifer Mt'].

An even more conservative assumption would be to include only storage resources with high density potentials which are the named three hydrocarbon fields (gas + oil) or saline aquifers and exclude the "conservative estimate Mt" which contains the largest part of the CO2 storage potential (78%)

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
