### PR TITLE
set OCGT capacities from generators to links

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -584,7 +584,7 @@ sector:
   biogas_upgrading_cc: false
   conventional_generation:
     OCGT: gas
-  keep_OCGT: False
+  keep_OCGT: false
   biomass_to_liquid: false
   biosng: false
   limit_max_growth:

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -584,6 +584,7 @@ sector:
   biogas_upgrading_cc: false
   conventional_generation:
     OCGT: gas
+  keep_OCGT: False
   biomass_to_liquid: false
   biosng: false
   limit_max_growth:

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -434,7 +434,7 @@ rule add_electricity:
             else resources("networks/base.nc")
         ),
         tech_costs=lambda w: resources(
-            f"costs_{config_provider('costs', 'year')(w)}.csv"
+            f"costs_{config_provider('costs', 'year') (w)}.csv"
         ),
         regions=resources("regions_onshore.geojson"),
         powerplants=resources("powerplants.csv"),
@@ -479,7 +479,7 @@ rule simplify_network:
     input:
         network=resources("networks/elec.nc"),
         tech_costs=lambda w: resources(
-            f"costs_{config_provider('costs', 'year')(w)}.csv"
+            f"costs_{config_provider('costs', 'year') (w)}.csv"
         ),
         regions_onshore=resources("regions_onshore.geojson"),
         regions_offshore=resources("regions_offshore.geojson"),
@@ -528,7 +528,7 @@ rule cluster_network:
             else []
         ),
         tech_costs=lambda w: resources(
-            f"costs_{config_provider('costs', 'year')(w)}.csv"
+            f"costs_{config_provider('costs', 'year') (w)}.csv"
         ),
     output:
         network=resources("networks/elec_s{simpl}_{clusters}.nc"),
@@ -557,7 +557,7 @@ rule add_extra_components:
     input:
         network=resources("networks/elec_s{simpl}_{clusters}.nc"),
         tech_costs=lambda w: resources(
-            f"costs_{config_provider('costs', 'year')(w)}.csv"
+            f"costs_{config_provider('costs', 'year') (w)}.csv"
         ),
     output:
         resources("networks/elec_s{simpl}_{clusters}_ec.nc"),
@@ -592,7 +592,7 @@ rule prepare_network:
     input:
         resources("networks/elec_s{simpl}_{clusters}_ec.nc"),
         tech_costs=lambda w: resources(
-            f"costs_{config_provider('costs', 'year')(w)}.csv"
+            f"costs_{config_provider('costs', 'year') (w)}.csv"
         ),
         co2_price=lambda w: resources("co2_price.csv") if "Ept" in w.opts else [],
     output:

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3690,7 +3690,8 @@ def lossy_bidirectional_links(n, carrier, efficiencies={}):
 
 def get_capacities_from_elec(n, carrier, component):
     """
-    Gets capacities for {carrier} in n.{component} that were previously assigned in add_electricity
+    Gets capacities for {carrier} in n.{component} that were previously
+    assigned in add_electricity.
     """
     component_list = ["generators", "storage_units", "links", "stores"]
     component_dict = {name: getattr(n, name) for name in component_list}

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3711,20 +3711,24 @@ def lossy_bidirectional_links(n, carrier, efficiencies={}):
 
 
 def get_nominal_capacities(n, carrier, component):
-    """Gets capacities for {carrier} in n.{component} """
+    """
+    Gets capacities for {carrier} in n.{component}
+    """
     component_list = ["generators", "storage_units", "links", "stores"]
     component_dict = {name: getattr(n, name) for name in component_list}
     e_nom_carriers = ["stores"]
     nom_col = {x: "e_nom" if x in e_nom_carriers else "p_nom" for x in component_list}
-    
-    capacity = component_dict[component].query("carrier in @carrier")[nom_col[component]]
+
+    capacity = component_dict[component].query("carrier in @carrier")[
+        nom_col[component]
+    ]
     return capacity
 
 
 def set_capacities(n, data, carrier, component, nom_types=["nom"]):
