### PR TITLE
Add solar tracking technology option (horizontal single axis)

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -111,7 +111,7 @@ electricity:
     H2: 168
 
   extendable_carriers:
-    Generator: [solar, onwind, offwind-ac, offwind-dc, OCGT]
+    Generator: [solar, solar-hsat, onwind, offwind-ac, offwind-dc, OCGT]
     StorageUnit: [] # battery, H2
     Store: [battery, H2]
     Link: [] # H2 pipeline
@@ -121,7 +121,7 @@ electricity:
   everywhere_powerplants: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
 
   conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
-  renewable_carriers: [solar, onwind, offwind-ac, offwind-dc, hydro]
+  renewable_carriers: [solar, solar-hsat, onwind, offwind-ac, offwind-dc, hydro]
 
   estimate_renewable_capacities:
     enable: true
@@ -232,6 +232,21 @@ renewable:
     natura: true
     excluder_resolution: 100
     clip_p_max_pu: 1.e-2
+  solar-hsat:
+    cutout: europe-2013-sarah
+    resource:
+      method: pv
+      panel: CSi
+      orientation:
+        slope: 35.
+        azimuth: 180.
+      tracking: horizontal  
+    capacity_per_sqkm: 4.43 # 15% higher land usage acc. to NREL
+    corine: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 26, 31, 32]
+    luisa: false # [1111, 1121, 1122, 1123, 1130, 1210, 1221, 1222, 1230, 1241, 1242, 1310, 1320, 1330, 1410, 1421, 1422, 2110, 2120, 2130, 2210, 2220, 2230, 2310, 2410, 2420, 3210, 3320, 3330]
+    natura: true
+    excluder_resolution: 100
+    clip_p_max_pu: 1.e-2    
   hydro:
     cutout: europe-2013-era5
     carriers: [ror, PHS, hydro]
@@ -311,6 +326,7 @@ pypsa_eur:
   - offwind-ac
   - offwind-dc
   - solar
+  - solar-hsat
   - ror
   - nuclear
   StorageUnit:
@@ -573,6 +589,7 @@ sector:
   biogas_upgrading_cc: false
   conventional_generation:
     OCGT: gas
+  solar_utility_singla_axis_tracking : true  
   biomass_to_liquid: false
   biosng: false
   limit_max_growth:
@@ -890,6 +907,7 @@ plotting:
     # solar
     solar: "#f9d002"
     solar PV: "#f9d002"
+    solar-hsat: "#fdb915"
     solar thermal: '#ffbf2b'
     residential rural solar thermal: '#f1c069'
     services rural solar thermal: '#eabf61'

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -233,7 +233,7 @@ rule determine_availability_matrix_MD_UA:
         offshore_shapes=resources("offshore_shapes.geojson"),
         regions=lambda w: (
             resources("regions_onshore.geojson")
-            if w.technology in ("onwind", "solar")
+            if w.technology in ("onwind", "solar", "solar-hsat")
             else resources("regions_offshore.geojson")
         ),
         cutout=lambda w: "cutouts/"

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -301,7 +301,7 @@ rule build_renewable_profiles:
         offshore_shapes=resources("offshore_shapes.geojson"),
         regions=lambda w: (
             resources("regions_onshore.geojson")
-            if w.technology in ("onwind", "solar")
+            if w.technology in ("onwind", "solar", "solar-hsat")
             else resources("regions_offshore.geojson")
         ),
         cutout=lambda w: "cutouts/"

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -235,6 +235,8 @@ def load_costs(tech_costs, config, max_hours, Nyears=1.0):
         + (1 - config["rooftop_share"]) * costs.at["solar-utility", "capital_cost"]
     )
 
+    costs= costs.rename({'solar-utility single-axis tracking':'solar-hsat'})
+
     def costs_for_storage(store, link1, link2=None, max_hours=1.0):
         capital_cost = link1["capital_cost"] + max_hours * store["capital_cost"]
         if link2 is not None:

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1115,7 +1115,7 @@ def insert_gas_distribution_costs(n, costs):
 
 
 def add_electricity_grid_connection(n, costs):
-    carriers = ["onwind", "solar"]
+    carriers = ["onwind", "solar", "solar-hsat"]
 
     gens = n.generators.index[n.generators.carrier.isin(carriers)]
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3319,7 +3319,13 @@ def remove_h2_network(n):
     if "EU H2 Store" in n.stores.index:
         n.stores.drop("EU H2 Store", inplace=True)
 
+def remove_solar_tracking(n):
 
+    for tech in ['solar-hsat']:
+        print('removing '+tech)
+        n.mremove("Generator" , n.generators.index[n.generators.carrier==tech])
+
+                  
 def limit_individual_line_extension(n, maxext):
     logger.info(f"Limiting new HVAC and HVDC extensions to {maxext} MW")
     n.lines["s_nom_max"] = n.lines["s_nom"] + maxext
@@ -3695,6 +3701,9 @@ if __name__ == "__main__":
 
     if options["electricity_distribution_grid"]:
         insert_electricity_distribution_grid(n, costs)
+
+    if not options["solar_utility_singla_axis_tracking"]:
+           remove_solar_tracking(n)
 
     maybe_adjust_costs_and_potentials(n, snakemake.params["adjustments"])
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -43,6 +43,7 @@ from _helpers import (
     set_scenario_config,
     update_config_from_wildcards,
 )
+from functools import reduce
 from pypsa.descriptors import get_activity_mask
 from pypsa.descriptors import get_switchable_as_dense as get_as_dense
 
