### PR TITLE
Fix small issues in add_land_use_constraint_m

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -181,6 +181,8 @@ Upcoming Release
 
 * Fix custom busmap read in `cluster_network`.
 
+* Fix p_nom_min of renewables generators for myopic approach and add check of existing capacities in `add_land_use_constraint_m`.
+
 PyPSA-Eur 0.10.0 (19th February 2024)
 =====================================
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Fix p_nom_min of renewables generators for myopic approach and add check of existing capacities in `add_land_use_constraint_m`. This reproduce the behaviour in `add_land_use_constraint`.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
