### PR TITLE
fix sector coupeled model for isolated non EU28 countries, e.g. UA

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -25,6 +25,10 @@ Upcoming Release
 
 * Bugfix: Correctly read in threshold capacity below which to remove components from previous planning horizons in :mod:`add_brownfield`.
 
+* Allow running the sector model for isolated non-EU28 countries, by filling missing sectoral
+  data with defaults, average EU values or zeros, if not available.
+
+
 PyPSA-Eur 0.11.0 (25th May 2024)
 =====================================
 

--- a/scripts/build_district_heat_share.py
+++ b/scripts/build_district_heat_share.py
@@ -73,8 +73,9 @@ if __name__ == "__main__":
     pop_layout["urban_ct_fraction"] = pop_layout.urban / pop_layout.ct.map(ct_urban.get)
 
     # fraction of node that is urban
-    urban_fraction = (pop_layout.urban / pop_layout[["rural", "urban"]].sum(axis=1)).fillna(0)
-
+    urban_fraction = (
+        pop_layout.urban / pop_layout[["rural", "urban"]].sum(axis=1)
+    ).fillna(0)
 
     # maximum potential of urban demand covered by district heating
     central_fraction = snakemake.config["sector"]["district_heating"]["potential"]

--- a/scripts/build_district_heat_share.py
+++ b/scripts/build_district_heat_share.py
@@ -56,9 +56,11 @@ if __name__ == "__main__":
     pop_layout = pd.read_csv(snakemake.input.clustered_pop_layout, index_col=0)
 
     year = str(snakemake.params.energy_totals_year)
-    district_heat_share = pd.read_csv(snakemake.input.district_heat_share, index_col=0)[
-        year
-    ]
+    district_heat_share = pd.read_csv(snakemake.input.district_heat_share, index_col=0)
+    if not district_heat_share.empty:
+        district_heat_share = district_heat_share[year]
+    else:
+        district_heat_share = pd.Series(index=pop_layout.index, data=0)
 
     # make ct-based share nodal
     district_heat_share = district_heat_share.reindex(pop_layout.ct).fillna(0)
@@ -71,7 +73,8 @@ if __name__ == "__main__":
     pop_layout["urban_ct_fraction"] = pop_layout.urban / pop_layout.ct.map(ct_urban.get)
 
     # fraction of node that is urban
-    urban_fraction = pop_layout.urban / pop_layout[["rural", "urban"]].sum(axis=1)
+    urban_fraction = (pop_layout.urban / pop_layout[["rural", "urban"]].sum(axis=1)).fillna(0)
+
 
     # maximum potential of urban demand covered by district heating
     central_fraction = snakemake.config["sector"]["district_heating"]["potential"]
@@ -79,7 +82,7 @@ if __name__ == "__main__":
     # district heating share at each node
     dist_fraction_node = (
         district_heat_share * pop_layout["urban_ct_fraction"] / pop_layout["fraction"]
-    )
+    ).fillna(0)
 
     # if district heating share larger than urban fraction -> set urban
     # fraction to district heating share

--- a/scripts/build_energy_totals.py
+++ b/scripts/build_energy_totals.py
@@ -1401,7 +1401,40 @@ if __name__ == "__main__":
         disable_progressbar=snakemake.config["run"].get("disable_progressbar", False),
     )
     swiss = build_swiss()
-    idees = build_idees(idees_countries)
+    if len(idees_countries) > 0:
+        idees = build_idees(idees_countries)
+    else:
+        # e.g. UA and MD
+        logger.info(f"No IDEES data available for {countries} and years 2000-2015. Filling with zeros.")
+        years = range(2000, 2016)
+        idees = pd.DataFrame(
+            index=pd.MultiIndex.from_tuples([(country, year) for country in countries for year in years]),
+            columns=[
+                "passenger cars",
+                "passenger car efficiency",
+                "total passenger cars",
+                "total other road passenger",
+                "total light duty road freight",
+                "total two-wheel",
+                "total heavy duty road freight",
+                "electricity passenger cars",
+                "electricity other road passenger",
+                "electricity light duty road freight",
+                "total rail passenger",
+                "total rail freight",
+                "electricity rail passenger",
+                "electricity rail freight",
+                "total domestic aviation passenger",
+                "total domestic aviation freight",
+                "total international aviation passenger",
+                "total international aviation freight",
+                "derived heat residential",
+                "derived heat services",
+                "thermal uses residential",
+                "thermal uses services",
+            ],
+            data=0
+        )
 
     energy = build_energy_totals(countries, eurostat, swiss, idees)
 

