### PR TITLE
Bug-fix: plot_summary script generating empty pdfs.

### DIFF
--- a/rules/postprocess.smk
+++ b/rules/postprocess.smk
@@ -233,9 +233,9 @@ rule plot_summary:
         eurostat="data/eurostat/Balances-April2023",
         co2="data/bundle/eea/UNFCCC_v23.csv",
     output:
-        costs=RESULTS + "graphs/costs.pdf",
-        energy=RESULTS + "graphs/energy.pdf",
-        balances=RESULTS + "graphs/balances-energy.pdf",
+        costs=RESULTS + "graphs/costs.svg",
+        energy=RESULTS + "graphs/energy.svg",
+        balances=RESULTS + "graphs/balances-energy.svg",
     threads: 2
     resources:
         mem_mb=10000,

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -353,7 +353,7 @@ def plot_balances():
             frameon=False,
         )
 
-        fig.savefig(snakemake.output.balances[:-10] + k + ".pdf", bbox_inches="tight")
+        fig.savefig(snakemake.output.balances[:-10] + k + ".svg", bbox_inches="tight")
 
 
 def historical_emissions(countries):
@@ -563,7 +563,7 @@ def plot_carbon_budget_distribution(input_eurostat, options):
     )
 
     plt.grid(axis="y")
-    path = snakemake.output.balances.split("balances")[0] + "carbon_budget.pdf"
+    path = snakemake.output.balances.split("balances")[0] + "carbon_budget.svg"
     plt.savefig(path, bbox_inches="tight")
 
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Changes snakemake output of `plot_summary` to `.svg`:
- `costs=RESULTS + "graphs/costs.svg",`
- `energy=RESULTS + "graphs/energy.svg",`
- `balances=RESULTS + "graphs/balances-energy.svg",`
- For unknown reasons, `plot_summary` generates empty pdf outputs when called from CI (either through `snakemake` workflow or `python scripts/plot_summary.py`). This problem is mitigated when using `.svg` exports instead.
        

## Checklist

- [X] I tested my contribution locally and it seems to work fine.
- [X] Code and workflow changes are sufficiently documented.
- [X] Changed dependencies are added to `envs/environment.yaml`.
