### PR TITLE
Add coal generators

### DIFF
--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -434,7 +434,7 @@ rule add_electricity:
             else resources("networks/base.nc")
         ),
         tech_costs=lambda w: resources(
-            f"costs_{config_provider('costs', 'year')(w)}.csv"
+            f"costs_{config_provider('costs', 'year') (w)}.csv"
         ),
         regions=resources("regions_onshore.geojson"),
         powerplants=resources("powerplants.csv"),
@@ -479,7 +479,7 @@ rule simplify_network:
     input:
         network=resources("networks/elec.nc"),
         tech_costs=lambda w: resources(
-            f"costs_{config_provider('costs', 'year')(w)}.csv"
+            f"costs_{config_provider('costs', 'year') (w)}.csv"
         ),
         regions_onshore=resources("regions_onshore.geojson"),
         regions_offshore=resources("regions_offshore.geojson"),
@@ -528,7 +528,7 @@ rule cluster_network:
             else []
         ),
         tech_costs=lambda w: resources(
-            f"costs_{config_provider('costs', 'year')(w)}.csv"
+            f"costs_{config_provider('costs', 'year') (w)}.csv"
         ),
     output:
         network=resources("networks/elec_s{simpl}_{clusters}.nc"),
@@ -557,7 +557,7 @@ rule add_extra_components:
     input:
         network=resources("networks/elec_s{simpl}_{clusters}.nc"),
         tech_costs=lambda w: resources(
-            f"costs_{config_provider('costs', 'year')(w)}.csv"
+            f"costs_{config_provider('costs', 'year') (w)}.csv"
         ),
     output:
         resources("networks/elec_s{simpl}_{clusters}_ec.nc"),
@@ -592,7 +592,7 @@ rule prepare_network:
     input:
         resources("networks/elec_s{simpl}_{clusters}_ec.nc"),
         tech_costs=lambda w: resources(
-            f"costs_{config_provider('costs', 'year')(w)}.csv"
+            f"costs_{config_provider('costs', 'year') (w)}.csv"
         ),
         co2_price=lambda w: resources("co2_price.csv") if "Ept" in w.opts else [],
     output:

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3689,12 +3689,12 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake(
             "prepare_sector_network",
-            configfiles="../../configs/EEE_study/config.rigid-industry_2030.yaml",
+            configfiles="test/config.overnight.yaml",
             simpl="",
             opts="",
-            clusters="48",
-            ll="v1.15",
-            sector_opts="CO2L0.45-100H-T-H-B-I",
+            clusters="37",
+            ll="v1.0",
+            sector_opts="CO2L0-24H-T-H-B-I-A-dist1",
             planning_horizons="2030",
         )
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -511,13 +511,16 @@ def add_carrier_buses(n, carrier, nodes=None):
     location = vars(spatial)[carrier].locations
 
     # skip if carrier already exists (continue with coal because it can be already added by in generators)
-    if carrier in n.carriers.index and not carrier in snakemake.config['pypsa_eur']['Generator']:
+    if (
+        carrier in n.carriers.index
+        and not carrier in snakemake.config["pypsa_eur"]["Generator"]
+    ):
         return
 
     if not isinstance(nodes, pd.Index):
         nodes = pd.Index(nodes)
 
-    if not carrier in snakemake.config['pypsa_eur']['Generator']:
+    if not carrier in snakemake.config["pypsa_eur"]["Generator"]:
         n.add("Carrier", carrier)
 
     unit = "MWh_LHV" if carrier == "gas" else "MWh_th"

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -511,13 +511,13 @@ def add_carrier_buses(n, carrier, nodes=None):
     location = vars(spatial)[carrier].locations
 
     # skip if carrier already exists (continue with coal because it can be already added by in generators)
-    if carrier in n.carriers.index and not carrier == "coal":
+    if carrier in n.carriers.index and not carrier in snakemake.config['pypsa_eur']['Generator']:
         return
 
     if not isinstance(nodes, pd.Index):
         nodes = pd.Index(nodes)
 
-    if not carrier == "coal":
+    if not carrier in snakemake.config['pypsa_eur']['Generator']:
         n.add("Carrier", carrier)
 
     unit = "MWh_LHV" if carrier == "gas" else "MWh_th"

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -511,13 +511,14 @@ def add_carrier_buses(n, carrier, nodes=None):
     location = vars(spatial)[carrier].locations
 
     # skip if carrier already exists
-    if carrier in n.carriers.index:
+    if carrier in n.carriers.index and not carrier == 'coal':
         return
 
     if not isinstance(nodes, pd.Index):
         nodes = pd.Index(nodes)
 
-    n.add("Carrier", carrier)
+    if not carrier == 'coal':
+        n.add("Carrier", carrier)
 
     unit = "MWh_LHV" if carrier == "gas" else "MWh_th"
     # preliminary value for non-gas carriers to avoid zeros
@@ -534,10 +535,6 @@ def add_carrier_buses(n, carrier, nodes=None):
         carrier=carrier,
         capital_cost=capital_cost,
     )
-
-    # omit gas generators
-    if carrier == "gas":
-        return
 
     n.madd(
         "Generator",
@@ -3716,12 +3713,12 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake(
             "prepare_sector_network",
-            configfiles="test/config.overnight.yaml",
+            configfiles="../../configs/EEE_study/config.rigid-industry_2030.yaml",
             simpl="",
             opts="",
-            clusters="37",
-            ll="v1.0",
-            sector_opts="CO2L0-24H-T-H-B-I-A-dist1",
+            clusters="48",
+            ll="v1.15",
+            sector_opts="CO2L0.45-100H-T-H-B-I",
             planning_horizons="2030",
         )
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -511,13 +511,13 @@ def add_carrier_buses(n, carrier, nodes=None):
     location = vars(spatial)[carrier].locations
 
     # skip if carrier already exists (continue with coal because it can be already added by in generators)
-    if carrier in n.carriers.index and not carrier == 'coal':
+    if carrier in n.carriers.index and not carrier == "coal":
         return
 
     if not isinstance(nodes, pd.Index):
         nodes = pd.Index(nodes)
 
-    if not carrier == 'coal':
+    if not carrier == "coal":
         n.add("Carrier", carrier)
 
     unit = "MWh_LHV" if carrier == "gas" else "MWh_th"
@@ -3719,10 +3719,7 @@ if __name__ == "__main__":
         nyears,
     )
     costs = costs.rename(
-        columns={
-            "capital_cost": "fixed",
-            "co2_emissions": "CO2 intensity"
-        }
+        columns={"capital_cost": "fixed", "co2_emissions": "CO2 intensity"}
     )
 
     pop_weighted_energy_totals = (

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -510,7 +510,7 @@ def add_carrier_buses(n, carrier, nodes=None):
         nodes = vars(spatial)[carrier].nodes
     location = vars(spatial)[carrier].locations
 
-    # skip if carrier already exists
+    # skip if carrier already exists (continue with coal because it can be already added by in generators)
     if carrier in n.carriers.index and not carrier == 'coal':
         return
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day.Here I propose to update the `prepare_sector_networks.py` script to facilitate addition of coal-based electricity generators attached to AC buses when coal and lignite is added to configs as follows:
![image](https://github.com/PyPSA/pypsa-eur/assets/113768325/2e1450f4-c553-4189-a52e-fddd99f1f937)

`EU coal` is considered to supply `coal for industry` as previous. Therefore we make sure that `EU coal` is created even though `coal` carrier is already there (from eariler created coal generators). Also carrier for coal is not redefined again, because it is already there. This code works both when adding `coal` and `lignite` to config and without them being added.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