--- a/scripts/build_energy_totals.py
+++ b/scripts/build_energy_totals.py
@@ -1405,10 +1405,14 @@ if __name__ == "__main__":
         idees = build_idees(idees_countries)
     else:
         # e.g. UA and MD
-        logger.info(f"No IDEES data available for {countries} and years 2000-2015. Filling with zeros.")
+        logger.info(
+            f"No IDEES data available for {countries} and years 2000-2015. Filling with zeros."
+        )
         years = range(2000, 2016)
         idees = pd.DataFrame(
-            index=pd.MultiIndex.from_tuples([(country, year) for country in countries for year in years]),
+            index=pd.MultiIndex.from_tuples(
+                [(country, year) for country in countries for year in years]
+            ),
             columns=[
                 "passenger cars",
                 "passenger car efficiency",
@@ -1433,7 +1437,7 @@ if __name__ == "__main__":
                 "thermal uses residential",
                 "thermal uses services",
             ],
-            data=0
+            data=0,
         )
 
     energy = build_energy_totals(countries, eurostat, swiss, idees)

--- a/scripts/build_industrial_energy_demand_per_country_today.py
+++ b/scripts/build_industrial_energy_demand_per_country_today.py
@@ -64,8 +64,8 @@ import multiprocessing as mp
 from functools import partial
 
 import country_converter as coco
-import pandas as pd
 import numpy as np
+import pandas as pd
 from _helpers import set_scenario_config
 from tqdm import tqdm
 
@@ -197,7 +197,9 @@ def add_non_eu28_industrial_energy_demand(countries, demand, production):
 
     eu28_production = production.loc[countries.intersection(eu28)].sum()
     if eu28_production.sum() == 0:
-        logger.info("EU production is zero. Fallback: Filling non EU28 countries with zeros.")
+        logger.info(
+            "EU production is zero. Fallback: Filling non EU28 countries with zeros."
+        )
     eu28_energy = demand.groupby(level=1).sum()
     eu28_averages = eu28_energy / eu28_production
 

--- a/scripts/build_industrial_energy_demand_per_node_today.py
+++ b/scripts/build_industrial_energy_demand_per_node_today.py
@@ -72,7 +72,15 @@ def build_nodal_industrial_energy_demand():
         buses = keys.index[keys.country == country]
         mapping = sector_mapping.get(sector, "population")
 
-        key = keys.loc[buses, mapping]
+        try:
+            key = keys.loc[buses, mapping].fillna(0)
+        except:
+            logger.info(
+                f"No industrial demand available for {mapping}. Filling with zeros."
+            )
+            keys[mapping] = 0
+            key = keys.loc[buses, mapping].fillna(0)
+            
         demand = industrial_demand[country, sector]
 
         outer = pd.DataFrame(

--- a/scripts/build_industrial_energy_demand_per_node_today.py
+++ b/scripts/build_industrial_energy_demand_per_node_today.py
@@ -80,7 +80,7 @@ def build_nodal_industrial_energy_demand():
             )
             keys[mapping] = 0
             key = keys.loc[buses, mapping].fillna(0)
-            
+
         demand = industrial_demand[country, sector]
 
         outer = pd.DataFrame(

--- a/scripts/build_industrial_production_per_node.py
+++ b/scripts/build_industrial_production_per_node.py
@@ -75,6 +75,15 @@ def build_nodal_industrial_production():
         buses = keys.index[keys.country == country]
         mapping = sector_mapping.get(sector, "population")
 
+        try:
+            key = keys.loc[buses, mapping].fillna(0)
+        except:
+            logger.info(
+                f"No industrial production available for {mapping}. Filling with zeros."
+            )
+            keys[mapping] = 0
+            key = keys.loc[buses, mapping].fillna(0)
+
         key = keys.loc[buses, mapping]
         nodal_production.loc[buses, sector] = (
             industrial_production.at[country, sector] * key


### PR DESCRIPTION
contents:
Just making the sec model run by filling missing sectoral data with defaults, average EU values or zeros, if nothing else is available. Thus, it currently has no real sectoral data, but allows the execution of the power model only in the sector coupeled style (i.e. adding distribution grids, solar thermal, etc.)

other comments:
experimenting to use git cherry-pick from OET/pypsa-eur fork to align our master branch with upstream ... (was this PR in OET fork https://github.com/open-energy-transition/pypsa-eur/pull/1)... unfortunately used the wrong git commands, so that the history was lost


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
