### PR TITLE
non-zero capital_cost for methanol stores

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,8 @@ Release Notes
 Upcoming Release
 ================
 
+* Set non-zero capital_cost for methanol stores to avoid unrealistic storage sizes
+
 * Set p_nom = p_nom_min for generators with baseyear == grouping_year in add_existing_baseyear. This has no effect on the optimization but helps n.statistics to correctly report already installed capacities.
 
 * Reverted outdated hotfix for doubled renewable capacity in myopic optimization.

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2702,6 +2702,7 @@ def add_industry(n, costs):
         e_nom_extendable=True,
         e_cyclic=True,
         carrier="methanol",
+        capital_cost=0.02,
     )
 
     n.madd(


### PR DESCRIPTION
For pypsa-ariadne @toniseibold added a DE specific methanol store with non-zero capital cost. For pypsa-eur the capital cost is zero, which leads to unrealistically large e_nom_opt values. 

I directly added capital_cost in `madd`. For the other stores the capital cost is added in `add_carrier_buses`. Maybe methanol should be handled via this function as well? @fneum 