### PR TITLE
Update to BAU constraint formulation in function add_BAU_constraints

### DIFF
--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -543,7 +543,7 @@ def add_BAU_constraints(n, config):
     ext_carrier_i = xr.DataArray(ext_i.carrier.rename_axis("Generator-ext"))
     lhs = p_nom.groupby(ext_carrier_i).sum()
     index = mincaps.index.intersection(lhs.indexes["carrier"])
-    rhs = mincaps[index].rename_axis("carrier")
+    rhs = mincaps[lhs.indexes["carrier"]].rename_axis("carrier")
     n.model.add_constraints(lhs >= rhs, name="bau_mincaps")
 
 


### PR DESCRIPTION
Incorrect constraint formulation

The lhs and rhs of the constraints have carriers specified in different orders. The constraint formulation was being done without reordering the carriers. This lead to incorrect constraint formulations where the limits specified for one carrier were used for another.

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
