### PR TITLE
Fix gas network retrofit in brownfield

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -181,6 +181,8 @@ Upcoming Release
 
 * Fix custom busmap read in `cluster_network`.
 
+* Fix gas network retrofitting in `add_brownfield`.
+
 PyPSA-Eur 0.10.0 (19th February 2024)
 =====================================
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

When adding the brownfield for the gas network, the index mismatch leads to 0 capacity of already retrofitted gas pipelines. This results in a remaining capacity that remains constant, while pipelines are being retrofitted. To avoid multiple calculation of the gas network, I also remove the code from the loop.


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
