### PR TITLE
revert hotfix for doubled renewable capacity

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,8 @@ Release Notes
 Upcoming Release
 ================
 
+* Reverted outdated hotfix for doubled renewable capacity in myopic optimization.
+
 * Added Enhanced Geothermal Systems for generation of electricity and district heat.
   Cost and available capacity assumptions based on `Aghahosseini et al. (2020)
   <https://www.sciencedirect.com/science/article/pii/S0306261920312551>`__.

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -132,7 +132,7 @@ def _add_land_use_constraint(n):
         "offwind-dc",
         "offwind-float",
     ]:
-        
+
         ext_i = (n.generators.carrier == carrier) & ~n.generators.p_nom_extendable
         existing = (
             n.generators.loc[ext_i, "p_nom"]
@@ -172,7 +172,7 @@ def _add_land_use_constraint_m(n, planning_horizons, config):
         "offwind-ac",
         "offwind-dc",
     ]:
-        
+
         existing = n.generators.loc[n.generators.carrier == carrier, "p_nom"]
         ind = list(
             {i.split(sep=" ")[0] + " " + i.split(sep=" ")[1] for i in existing.index}

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -132,9 +132,7 @@ def _add_land_use_constraint(n):
         "offwind-dc",
         "offwind-float",
     ]:
-        extendable_i = (n.generators.carrier == carrier) & n.generators.p_nom_extendable
-        n.generators.loc[extendable_i, "p_nom_min"] = 0
-
+        
         ext_i = (n.generators.carrier == carrier) & ~n.generators.p_nom_extendable
         existing = (
             n.generators.loc[ext_i, "p_nom"]
@@ -174,9 +172,7 @@ def _add_land_use_constraint_m(n, planning_horizons, config):
         "offwind-ac",
         "offwind-dc",
     ]:
-        extendable_i = (n.generators.carrier == carrier) & n.generators.p_nom_extendable
-        n.generators.loc[extendable_i, "p_nom_min"] = 0
-
+        
         existing = n.generators.loc[n.generators.carrier == carrier, "p_nom"]
         ind = list(
             {i.split(sep=" ")[0] + " " + i.split(sep=" ")[1] for i in existing.index}


### PR DESCRIPTION
In myopic optimisation the renewable capacities were added twice. This has recently been noted in #1016, but before that already in #727 and more recently in #1029.

With #1080 the underlying cause has been addressed, and the estimation of renewable capacities in add_electricity has been disabled for myopic foresight (and i think for perfect foresight as well, was this intentional?).

However, before #1080, two hotfixes addressed the problems caused be the doubled renewable capacity, namely #728 and #1022. 

This PR removes the hotfixes, which were now causing problems themselves when the grouping_year was equal to the baseyear.


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
