### PR TITLE
Increase default costs for gas storage and allam cycle

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -181,6 +181,8 @@ Upcoming Release
 
 * Fix custom busmap read in `cluster_network`.
 
+* Increase default capital cost for gas storage and default marginal cost for allam cycle in `prepare_sector_network`.
+
 PyPSA-Eur 0.10.0 (19th February 2024)
 =====================================
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -520,7 +520,8 @@ def add_carrier_buses(n, carrier, nodes=None):
 
     unit = "MWh_LHV" if carrier == "gas" else "MWh_th"
     # preliminary value for non-gas carriers to avoid zeros
-    capital_cost = costs.at["gas storage", "fixed"] if carrier == "gas" else 0.02
+    capital_cost = costs.at["gas storage", "fixed"] if carrier == "gas"\
+        else 200 * costs.at[carrier, "discount rate"]
 
     n.madd("Bus", nodes, location=location, carrier=carrier, unit=unit)
 
@@ -747,7 +748,7 @@ def add_allam(n, costs):
         p_nom_extendable=True,
         # TODO: add costs to technology-data
         capital_cost=0.6 * 1.5e6 * 0.1,  # efficiency * EUR/MW * annuity
-        marginal_cost=2,
+        marginal_cost=costs.at["gas", "fuel"]/0.6,  # Fuel cost of gas * efficiency (MWth to MWe)
         efficiency=0.6,
         efficiency2=costs.at["gas", "CO2 intensity"],
         lifetime=30.0,


### PR DESCRIPTION
## Changes proposed in this Pull Request

Increase the default capital cost for gas storage and the default marginal cost for allam cycle in `prepare_sector_network`.

For gas storage, the low capital cost of gas storage  leads to a huge amount of stores. To avoid this, an increase is proposed.

For allam cycle, low marginal cost is extremely in favour of allam cycle. To avoid undesirable behaviour, the use of the gas value is suggested.


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
