### PR TITLE
overwrite wildcard depending on sector setting

### DIFF
--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -539,7 +539,7 @@ def update_config_from_wildcards(config, w, inplace=True):
     if w.get("opts"):
         opts = w.opts.split("-")
 
-        if nhours := get_opt(opts, r"^\d+(h|seg)$"):
+        if nhours := get_opt(opts, r"^\d+(h|seg)$") and not config["clustering"]["temporal"]["resolution_elec"]:
             config["clustering"]["temporal"]["resolution_elec"] = nhours
 
         co2l_enable, co2l_value = find_opt(opts, "Co2L")
@@ -624,7 +624,7 @@ def update_config_from_wildcards(config, w, inplace=True):
         if "SAFE" in opts:
             config["solving"]["constraints"]["SAFE"] = True
 
-        if nhours := get_opt(opts, r"^\d+(h|sn|seg)$"):
+        if nhours := get_opt(opts, r"^\d+(h|sn|seg)$") and not config["clustering"]["temporal"]["resolution_sector"]:
             config["clustering"]["temporal"]["resolution_sector"] = nhours
 
         if "decentral" in opts:

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -539,7 +539,10 @@ def update_config_from_wildcards(config, w, inplace=True):
     if w.get("opts"):
         opts = w.opts.split("-")
 
-        if nhours := get_opt(opts, r"^\d+(h|seg)$") and not config["clustering"]["temporal"]["resolution_elec"]:
+        if (
+            nhours := get_opt(opts, r"^\d+(h|seg)$")
+            and not config["clustering"]["temporal"]["resolution_elec"]
+        ):
             config["clustering"]["temporal"]["resolution_elec"] = nhours
 
         co2l_enable, co2l_value = find_opt(opts, "Co2L")
@@ -624,7 +627,10 @@ def update_config_from_wildcards(config, w, inplace=True):
         if "SAFE" in opts:
             config["solving"]["constraints"]["SAFE"] = True
 
-        if nhours := get_opt(opts, r"^\d+(h|sn|seg)$") and not config["clustering"]["temporal"]["resolution_sector"]:
+        if (
+            nhours := get_opt(opts, r"^\d+(h|sn|seg)$")
+            and not config["clustering"]["temporal"]["resolution_sector"]
+        ):
             config["clustering"]["temporal"]["resolution_sector"] = nhours
 
         if "decentral" in opts:


### PR DESCRIPTION

## Changes proposed in this Pull Request
It would be nice to aggregate scenarios temporally with the scenario management to different levels. We already have the option in the config [here](https://github.com/PyPSA/pypsa-eur/blob/c05cfff7653d60c4dac04f5c8726a45e40014c4a/config/config.default.yaml#L731-L733) but with the scenario management it uses the wildcard again. It is a bit a question how to handle this because we normally say, that settings set in `scenario` overrule the ones set in `sector` but currently I think the temporal clustering settings in the config have no impact and do not result in any temporal aggregation. What do you think @fneum?

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
