### PR TITLE
Fix hydropower and load bugs

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -172,6 +172,8 @@ Upcoming Release
 
 * Bugfix: allow modelling sector-coupled landlocked regions. (Fixed handling of offshore wind.)
 
+* Bugfix: approximation of hydro power generation if Portugal or Spain are not included works now.
+
 * Adapt the disabling of transmission expansion in myopic foresight optimisations when limit is already reached to also handle cost limits.
 
 * Fix duplicated years and grouping years reference in `add_land_use_constraint_m`.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -174,6 +174,8 @@ Upcoming Release
 
 * Bugfix: approximation of hydro power generation if Portugal or Spain are not included works now.
 
+* Bugfix: copy_timeslice does not copy anymore, if country not present in load data.
+
 * Adapt the disabling of transmission expansion in myopic foresight optimisations when limit is already reached to also handle cost limits.
 
 * Fix duplicated years and grouping years reference in `add_land_use_constraint_m`.

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -129,7 +129,7 @@ def copy_timeslice(load, cntry, start, stop, delta, fn_load=None):
             load.loc[start:stop, cntry] = load.loc[
                 start - delta : stop - delta, cntry
             ].values
-        elif fn_load is not None:
+        elif fn_load is not None and cntry in load:
             duration = pd.date_range(freq="h", start=start - delta, end=stop - delta)
             load_raw = load_timeseries(fn_load, duration, [cntry])
             load.loc[start:stop, cntry] = load_raw.loc[

--- a/scripts/build_hydro_profile.py
+++ b/scripts/build_hydro_profile.py
@@ -140,9 +140,9 @@ def approximate_missing_eia_stats(eia_stats, runoff_fn, countries):
 
     # fix outliers; exceptional floods in 1977-1979 in ES & PT
     if "ES" in runoff:
-        runoff.loc[1978, ["ES"]] = runoff.loc[1979, ["ES"]]
+        runoff.loc[1978, "ES"] = runoff.loc[1979, "ES"]
     if "PT" in runoff:
-        runoff.loc[1978, ["PT"]] = runoff.loc[1979, ["PT"]]
+        runoff.loc[1978, "PT"] = runoff.loc[1979, "PT"]
 
     runoff_eia = runoff.loc[eia_stats.index]
 

--- a/scripts/build_hydro_profile.py
+++ b/scripts/build_hydro_profile.py
@@ -139,7 +139,8 @@ def approximate_missing_eia_stats(eia_stats, runoff_fn, countries):
     runoff.index = runoff.index.astype(int)
 
     # fix outliers; exceptional floods in 1977-1979 in ES & PT
-    runoff.loc[1978, ["ES", "PT"]] = runoff.loc[1979, ["ES", "PT"]]
+    if ("ES" and "PT") in runoff:
+        runoff.loc[1978, ["ES", "PT"]] = runoff.loc[1979, ["ES", "PT"]]
 
     runoff_eia = runoff.loc[eia_stats.index]
 

--- a/scripts/build_hydro_profile.py
+++ b/scripts/build_hydro_profile.py
@@ -139,8 +139,10 @@ def approximate_missing_eia_stats(eia_stats, runoff_fn, countries):
     runoff.index = runoff.index.astype(int)
 
     # fix outliers; exceptional floods in 1977-1979 in ES & PT
-    if ("ES" and "PT") in runoff:
-        runoff.loc[1978, ["ES", "PT"]] = runoff.loc[1979, ["ES", "PT"]]
+    if "ES" in runoff:
+        runoff.loc[1978, ["ES"]] = runoff.loc[1979, ["ES"]]
+    if "PT" in runoff:
+        runoff.loc[1978, ["PT"]] = runoff.loc[1979, ["PT"]]
 
     runoff_eia = runoff.loc[eia_stats.index]
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
### Bugfix for `approximate_missing_eia_stats()`

If ES or PT were not present in the list of optimized countries, the IEA hydropower approximation would fail, i.e. `approximate_missing_eia_stats()`. Therefore runs, where  the option `eia_approximate_missing` was activated would fail for weather years not part of the IEA data. The functoin would throw a key error:
`KeyError: "None of [Index(['ES', 'PT'], dtype='object', name='name')] are in the [index]"`

The reason is that `approximate_missing_eia_stats()` overwrites anomalous years for 'ES' and 'PT'. By checking if the countries are present before overwriting the data, the bug can be fixed:
`if ("ES") in runoff:`
        `    runoff.loc[1978, ["ES"]] = runoff.loc[1979, ["ES"]]`
`if ("PT") in runoff:`
        `    runoff.loc[1978, ["PT"]] = runoff.loc[1979, ["PT"]]`

### Bugfix for `manual_adjustment()`

The `copy_timeslice()` procedure will add countries to the load data which are not present in the countries list, if a `fn_load` object is provided. If `manual_adjustment()` is called, which uses `copy_timeslice()`, this will partly add data for some countries such as GB. Later on, this causes an `AssertionError: Load data contains nans.`



## Checklist

- [X] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [X] A release note `doc/release_notes.rst` is added.
