### PR TITLE
Fix grouping logic again

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -391,7 +391,7 @@ solar_thermal:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#existing-capacities
 existing_capacities:
   grouping_years_power: [1920, 1950, 1955, 1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025]
-  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019] # these should not extend 2020
+  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019] # heat grouping years >= baseyear will be ignored
   threshold_capacity: 10
   default_heating_lifetime: 20
   conventional_carriers:

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -1024,7 +1024,6 @@ plotting:
     solid biomass for industry co2 from atmosphere: '#736412'
     solid biomass for industry co2 to stored: '#47411c'
     urban central solid biomass CHP: '#9d9042'
-    solid biomass: '#9d9042'
     solid biomass OP: '#9d9042'
     urban central solid biomass CHP CC: '#6c5d28'
     biomass boiler: '#8A9A5B'

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -391,7 +391,7 @@ solar_thermal:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#existing-capacities
 existing_capacities:
   grouping_years_power: [1920, 1950, 1955, 1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025]
-  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025] # heat grouping years >= baseyear will be ignored
+  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019] # these should not extend 2020
   threshold_capacity: 10
   default_heating_lifetime: 20
   conventional_carriers:

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -390,8 +390,8 @@ solar_thermal:
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#existing-capacities
 existing_capacities:
-  grouping_years_power: [1895, 1920, 1950, 1955, 1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025, 2030]
-  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020] # heat grouping years >= baseyear will be ignored
+  grouping_years_power: [1920, 1950, 1955, 1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025]
+  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025] # heat grouping years >= baseyear will be ignored
   threshold_capacity: 10
   default_heating_lifetime: 20
   conventional_carriers:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,6 +9,10 @@ Release Notes
 
 .. Upcoming Release
 .. ================
+
+* Partially revert https://github.com/PyPSA/pypsa-eur/pull/967 to return to old grouping year logic (which was mostly correct)
+
+
 PyPSA-Eur 0.11.0 (25th May 2024)
 =====================================
 

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -295,9 +295,11 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
 
             # this is for the year 2020
             if not already_build.empty:
-                n.generators.loc[already_build, "p_nom_min"] = capacity.loc[
-                    already_build.str.replace(name_suffix, "")
-                ].values
+                n.generators.loc[already_build, "p_nom"] = \
+                n.generators.loc[already_build, "p_nom_min"] = \
+                    capacity.loc[
+                        already_build.str.replace(name_suffix, "")
+                    ].values
             new_capacity = capacity.loc[new_build.str.replace(name_suffix, "")]
 
             if "m" in snakemake.wildcards.clusters:

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -295,11 +295,9 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
 
             # this is for the year 2020
             if not already_build.empty:
-                n.generators.loc[already_build, "p_nom"] = \
-                n.generators.loc[already_build, "p_nom_min"] = \
-                    capacity.loc[
-                        already_build.str.replace(name_suffix, "")
-                    ].values
+                n.generators.loc[already_build, "p_nom"] = n.generators.loc[
+                    already_build, "p_nom_min"
+                ] = capacity.loc[already_build.str.replace(name_suffix, "")].values
             new_capacity = capacity.loc[new_build.str.replace(name_suffix, "")]
 
             if "m" in snakemake.wildcards.clusters:

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -224,7 +224,6 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
     phased_out = df_agg[df_agg["DateOut"] < baseyear].index
     df_agg.drop(phased_out, inplace=True)
 
-
     newer_assets = (df_agg.DateIn > max(grouping_years)).sum()
     if newer_assets:
         logger.warning(
@@ -235,7 +234,6 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
         )
         to_drop = df_agg[df_agg.DateIn > max(grouping_years)].index
         df_agg.drop(to_drop, inplace=True)
