### PR TITLE
Fixed mock_snakemake for snakemake v.8.14: All snakemake settings moved

### DIFF
--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -406,13 +406,13 @@ def mock_snakemake(
     from snakemake.api import Workflow
     from snakemake.common import SNAKEFILE_CHOICES
     from snakemake.script import Snakemake
-    from snakemake.settings import (
+    from snakemake.settings.types import (
+        ConfigSettings,
         DAGSettings,
         ResourceSettings,
         StorageSettings,
         WorkflowSettings,
     )
-    from snakemake.settings.types import ConfigSettings
 
     script_dir = Path(__file__).parent.resolve()
     if root_dir is None:


### PR DESCRIPTION
Closes #1108 

## Changes proposed in this Pull Request
- Settings related to snakemake are all moved to snakemake.settings.types in snakemake version 8.14.0
- In `_helpers.py`:

```
from snakemake.settings.types import (
        ConfigSettings,
        DAGSettings,
        ResourceSettings,
        StorageSettings,
        WorkflowSettings,
    )
```

## Checklist

- [X] I tested my contribution locally and it seems to work fine.
- [X] Code and workflow changes are sufficiently documented.
