### PR TITLE
Add option to exclude fossil fuels

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -407,6 +407,7 @@ sector:
   biomass: true
   industry: true
   agriculture: true
+  fossil_fuels: true
   district_heating:
     potential: 0.6
     progress:

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -542,11 +542,19 @@ def add_carrier_buses(n, carrier, nodes=None):
         capital_cost=capital_cost,
     )
 
+    fossils = ['coal', 'gas', 'oil', 'lignite']
+    if not options.get('fossil_fuels',True) and carrier in fossils:
+        print('Not adding fossil ', carrier)
+        extendable = False
+    else:
+        print('Adding fossil ', carrier)
+        extendable = True
+
     n.madd(
         "Generator",
         nodes,
         bus=nodes,
-        p_nom_extendable=True,
+        p_nom_extendable=extendable,
         carrier=carrier,
         marginal_cost=costs.at[carrier, "fuel"],
     )
@@ -2894,12 +2902,17 @@ def add_industry(n, costs):
             carrier="oil",
         )
 
+    if not options.get('fossil_fuels', True):
+        extendable = False
+    else:
+        extendable = True
+
     if "oil" not in n.generators.carrier.unique():
         n.madd(
             "Generator",
             spatial.oil.nodes,
             bus=spatial.oil.nodes,
-            p_nom_extendable=True,
+            p_nom_extendable=extendable,
             carrier="oil",
             marginal_cost=costs.at["oil", "fuel"],
         )

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -542,12 +542,12 @@ def add_carrier_buses(n, carrier, nodes=None):
         capital_cost=capital_cost,
     )
 
-    fossils = ['coal', 'gas', 'oil', 'lignite']
-    if not options.get('fossil_fuels',True) and carrier in fossils:
-        print('Not adding fossil ', carrier)
+    fossils = ["coal", "gas", "oil", "lignite"]
+    if not options.get("fossil_fuels", True) and carrier in fossils:
+        print("Not adding fossil ", carrier)
         extendable = False
     else:
-        print('Adding fossil ', carrier)
+        print("Adding fossil ", carrier)
         extendable = True
 
     n.madd(
@@ -2902,7 +2902,7 @@ def add_industry(n, costs):
             carrier="oil",
         )
 
-    if not options.get('fossil_fuels', True):
+    if not options.get("fossil_fuels", True):
         extendable = False
     else:
         extendable = True


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
Toggle to set boolean extendability of fossil fuel generators (oil, gas, coal, lignite).
Affects CO2 shadow price and CO2 storage shadow price strongly.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
