### PR TITLE
Fix double space in existing capacities

### DIFF
--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -433,7 +433,7 @@ rule add_electricity:
             else resources("networks/base.nc")
         ),
         tech_costs=lambda w: resources(
-            f"costs_{config_provider('costs', 'year')(w)}.csv"
+            f"costs_{config_provider('costs', 'year') (w)}.csv"
         ),
         regions=resources("regions_onshore.geojson"),
         powerplants=resources("powerplants.csv"),
@@ -478,7 +478,7 @@ rule simplify_network:
     input:
         network=resources("networks/elec.nc"),
         tech_costs=lambda w: resources(
-            f"costs_{config_provider('costs', 'year')(w)}.csv"
+            f"costs_{config_provider('costs', 'year') (w)}.csv"
         ),
         regions_onshore=resources("regions_onshore.geojson"),
         regions_offshore=resources("regions_offshore.geojson"),
@@ -526,7 +526,7 @@ rule cluster_network:
             else []
         ),
         tech_costs=lambda w: resources(
-            f"costs_{config_provider('costs', 'year')(w)}.csv"
+            f"costs_{config_provider('costs', 'year') (w)}.csv"
         ),
     output:
         network=resources("networks/elec_s{simpl}_{clusters}.nc"),
@@ -555,7 +555,7 @@ rule add_extra_components:
     input:
         network=resources("networks/elec_s{simpl}_{clusters}.nc"),
         tech_costs=lambda w: resources(
-            f"costs_{config_provider('costs', 'year')(w)}.csv"
+            f"costs_{config_provider('costs', 'year') (w)}.csv"
         ),
     output:
         resources("networks/elec_s{simpl}_{clusters}_ec.nc"),
@@ -590,7 +590,7 @@ rule prepare_network:
     input:
         resources("networks/elec_s{simpl}_{clusters}_ec.nc"),
         tech_costs=lambda w: resources(
-            f"costs_{config_provider('costs', 'year')(w)}.csv"
+            f"costs_{config_provider('costs', 'year') (w)}.csv"
         ),
         co2_price=lambda w: resources("co2_price.csv") if "Ept" in w.opts else [],
     output:

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -310,7 +310,7 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
                     n.madd(
                         "Generator",
                         new_capacity.index,
-                        suffix=" " + name_suffix,
+                        suffix=name_suffix,
                         bus=new_capacity.index,
                         carrier=generator,
                         p_nom=new_capacity,


### PR DESCRIPTION
A very minor fix, but even this will surely avoid some confusion in the long run.

The `name_suffix` variable already includes a space after the bus name, so before this there used to be a double space after the bus name in the added capacities.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
