### PR TITLE
allow keeping existing capacities in sec from power (#4)

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -605,6 +605,7 @@ sector:
   biogas_upgrading_cc: false
   conventional_generation:
     OCGT: gas
+  keep_existing_capacities: false
   biomass_to_liquid: false
   biosng: false
   limit_max_growth:

--- a/doc/configtables/sector.csv
+++ b/doc/configtables/sector.csv
@@ -136,6 +136,7 @@ biomass_spatial,--,"{true, false}",Add option for resolving biomass demand regio
 biomass_transport,--,"{true, false}",Add option for transporting solid biomass between nodes
 biogas_upgrading_cc,--,"{true, false}",Add option to capture CO2 from biomass upgrading
 conventional_generation,,,Add a more detailed description of conventional carriers. Any power generation requires the consumption of fuel from nodes representing that fuel.
+keep_existing_capacities,--,"{true, false}",Keep existing conventional carriers from the power model. Defaults to false.
 biomass_to_liquid,--,"{true, false}",Add option for transforming solid biomass into liquid fuel with the same properties as oil
 biosng,--,"{true, false}",Add option for transforming solid biomass into synthesis gas with the same properties as natural gas
 limit_max_growth,,,

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -25,6 +25,8 @@ Upcoming Release
 
 * Bugfix: Correctly read in threshold capacity below which to remove components from previous planning horizons in :mod:`add_brownfield`.
 
+* Enable retaining exisiting conventional capacities added in the power only model for sector coupeled applications.
+
 PyPSA-Eur 0.11.0 (25th May 2024)
 =====================================
 

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -948,6 +948,7 @@ rule prepare_sector_network:
         countries=config_provider("countries"),
         adjustments=config_provider("adjustments", "sector"),
         emissions_scope=config_provider("energy", "emissions"),
+        electricity=config_provider("electricity"),
         RDIR=RDIR,
     input:
         unpack(input_profile_offwind),

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -421,9 +421,9 @@ def attach_wind_and_solar(
 
             if not ppl.query("carrier == @car").empty:
                 caps = ppl.query("carrier == @car").groupby("bus").p_nom.sum()
-                caps = pd.Series(data = caps, index = ds.indexes["bus"]).fillna(0)
+                caps = pd.Series(data=caps, index=ds.indexes["bus"]).fillna(0)
             else:
-                caps = pd.Series(index = ds.indexes["bus"]).fillna(0)
+                caps = pd.Series(index=ds.indexes["bus"]).fillna(0)
 
             n.madd(
                 "Generator",
@@ -431,8 +431,8 @@ def attach_wind_and_solar(
                 " " + car,
                 bus=ds.indexes["bus"],
                 carrier=car,
-                p_nom = caps,
-                p_nom_min = caps,
+                p_nom=caps,
+                p_nom_min=caps,
                 p_nom_extendable=car in extendable_carriers["Generator"],
                 p_nom_max=ds["p_nom_max"].to_pandas(),
                 weight=ds["weight"].to_pandas(),

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -851,19 +851,17 @@ def prepare_costs(cost_file, params, nyears):
     return costs
 
 
-def add_generation(n, costs):
+def add_generation(n, costs, existing_capacities=0, existing_efficiencies=None):
     logger.info("Adding electricity generation")
 
     nodes = pop_layout.index
 
     fallback = {"OCGT": "gas"}
     conventionals = options.get("conventional_generation", fallback)
-
     for generator, carrier in conventionals.items():
         carrier_nodes = vars(spatial)[carrier].nodes
 
         add_carrier_buses(n, carrier, carrier_nodes)
-
         n.madd(
             "Link",
             nodes + " " + generator,
@@ -874,9 +872,28 @@ def add_generation(n, costs):
             * costs.at[generator, "VOM"],  # NB: VOM is per MWel
             capital_cost=costs.at[generator, "efficiency"]
             * costs.at[generator, "fixed"],  # NB: fixed cost is per MWel
-            p_nom_extendable=True,
+            p_nom_extendable=(
+                True
+                if generator
+                in snakemake.params.electricity.get("extendable_carriers", dict()).get(
+                    "Generator", list()
+                )
+                else False
+            ),    
+            p_nom=(
+                existing_capacities[generator] / existing_efficiencies[generator]
+                if not existing_capacities == 0 else 0
+            ), # NB: existing capacities are MWel     
+            p_max_pu = 0.7 if carrier == "uranium" else 1, # be conservative for nuclear (maintance or unplanned shut downs)
+            p_nom_min=(
+                existing_capacities[generator] if not existing_capacities == 0 else 0
+            ),   
             carrier=generator,
-            efficiency=costs.at[generator, "efficiency"],
+            efficiency=(
+                existing_efficiencies[generator]
+                if existing_efficiencies is not None
+                else costs.at[generator, "efficiency"]
+            ),
             efficiency2=costs.at[carrier, "CO2 intensity"],
             lifetime=costs.at[generator, "lifetime"],
         )
@@ -3935,6 +3952,28 @@ def add_enhanced_geothermal(n, egs_potentials, egs_overlap, costs):
                 cyclic_state_of_charge=True,
             )
 
+def get_capacities_from_elec(n, carriers, component):
+    """
+    Gets capacities and efficiencies for {carrier} in n.{component} that were
+    previously assigned in add_electricity.
+    """
+    component_list = ["generators", "storage_units", "links", "stores"]
+    component_dict = {name: getattr(n, name) for name in component_list}
+    e_nom_carriers = ["stores"]
+    nom_col = {x: "e_nom" if x in e_nom_carriers else "p_nom" for x in component_list}
+    eff_col = "efficiency"
+
+    capacity_dict = {}
+    efficiency_dict = {}
+    for carrier in carriers:
+        capacity_dict[carrier] = component_dict[component].query("carrier in @carrier")[
+            nom_col[component]
+        ]
+        efficiency_dict[carrier] = component_dict[component].query(
+            "carrier in @carrier"
+        )[eff_col]
+
+    return capacity_dict, efficiency_dict
 
 # %%
 if __name__ == "__main__":
@@ -3981,11 +4020,20 @@ if __name__ == "__main__":
     )
     pop_weighted_energy_totals.update(pop_weighted_heat_totals)
 
+    if options.get("keep_existing_capacities", False):
+        existing_capacities, existing_efficiencies = get_capacities_from_elec(
+            n,
+            carriers=options.get("conventional_generation").keys(),
+            component="generators",
+        )
+    else:
+        existing_capacities, existing_efficiencies = 0, None
+
     patch_electricity_network(n)
 
     spatial = define_spatial(pop_layout.index, options)
 
-    if snakemake.params.foresight in ["myopic", "perfect"]:
+    if snakemake.params.foresight in ["overnight", "myopic", "perfect"]:
         add_lifetime_wind_solar(n, costs)
 
         conventional = snakemake.params.conventional_carriers
@@ -3996,7 +4044,7 @@ if __name__ == "__main__":
 
     add_co2_tracking(n, costs, options)
 
-    add_generation(n, costs)
+    add_generation(n, costs, existing_capacities, existing_efficiencies)
 
     add_storage_and_grids(n, costs)
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -879,15 +879,18 @@ def add_generation(n, costs, existing_capacities=0, existing_efficiencies=None):
                     "Generator", list()
                 )
                 else False
-            ),    
+            ),
             p_nom=(
                 existing_capacities[generator] / existing_efficiencies[generator]
-                if not existing_capacities == 0 else 0
-            ), # NB: existing capacities are MWel     
-            p_max_pu = 0.7 if carrier == "uranium" else 1, # be conservative for nuclear (maintance or unplanned shut downs)
+                if not existing_capacities == 0
+                else 0
+            ),  # NB: existing capacities are MWel
+            p_max_pu=(
+                0.7 if carrier == "uranium" else 1
+            ),  # be conservative for nuclear (maintance or unplanned shut downs)
             p_nom_min=(
                 existing_capacities[generator] if not existing_capacities == 0 else 0
-            ),   
+            ),
             carrier=generator,
             efficiency=(
                 existing_efficiencies[generator]
@@ -3952,6 +3955,7 @@ def add_enhanced_geothermal(n, egs_potentials, egs_overlap, costs):
                 cyclic_state_of_charge=True,
             )
 
+
 def get_capacities_from_elec(n, carriers, component):
     """
     Gets capacities and efficiencies for {carrier} in n.{component} that were
@@ -3974,6 +3978,7 @@ def get_capacities_from_elec(n, carriers, component):
         )[eff_col]
 
     return capacity_dict, efficiency_dict
+
 
 # %%
 if __name__ == "__main__":


### PR DESCRIPTION
Contents:

 Enable retaining existing conventional capacities added in the power only model (`elec.nc`) for sector coupeled applications (add them again in `prepare_sector_network`), if specified in the config file.


Other comments:
Keep experimenting with git cherry-picking... this originates here: https://github.com/open-energy-transition/pypsa-eur/pull/4
Here's a log file of initial commits:

* allow keeping existing capacities in sec from power

* remove print statement

* Fixes to keep caps

* allow keeping existing capacities in sec from power

* remove print statement

* Fixes to prepare sector network to reflect existing conventional generations

* Modifications to add renewable capacities from custom powerplants file

* Update scripts/prepare_sector_network.py

* Update scripts/prepare_sector_network.py

* Fixing existing_efficiencies



---------

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
