### PR TITLE
Make links non-extendable if not configured in config'

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -870,7 +870,7 @@ def add_generation(n, costs, existing_capacities=0, existing_efficiencies=None):
             * costs.at[generator, "VOM"],  # NB: VOM is per MWel
             capital_cost=costs.at[generator, "efficiency"]
             * costs.at[generator, "fixed"],  # NB: fixed cost is per MWel
-            p_nom_extendable=True,
+            p_nom_extendable=True if generator in snakemake.params.electricity.get("extendable_carriers", dict()).get("Generator", list()) else False,
             p_nom=existing_capacities[generator] if not existing_capacities == 0 else 0,
             p_nom_min=(
                 existing_capacities[generator] if not existing_capacities == 0 else 0


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. I propose here improvements in `add_generation` function of `prepare_sector_networks` by making `p_nom_extendable` be configured by config file.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
