### PR TITLE
Enhance Carbon budget distribution plot

### DIFF
--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -477,9 +477,10 @@ def plot_carbon_budget_distribution(input_eurostat, options):
     )
     emissions = historical_emissions(countries)
     # add other years https://sdi.eea.europa.eu/data/0569441f-2853-4664-a7cd-db969ef54de0
-    emissions.loc[2019] = 2.971372
-    emissions.loc[2020] = 2.691958
-    emissions.loc[2021] = 2.869355
+    emissions.loc[2019] = 3.414362 
+    emissions.loc[2020] = 3.092434 
+    emissions.loc[2021] = 3.290418 
+    emissions.loc[2022] = 3.213025
 
     if snakemake.config["foresight"] == "myopic":
         path_cb = "results/" + snakemake.params.RDIR + "/csvs/"

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -477,9 +477,9 @@ def plot_carbon_budget_distribution(input_eurostat, options):
     )
     emissions = historical_emissions(countries)
     # add other years https://sdi.eea.europa.eu/data/0569441f-2853-4664-a7cd-db969ef54de0
-    emissions.loc[2019] = 3.414362 
-    emissions.loc[2020] = 3.092434 
-    emissions.loc[2021] = 3.290418 
+    emissions.loc[2019] = 3.414362
+    emissions.loc[2020] = 3.092434
+    emissions.loc[2021] = 3.290418
     emissions.loc[2022] = 3.213025
 
     if snakemake.config["foresight"] == "myopic":


### PR DESCRIPTION
Enhance the carbon budget plot by:
-Adding 2022 emissions 
-Adding UK emissions to the previous numbers

## Changes proposed in this Pull Request
currently, the plot_carbon_budget_distribution from plot_summary uses the below numbers for plotting Europe's carbon emissions:
    emissions.loc[2019] = 2.971372
    emissions.loc[2020] = 2.691958
    emissions.loc[2021] = 2.869355
This is technically missing the UK emissions and that's why there is a rather sudden drop in emissions (figure below). I tried calculating the UK emissions by taking the latest available numbers for UK from EEA_2018 (v23) and estimating their reduction based on the UK's total emissions reductions ([Provisional UK greenhouse gas emissions national statistics, 2022](https://assets.publishing.service.gov.uk/media/642588293d885d000cdadf45/2022-provisional-emissions-data-tables.xlsx)).
I've also added the carbon emissions for 2022 using the latest EEA report from 2024 ([v27](https://sdi.eea.europa.eu/data/6331f651-8863-4656-a911-669f2a332a1e?path=%2FCSV)) and again estimating the UK emissions for 2022.  Here's what the graph would look like before :

<img src="https://github.com/PyPSA/pypsa-eur/assets/102019906/04b236e0-c834-467c-82d6-a679ac438ed0" width=50% height=50%>

and after:
<img src="https://github.com/PyPSA/pypsa-eur/assets/102019906/50f06cb6-576e-442e-97c6-8d80b2c8c456" width=50% height=50%>





## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
