### PR TITLE
Quick fix of missing country but in add_existing_baseyear.py

### DIFF
--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -104,7 +104,7 @@ def add_existing_renewables(df_agg, costs):
                 n.generators.loc[gens, "bus"]
             ).sum()
 
-        nodal_df = df.reindex(n.buses.loc[elec_buses, "country"])
+        nodal_df = df.reindex(n.buses.loc[elec_buses, "country"], fill_value=0)
         nodal_df.index = elec_buses
         nodal_df = nodal_df.multiply(nodal_fraction, axis=0)
 

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -104,7 +104,7 @@ def add_existing_renewables(df_agg, costs):
                 n.generators.loc[gens, "bus"]
             ).sum()
 
-        nodal_df = df.loc[n.buses.loc[elec_buses, "country"]]
+        nodal_df = df.reindex(n.buses.loc[elec_buses, "country"])
         nodal_df.index = elec_buses
         nodal_df = nodal_df.multiply(nodal_fraction, axis=0)
 
@@ -879,7 +879,7 @@ if __name__ == "__main__":
             opts="",
             sector_opts="none",
             planning_horizons=2020,
-            run="KN2045_Bal_v4",
+            run="CurrentPolicies",
         )
 
     configure_logging(snakemake)


### PR DESCRIPTION
I guess it either has to do with Pandas version or powerplantmatching.
Could not reproduce the bug since currently I do not have it but maybe check whether missing countries are in
```
import powerplantmatching as pm
irena=pm.data.IRENASTAT().powerplant.convert_country_to_alpha2()
irena.Country.unique()
```
@toniseibold checked and the coutnries were inside `irena.Country.unique()` in her environment which caused the error

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
