### PR TITLE
dirtiest hottest fix for oil demand in transport sector

### DIFF
--- a/scripts/build_energy_totals.py
+++ b/scripts/build_energy_totals.py
@@ -305,8 +305,8 @@ def idees_per_country(ct, base_dir):
     row = "Heavy duty vehicles (Diesel oil incl. biofuels)"
     ct_totals["total heavy duty road freight"] = df.loc[row]
 
-    assert df.index[61] == "Passenger cars"
-    ct_totals["passenger car efficiency"] = df.iloc[61]
+    assert df.index[58] == "Vehicle-efficiency - effective (kgoe/100 km)"
+    ct_totals["passenger car efficiency"] = df.iloc[58]
 
     df = pd.read_excel(fn_transport, "TrRail_ene", index_col=0)
 


### PR DESCRIPTION
Closing https://github.com/PyPSA/pypsa-ariadne/issues/102 for now.

Problem is, that in `build_energy_totals.py` the efficiencies of cars are taken from JRC IDEES.
Also the `config["sector"]["transport_ice_efficiency"] is only valid for cars.
So far, from the energy demand a transport demand in kilometers is calculated neglecting the demand in road freight transport.
This leads to a significant difference in oil demand between PyPSA-Eur and reality.
Until this is fixed, this very hot and dirty fix ensures that the demand in the transport sector is correct.
It takes an average fuel efficiency across all road vehicles.

Additionally in the config is changed to the following values:
```
  transport_ice_efficiency: 10.637 # 1 MWh_oil = 16.0712 * 100 km
```

This leads to the following demand in transport sector:
![final_energy_detailed](https://github.com/PyPSA/pypsa-eur/assets/153275395/226b50d0-ee07-4f91-8481-7ad1aa3f6e1b)
![primary_energy](https://github.com/PyPSA/pypsa-eur/assets/153275395/2343c628-bbfa-403d-90ff-9d3f494d1210)


