### PR TITLE
Remove simplification of shapes to retain full resolution and avoid overlaps/gaps between neighbouring countries

### DIFF
--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -91,7 +91,7 @@ def _get_country(target, **keys):
         return np.nan
 
 
-def _simplify_polys(polys, minarea=0.1, tolerance=0.01, filterremote=True):
+def _simplify_polys(polys, minarea=0.1, filterremote=True):
     if isinstance(polys, MultiPolygon):
         polys = sorted(polys.geoms, key=attrgetter("area"), reverse=True)
         mainpoly = polys[0]
@@ -106,7 +106,7 @@ def _simplify_polys(polys, minarea=0.1, tolerance=0.01, filterremote=True):
             )
         else:
             polys = mainpoly
-    return polys.simplify(tolerance=tolerance)
+    return polys
 
 
 def countries(naturalearth, country_list):


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Remove simplification of region shapes.
- As such, the full resolution of the region shapes is retained and overlaps/gaps between neighbouring countries are avoided.
- So far, the workflow does not seem to be negatively impacted, the duration of rules seems to stay the same.
- If simplification is needed in the future, propose to switch to topojson simplification algorithm, as topological relations and boundaries are preserved (no overlaps and gaps):
  - https://github.com/geopandas/geopandas/issues/1387
  - https://gis.stackexchange.com/questions/325766/geopandas-simplify-results-in-gaps-between-polygons

## Checklist

- [X] I tested my contribution locally and it seems to work fine.
- [X] Code and workflow changes are sufficiently documented.