-    """Sets capacities for {carrier} in n.{component} 
-            nom_type - specifies which nominal is set (i.e. p_nom, p_nom_min). 
-                       options = {"nom", "nom_min", "nom_max"}
+    """Sets capacities for {carrier} in n.{component}
+    nom_type - specifies which nominal is set (i.e. p_nom, p_nom_min).
+               options = {"nom", "nom_min", "nom_max"}
     """
     component_list = ["generators", "storage_units", "links", "stores"]
     component_dict = {name: getattr(n, name) for name in component_list}
@@ -3733,11 +3737,14 @@ def set_capacities(n, data, carrier, component, nom_types=["nom"]):
     mask = component_dict[component].query("carrier in @carrier").index
 
     for nom_type in nom_types:
-        nom_col = {x: f"e_{nom_type}" if x in e_nom_carriers else f"p_{nom_type}" for x in component_list}
+        nom_col = {
+            x: f"e_{nom_type}" if x in e_nom_carriers else f"p_{nom_type}"
+            for x in component_list
+        }
         component_dict[component].loc[mask, nom_col[component]] = data
-        
+
         logger.info(f"Set {nom_col[component]} for {carrier} in {component}")
-    
+
     return n
 
 
@@ -3803,7 +3810,13 @@ if __name__ == "__main__":
 
     add_generation(n, costs)
 
-    set_capacities(n, data=capacities_OCGT, carrier="OCGT", component="links", nom_types=["nom", "nom_min"])
+    set_capacities(
+        n,
+        data=capacities_OCGT,
+        carrier="OCGT",
+        component="links",
+        nom_types=["nom", "nom_min"],
+    )
 
     add_storage_and_grids(n, costs)
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -871,10 +871,14 @@ def add_generation(n, costs, capacities_OCGT=0, efficiencies_OCGT=None):
             capital_cost=costs.at[generator, "efficiency"]
             * costs.at[generator, "fixed"],  # NB: fixed cost is per MWel
             p_nom_extendable=True,
-            p_nom = capacities_OCGT if carrier == "gas" else 0,
-            p_nom_min = capacities_OCGT if carrier == "gas" else 0,
+            p_nom=capacities_OCGT if carrier == "gas" else 0,
+            p_nom_min=capacities_OCGT if carrier == "gas" else 0,
             carrier=generator,
-            efficiency=efficiencies_OCGT if (carrier =="gas" and efficiencies_OCGT is not None) else costs.at[generator, "efficiency"],
+            efficiency=(
+                efficiencies_OCGT
+                if (carrier == "gas" and efficiencies_OCGT is not None)
+                else costs.at[generator, "efficiency"]
+            ),
             efficiency2=costs.at[carrier, "CO2 intensity"],
             lifetime=costs.at[generator, "lifetime"],
         )
@@ -3737,10 +3741,7 @@ if __name__ == "__main__":
         nyears,
     )
     costs = costs.rename(
-        columns={
-            "capital_cost": "fixed",
-            "co2_emissions": "CO2 intensity"
-        }
+        columns={"capital_cost": "fixed", "co2_emissions": "CO2 intensity"}
     )
 
     pop_weighted_energy_totals = (
@@ -3751,7 +3752,9 @@ if __name__ == "__main__":
     )
     pop_weighted_energy_totals.update(pop_weighted_heat_totals)
 
-    capacities_OCGT, efficiencies_OCGT = get_capacities(n, carrier="OCGT", component="generators")
+    capacities_OCGT, efficiencies_OCGT = get_capacities(
+        n, carrier="OCGT", component="generators"
+    )
 
     patch_electricity_network(n)
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3753,9 +3753,12 @@ if __name__ == "__main__":
     )
     pop_weighted_energy_totals.update(pop_weighted_heat_totals)
 
-    capacities_OCGT, efficiencies_OCGT = get_capacities(
-        n, carrier="OCGT", component="generators"
-    )
+    if options.get("keep_OCGT", False):
+        capacities_OCGT, efficiencies_OCGT = get_capacities_from_elec(
+            n, carrier="OCGT", component="generators"
+        )
+    else:
+        capacities_OCGT, efficiencies_OCGT = 0, None
 
     patch_electricity_network(n)
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3688,9 +3688,9 @@ def lossy_bidirectional_links(n, carrier, efficiencies={}):
         )
 
 
-def get_capacities(n, carrier, component):
+def get_capacities_from_elec(n, carrier, component):
     """
-    Gets capacities for {carrier} in n.{component}
+    Gets capacities for {carrier} in n.{component} that were previously assigned in add_electricity
     """
     component_list = ["generators", "storage_units", "links", "stores"]
     component_dict = {name: getattr(n, name) for name in component_list}


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. Here I propose to set `p_nom` and `p_nom_min` for OCGT in n.links from `p_nom` n.generators (before OCGT is removed using `remove_elec_base_techs` in `prepare_sector_networks`. 

Currently `p_nom` of n.links for OCGT is 0 after `prepare_sector_network`. I helps to set capacities back, when OCGT is moved from generators to links.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
