### PR TITLE
fix_DC_cluster_issue

### DIFF
--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -272,14 +272,15 @@ def _add_links_from_tyndp(buses, links, links_tyndp, europe_shape):
         if links_tyndp.empty:
             return buses, links
 
-    tree = spatial.KDTree(buses[["x", "y"]])
+    tree_buses = buses.query("carrier=='AC'")
+    tree = spatial.KDTree(tree_buses[["x", "y"]])
     _, ind0 = tree.query(links_tyndp[["x1", "y1"]])
-    ind0_b = ind0 < len(buses)
-    links_tyndp.loc[ind0_b, "bus0"] = buses.index[ind0[ind0_b]]
+    ind0_b = ind0 < len(tree_buses)
+    links_tyndp.loc[ind0_b, "bus0"] = tree_buses.index[ind0[ind0_b]]
 
     _, ind1 = tree.query(links_tyndp[["x2", "y2"]])
-    ind1_b = ind1 < len(buses)
-    links_tyndp.loc[ind1_b, "bus1"] = buses.index[ind1[ind1_b]]
+    ind1_b = ind1 < len(tree_buses)
+    links_tyndp.loc[ind1_b, "bus1"] = tree_buses.index[ind1[ind1_b]]
 
     links_tyndp_located_b = (
         links_tyndp["bus0"].notnull() & links_tyndp["bus1"].notnull()


### PR DESCRIPTION
Closes #996 

## Changes proposed in this Pull Request
This PR fixes the bug described in #996. It guarantees that new links defined in `links_tyndp.csv` are only connected to AC buses. Before, this caused an error because we obtained a "meshed" DC grid in the model, which was not cleaned in the simplify_network script and led to wrong clustering.

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