@@ -198,6 +199,61 @@ def _add_land_use_constraint_m(n, planning_horizons, config):
 
     n.generators.p_nom_max.clip(lower=0, inplace=True)
 
+def add_solar_potential_constraints(n, config):  
+    """
+    Add constraint to make sure the sum capacity of all solar technologies (fixed, tracking, ets. ) is below the region potential.
+    Example:
+    ES1 0: total solar potential is 10 GW, meaning:
+           solar potential : 10 GW
+           solar-hsat potential : 8 GW (solar with single axis tracking is assumed to have higher land use)
+    The constraint ensures that:
+           solar_p_nom + solar_hsat_p_nom * 1.13 <= 10 GW
+    """
+    land_use_factors= {
+        'solar-hsat'  : config['renewable']['solar']['capacity_per_sqkm']/config['renewable']['solar-hsat']['capacity_per_sqkm'] ,                                                                      
+        }
+    gen_index = n.generators[n.generators.p_nom_extendable].index
+
+    filters = [("solar", True), ("thermal", False), ("rooftop", False)]     ## filter all utility solar generation except solar thermal
+    solar = reduce(lambda gen_index, f: gen_index[gen_index.str.contains(f[0]) == f[1]], filters, gen_index)
+    solar_today = n.generators[(n.generators.carrier=='solar') & (n.generators.p_nom_extendable)].index
+    solar_hsat = n.generators[(n.generators.carrier=='solar-hsat') ].index
+    land_use = pd.DataFrame(1, index=solar, columns=['land_use_factor'])
+    for key in land_use_factors.keys():
+            land_use = land_use.apply(lambda x: (x*land_use_factors[key]) if key in x.name else x,  axis=1)
+
+    rename = {"Generator-ext": "Generator"}
+    if "m" in snakemake.wildcards.clusters:
+        location = (
+        pd.Series([' '.join(i.split(' ')[:2]) for i in n.generators.index], index=n.generators.index)
+        )
+        ggrouper= pd.Series(n.generators.loc[solar].index.rename('bus').map(location), index=n.generators.loc[solar].index,).to_xarray()
+        rhs = (n.generators.loc[solar_today,"p_nom_max"]
+                            .groupby(n.generators.loc[solar_today].index.rename('bus').map(location)).sum() -
+               n.generators.loc[solar_hsat,"p_nom_opt"]
+                            .groupby(n.generators.loc[solar_hsat].index.rename('bus').map(location)).sum() * land_use_factors['solar-hsat'] ).clip(lower=0)
+
+    else : 
+        location = (
+            n.buses.location
+            if "location" in n.buses.columns
+            else pd.Series(n.buses.index, index=n.buses.index)
+        )
+        ggrouper= (n.generators.loc[solar].bus)
+        rhs = (n.generators.loc[solar_today,"p_nom_max"]      
+                            .groupby(n.generators.loc[solar_today].bus.map(location)).sum() -
+                n.generators.loc[solar_hsat,"p_nom_opt"]    
+                            .groupby(n.generators.loc[solar_hsat].bus.map(location)).sum() * land_use_factors['solar-hsat'] ).clip(lower=0)
+
+    lhs = (
+            (n.model["Generator-p_nom"].rename(rename).loc[solar]
+            *land_use.squeeze().values)
+            .groupby(ggrouper) 
+            .sum()
+        )    
+
+    print('adding solar rooftop constraints...')
+    n.model.add_constraints(lhs <= rhs, name="solar_potential")            
 
 def add_co2_sequestration_limit(n, limit=200):
     """

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -918,6 +918,10 @@ def extra_functionality(n, snapshots):
     if EQ_o := constraints["EQ"]:
         add_EQ_constraints(n, EQ_o.replace("EQ", ""))
 
+    
+    if config["sector"]['solar_utility_singla_axis_tracking']:
+       add_solar_potential_constraints(n, config)
+
     add_battery_constraints(n)
     add_lossy_bidirectional_link_constraints(n)
     add_pipe_retrofit_constraint(n)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -124,7 +124,7 @@ def add_land_use_constraint_perfect(n):
 def _add_land_use_constraint(n):
     # warning: this will miss existing offwind which is not classed AC-DC and has carrier 'offwind'
 
-    for carrier in ["solar", "onwind", "offwind-ac", "offwind-dc"]:
+    for carrier in ["solar", "solar rooftop", "solar-hsat", "onwind", "offwind-ac", "offwind-dc"]:
         extendable_i = (n.generators.carrier == carrier) & n.generators.p_nom_extendable
         n.generators.loc[extendable_i, "p_nom_min"] = 0
 
@@ -159,7 +159,7 @@ def _add_land_use_constraint_m(n, planning_horizons, config):
     grouping_years = config["existing_capacities"]["grouping_years_power"]
     current_horizon = snakemake.wildcards.planning_horizons
 
-    for carrier in ["solar", "onwind", "offwind-ac", "offwind-dc"]:
+    for carrier in ["solar", "solar rooftop", "solar-hsat", "onwind", "offwind-ac", "offwind-dc"]:
         extendable_i = (n.generators.carrier == carrier) & n.generators.p_nom_extendable
         n.generators.loc[extendable_i, "p_nom_min"] = 0
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This pull request adds a new technology, solar PV with single-axis horizontal tracking (on a N-S axis), with a carrier called 'solar-hsat' to the networks. The default option for adding this technology is set to 'true' in the config.yaml.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
