### PR TITLE
Fix and simplify solar potential constraint

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,8 @@ Release Notes
 Upcoming Release
 ================
 
+* Bugfix for previously incorrect total solar potential constraint (only relevant when ``solar-hsat`` was enabled).
+
 * Set p_nom = p_nom_min for generators with baseyear == grouping_year in add_existing_baseyear. This has no effect on the optimization but helps n.statistics to correctly report already installed capacities.
 
 * Reverted outdated hotfix for doubled renewable capacity in myopic optimization.


### PR DESCRIPTION
The right hand side of equation was incorrect; the `solar-hsat` capacities shouldn't be subtracted! The assumption is that the rhs of the equation is the _total_ solar potential, and that total potential is stored in `p_nom_max` of the "regular" solar generators.

I have indeed run into infeasibility caused by this mistake.

I also took the opportunity to clean up some of the surrounding code.

Finally, I'll note that the tests are pretty much guaranteed to succeed whether or not this fix is correct (you'll have to trust my personal judgement), because there are no extendable renewables in the test configs! I'm sure this is not actually intentional; maybe from back when renewables were automatically extendable? Anyway I would suggest an update of the test configs :)

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
