### PR TITLE
Remove connection costs output

### DIFF
--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -487,7 +487,6 @@ rule simplify_network:
         regions_onshore=resources("regions_onshore_elec_s{simpl}.geojson"),
         regions_offshore=resources("regions_offshore_elec_s{simpl}.geojson"),
         busmap=resources("busmap_elec_s{simpl}.csv"),
-        connection_costs=resources("connection_costs_s{simpl}.csv"),
     log:
         logs("simplify_network/elec_s{simpl}.log"),
     benchmark:

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -311,6 +311,8 @@ if __name__ == "__main__":
         logger.info("Supplement missing data with synthetic data.")
         fn = snakemake.input.synthetic
         synthetic_load = pd.read_csv(fn, index_col=0, parse_dates=True)
+        # "UA" does not appear in synthetic load data
+        countries = list(set(countries) - set(["UA"]))
         synthetic_load = synthetic_load.loc[snapshots, countries]
         load = load.combine_first(synthetic_load)
 

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -207,7 +207,7 @@ def _compute_connection_costs_to_bus(
     return connection_costs_to_bus
 
 
-def _adjust_capital_costs_using_connection_costs(n, connection_costs_to_bus, output):
+def _adjust_capital_costs_using_connection_costs(n, connection_costs_to_bus):
     connection_costs = {}
     for tech in connection_costs_to_bus:
         tech_b = n.generators.carrier == tech
@@ -228,14 +228,12 @@ def _adjust_capital_costs_using_connection_costs(n, connection_costs_to_bus, out
                 )
             )
             connection_costs[tech] = costs
-    pd.DataFrame(connection_costs).to_csv(output.connection_costs)
 
 
 def _aggregate_and_move_components(
     n,
     busmap,
     connection_costs_to_bus,
-    output,
     aggregate_one_ports={"Load", "StorageUnit"},
     aggregation_strategies=dict(),
     exclude_carriers=None,
@@ -248,7 +246,7 @@ def _aggregate_and_move_components(
             if not df.empty:
                 import_series_from_dataframe(n, df, c, attr)
 
-    _adjust_capital_costs_using_connection_costs(n, connection_costs_to_bus, output)
+    _adjust_capital_costs_using_connection_costs(n, connection_costs_to_bus)
 
     generator_strategies = aggregation_strategies["generators"]
 
@@ -281,7 +279,6 @@ def simplify_links(
     length_factor,
     p_max_pu,
     exclude_carriers,
-    output,
     aggregation_strategies=dict(),
 ):
     ## Complex multi-node links are folded into end-points
@@ -406,7 +403,6 @@ def simplify_links(
         n,
         busmap,
         connection_costs_to_bus,
-        output,
         aggregation_strategies=aggregation_strategies,
         exclude_carriers=exclude_carriers,
     )
@@ -419,7 +415,6 @@ def remove_stubs(
     renewable_carriers,
     length_factor,
     simplify_network,
-    output,
     aggregation_strategies=dict(),
 ):
     logger.info("Removing stubs")
@@ -436,7 +431,6 @@ def remove_stubs(
         n,
         busmap,
         connection_costs_to_bus,
-        output,
         aggregation_strategies=aggregation_strategies,
         exclude_carriers=simplify_network["exclude_carriers"],
     )
@@ -556,7 +550,6 @@ if __name__ == "__main__":
         params.length_factor,
         params.p_max_pu,
         params.simplify_network["exclude_carriers"],
-        snakemake.output,
         params.aggregation_strategies,
     )
 
@@ -569,7 +562,6 @@ if __name__ == "__main__":
             params.renewable_carriers,
             params.length_factor,
             params.simplify_network,
-            snakemake.output,
             aggregation_strategies=params.aggregation_strategies,
         )
         busmaps.append(stub_map)


### PR DESCRIPTION
## Changes proposed in this Pull Request

Suggest to remove the snakemake output for connection costs, because it creates bugs if a selection of `countries` is taken that does not contain links, and `remove_stubs` is set to `false`.

Also, `UA` is not part of the synthetic load data, so removing `UA` there. I noticed the `connection_costs` bug when running `UA` only which is why I'm combining those two bugfixes here.

workflow tested also with config.default (all countries) for power and all other sectors.

I'm not aware of any need of the output in other rules.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
