### PR TITLE
Fix disabling transmission limit for volume limit type

### DIFF
--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -132,22 +132,20 @@ def disable_grid_expansion_if_limit_hit(n):
     minimum and extendable is turned off; the corresponding global
     constraint is then dropped.
     """
-    cols = {"cost": "capital_cost", "volume": "length"}
-    for limit_type in ["cost", "volume"]:
-        glcs = n.global_constraints.query(
-            f"type == 'transmission_expansion_{limit_type}_limit'"
-        )
+    types = {"expansion_cost": "capital_cost", "volume_expansion": "length"}
+    for limit_type in types:
+        glcs = n.global_constraints.query(f"type == 'transmission_{limit_type}_limit'")
 
         for name, glc in glcs.iterrows():
             total_expansion = (
                 (
                     n.lines.query("s_nom_extendable")
-                    .eval(f"s_nom_min * {cols[limit_type]}")
+                    .eval(f"s_nom_min * {types[limit_type]}")
                     .sum()
                 )
                 + (
                     n.links.query("carrier == 'DC' and p_nom_extendable")
-                    .eval(f"p_nom_min * {cols[limit_type]}")
+                    .eval(f"p_nom_min * {types[limit_type]}")
                     .sum()
                 )
             ).sum()


### PR DESCRIPTION
A simple little fix; we were looking up the names of transmission limits incorrectly so disabling the limit only worked for cost limits, not volume limits

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
