### PR TITLE
Fix non steel related coal demand during transition (using sector_ratios_fraction_future)

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -181,6 +181,8 @@ Upcoming Release
 
 * Fix custom busmap read in `cluster_network`.
 
+* Fix non steel related coal demand during transition (using `sector_ratios_fraction_future`).
+
 PyPSA-Eur 0.10.0 (19th February 2024)
 =====================================
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3070,13 +3070,7 @@ def add_industry(n, costs):
             p_set=p_set,
         )
 
-    primary_steel = get(
-        snakemake.config["industry"]["St_primary_fraction"], investment_year
-    )
-    dri_steel = get(snakemake.config["industry"]["DRI_fraction"], investment_year)
-    bof_steel = primary_steel - dri_steel
-
-    if bof_steel > 0:
+    if (industrial_demand["coke"].sum() + industrial_demand["coal"].sum()) != 0:
         add_carrier_buses(n, "coal")
 
         mwh_coal_per_mwh_coke = 1.366  # from eurostat energy balance


### PR DESCRIPTION
## Changes proposed in this Pull Request

With the addition of the function `sector_ratios_fraction_future`, it's very likely that the energy demand for coal comes not only from the steel industry but also from other industries (e.g.: cement or HVC).

As an example, the energy demand by industry in 2040 for a given scenario is attached..
[industrial_energy_demand_elec_s181_39m_2040_by_industries.csv](https://github.com/PyPSA/pypsa-eur/files/15190544/industrial_energy_demand_elec_s181_39m_2040_by_industries.csv)


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