-
 
     df_agg["grouping_year"] = np.take(
         grouping_years, np.digitize(df_agg.DateIn, grouping_years, right=True)

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -475,7 +475,6 @@ def add_chp_plants(n, grouping_years, costs, baseyear, clustermaps):
 
     # calculate remaining lifetime before phase-out (+1 because assuming
     # phase out date at the end of the year)
-    chp["lifetime"] = chp.DateOut - chp.DateIn + 1
     chp.Fueltype = chp.Fueltype.map(rename_fuel)
 
     # assign clustered bus
@@ -485,6 +484,7 @@ def add_chp_plants(n, grouping_years, costs, baseyear, clustermaps):
     chp["grouping_year"] = np.take(
         grouping_years, np.digitize(chp.DateIn, grouping_years, right=True)
     )
+    chp["lifetime"] = chp.DateOut - chp["grouping_year"] + 1
 
     # check if the CHPs were read in from MaStR for Germany
     if "Capacity_thermal" in chp.columns:
@@ -729,7 +729,7 @@ def add_heating_capacities_installed_before_baseyear(
 
         assert valid_grouping_years.is_monotonic_increasing
 
-        if not baseyear in valid_grouping_years:
+        if not valid_grouping_years.iloc[-1] == baseyear:
             logger.warning(
                 f"Baseyear {baseyear} not in grouping years. "
                 "Adding capacities built between last grouping year and baseyear to last grouping year."

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -716,22 +716,19 @@ def add_heating_capacities_installed_before_baseyear(
         else:
             efficiency = costs.at[costs_name, "efficiency"]
 
+        too_large_grouping_years = [gy for gy in grouping_years if gy >= int(baseyear)]     
+        if too_large_grouping_years:
+            logger.warning(f"Grouping years >= baseyear are ignored. Dropping {too_large_grouping_years}.")
         valid_grouping_years = pd.Series(
             [
                 int(grouping_year)
                 for grouping_year in grouping_years
                 if int(grouping_year) + default_lifetime > int(baseyear)
-                and int(grouping_year) <= int(baseyear)
+                and int(grouping_year) < int(baseyear)
             ]
         )
 
         assert valid_grouping_years.is_monotonic_increasing
-
-        if not valid_grouping_years.iloc[-1] == baseyear:
-            logger.warning(
-                f"Baseyear {baseyear} not in grouping years. "
-                "Adding capacities built between last grouping year and baseyear to last grouping year."
-            )
 
         # get number of years of each interval
         _years = valid_grouping_years.diff()

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -716,9 +716,11 @@ def add_heating_capacities_installed_before_baseyear(
         else:
             efficiency = costs.at[costs_name, "efficiency"]
 
-        too_large_grouping_years = [gy for gy in grouping_years if gy >= int(baseyear)]     
+        too_large_grouping_years = [gy for gy in grouping_years if gy >= int(baseyear)]
         if too_large_grouping_years:
-            logger.warning(f"Grouping years >= baseyear are ignored. Dropping {too_large_grouping_years}.")
+            logger.warning(
+                f"Grouping years >= baseyear are ignored. Dropping {too_large_grouping_years}."
+            )
         valid_grouping_years = pd.Series(
             [
                 int(grouping_year)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -132,7 +132,7 @@ def _add_land_use_constraint(n):
         "offwind-dc",
         "offwind-float",
     ]:
-        
+
         ext_i = (n.generators.carrier == carrier) & ~n.generators.p_nom_extendable
         existing = (
             n.generators.loc[ext_i, "p_nom"]
@@ -172,7 +172,7 @@ def _add_land_use_constraint_m(n, planning_horizons, config):
         "offwind-ac",
         "offwind-dc",
     ]:
-        
+
         existing = n.generators.loc[n.generators.carrier == carrier, "p_nom"]
         ind = list(
             {i.split(sep=" ")[0] + " " + i.split(sep=" ")[1] for i in existing.index}

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -132,9 +132,7 @@ def _add_land_use_constraint(n):
         "offwind-dc",
         "offwind-float",
     ]:
-        extendable_i = (n.generators.carrier == carrier) & n.generators.p_nom_extendable
-        n.generators.loc[extendable_i, "p_nom_min"] = 0
-
+        
         ext_i = (n.generators.carrier == carrier) & ~n.generators.p_nom_extendable
         existing = (
             n.generators.loc[ext_i, "p_nom"]
@@ -174,9 +172,7 @@ def _add_land_use_constraint_m(n, planning_horizons, config):
         "offwind-ac",
         "offwind-dc",
     ]:
-        extendable_i = (n.generators.carrier == carrier) & n.generators.p_nom_extendable
-        n.generators.loc[extendable_i, "p_nom_min"] = 0
-
+        
         existing = n.generators.loc[n.generators.carrier == carrier, "p_nom"]
         ind = list(
             {i.split(sep=" ")[0] + " " + i.split(sep=" ")[1] for i in existing.index}


### PR DESCRIPTION
#967 takes the point of view, that the capacities added by the model in 2025 correspond to the time interval [2025,2030]. The logic of the grouping years for existing capacities was different and solar-2020 would correspond to capacities installed in [2015,2020].  #967 aligned the way the grouping years work, s.t. solar-2015 would correspond to the interval [2015,2020].

However, as pointed out in https://github.com/PyPSA/pypsa-ariadne/issues/101 the interpretation that solar-2025 corresponds to [2025,2030] might be flawed. In pypsa-ariadne we impose capacities and co2 limits corresponding to actual laws. These limits apply to the year 2025,  thus any capacities extensions of the solar-2025 generator required to achieve these limit have to be built before 2025. Hence the more correct point of view is that the capacities expanded by the model in 2025 correspond to the time interval [2020,2025]. This is how the grouping years of existing capacities worked before #967, and thus this PR mostly reverts #967.


Open issues:

- [x] grouping years for heating may not extend 2020. Otherwise infeasibilities occur. I have no idea why, but i would prefer if this would be handled in the code and not in the config

- [x] The renewable capacity added in the base year is neglected because of the land use constraint in solve_network. it would be desirable to have separate Generators for extendable and existing renewable capacities.