### PR TITLE
FT and electrolysis waste heat for DH as float

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -571,12 +571,12 @@ sector:
   min_part_load_fischer_tropsch: 0.5
   min_part_load_methanolisation: 0.3
   min_part_load_methanation: 0.3
-  use_fischer_tropsch_waste_heat: true
+  use_fischer_tropsch_waste_heat: 0.2
   use_haber_bosch_waste_heat: true
   use_methanolisation_waste_heat: true
   use_methanation_waste_heat: true
   use_fuel_cell_waste_heat: true
-  use_electrolysis_waste_heat: true
+  use_electrolysis_waste_heat: 0.2
   electricity_transmission_grid: true
   electricity_distribution_grid: true
   electricity_distribution_grid_cost_factor: 1.0

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -571,12 +571,13 @@ sector:
   min_part_load_fischer_tropsch: 0.5
   min_part_load_methanolisation: 0.3
   min_part_load_methanation: 0.3
-  use_fischer_tropsch_waste_heat: 0.2
-  use_haber_bosch_waste_heat: true
-  use_methanolisation_waste_heat: true
-  use_methanation_waste_heat: true
-  use_fuel_cell_waste_heat: true
-  use_electrolysis_waste_heat: 0.2
+  use_waste_heat:
+    fischer_tropsch: 0.25
+    haber_bosch: 0.25
+    methanolisation: 0.25
+    methanation: 0.25
+    fuel_cell: 0.25
+    electrolysis: 0.25
   electricity_transmission_grid: true
   electricity_distribution_grid: true
   electricity_distribution_grid_cost_factor: 1.0

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,8 @@ Release Notes
 Upcoming Release
 ================
 
+* Allow for more conservative waste heat usage assumptions in district heating using a scaling factor for respective link efficiencies
+
 * In simplifying polygons in :mod:`build_shapes` default to no tolerance.
 
 * Set non-zero capital_cost for methanol stores to avoid unrealistic storage sizes

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -644,12 +644,12 @@ def update_config_from_wildcards(config, w, inplace=True):
             config["sector"]["H2_network"] = False
 
         if "nowasteheat" in opts:
-            config["sector"]["use_fischer_tropsch_waste_heat"] = False
-            config["sector"]["use_methanolisation_waste_heat"] = False
-            config["sector"]["use_haber_bosch_waste_heat"] = False
-            config["sector"]["use_methanation_waste_heat"] = False
-            config["sector"]["use_fuel_cell_waste_heat"] = False
-            config["sector"]["use_electrolysis_waste_heat"] = False
+            config["sector"]["use_waste_heat"]["fischer_tropsch"] = False
+            config["sector"]["use_waste_heat"]["methanolisation"] = False
+            config["sector"]["use_waste_heat"]["haber_bosch"] = False
+            config["sector"]["use_waste_heat"]["methanation"] = False
+            config["sector"]["use_waste_heat"]["fuel_cell"] = False
+            config["sector"]["use_waste_heat"]["electrolysis"] = False
 
         if "nodistrict" in opts:
             config["sector"]["district_heating"]["progress"] = 0.0

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3342,7 +3342,7 @@ def add_waste_heat(n):
 
         # TODO what is the 0.95 and should it be a config option?
         if (
-            options["use_fischer_tropsch_waste_heat"]
+            options["use_waste_heat"].get("fischer_tropsch", 1)
             and "Fischer-Tropsch" in link_carriers
         ):
             n.links.loc[urban_central + " Fischer-Tropsch", "bus3"] = (
@@ -3350,18 +3350,18 @@ def add_waste_heat(n):
             )
             n.links.loc[urban_central + " Fischer-Tropsch", "efficiency3"] = (
                 0.95 - n.links.loc[urban_central + " Fischer-Tropsch", "efficiency"]
-            ) * options["use_fischer_tropsch_waste_heat"]
+            ) * options["use_waste_heat"].get("fischer_tropsch", 1)
 
-        if options["use_methanation_waste_heat"] and "Sabatier" in link_carriers:
+        if options["use_waste_heat"].get("methanation", 1) and "Sabatier" in link_carriers:
             n.links.loc[urban_central + " Sabatier", "bus3"] = (
                 urban_central + " urban central heat"
             )
             n.links.loc[urban_central + " Sabatier", "efficiency3"] = (
                 0.95 - n.links.loc[urban_central + " Sabatier", "efficiency"]
-            )
+            )* options["use_waste_heat"].get("methanation", 1)
 
         # DEA quotes 15% of total input (11% of which are high-value heat)
-        if options["use_haber_bosch_waste_heat"] and "Haber-Bosch" in link_carriers:
+        if options["use_waste_heat"].get("haber_bosch", 1) and "Haber-Bosch" in link_carriers:
             n.links.loc[urban_central + " Haber-Bosch", "bus3"] = (
                 urban_central + " urban central heat"
             )
@@ -3375,10 +3375,10 @@ def add_waste_heat(n):
             )
             n.links.loc[urban_central + " Haber-Bosch", "efficiency3"] = (
                 0.15 * total_energy_input / electricity_input
-            )
+            )* options["use_waste_heat"].get("haber_bosch", 1)
 
         if (
-            options["use_methanolisation_waste_heat"]
+            options["use_waste_heat"].get("methanolisation", 1)
             and "methanolisation" in link_carriers
         ):
             n.links.loc[urban_central + " methanolisation", "bus4"] = (
@@ -3387,11 +3387,11 @@ def add_waste_heat(n):
             n.links.loc[urban_central + " methanolisation", "efficiency4"] = (
                 costs.at["methanolisation", "heat-output"]
                 / costs.at["methanolisation", "hydrogen-input"]
-            )
+            )* options["use_waste_heat"].get("methanolisation", 1)
 
         # TODO integrate usable waste heat efficiency into technology-data from DEA
         if (
-            options.get("use_electrolysis_waste_heat", False)
+           options["use_waste_heat"].get("electrolysis", 1)
             and "H2 Electrolysis" in link_carriers
         ):
             n.links.loc[urban_central + " H2 Electrolysis", "bus2"] = (
@@ -3399,15 +3399,15 @@ def add_waste_heat(n):
             )
             n.links.loc[urban_central + " H2 Electrolysis", "efficiency2"] = (
                 0.84 - n.links.loc[urban_central + " H2 Electrolysis", "efficiency"]
-            ) * options["use_electrolysis_waste_heat"]
+            ) * options["use_waste_heat"].get("electrolysis", 1)
 
-        if options["use_fuel_cell_waste_heat"] and "H2 Fuel Cell" in link_carriers:
+        if options["use_waste_heat"].get("fuel_cell", 1) and "H2 Fuel Cell" in link_carriers:
             n.links.loc[urban_central + " H2 Fuel Cell", "bus2"] = (
                 urban_central + " urban central heat"
             )
             n.links.loc[urban_central + " H2 Fuel Cell", "efficiency2"] = (
                 0.95 - n.links.loc[urban_central + " H2 Fuel Cell", "efficiency"]
-            )
+            )* options["use_waste_heat"].get("fuel_cell", 1)
 
 
 def add_agriculture(n, costs):

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3350,7 +3350,7 @@ def add_waste_heat(n):
             )
             n.links.loc[urban_central + " Fischer-Tropsch", "efficiency3"] = (
                 0.95 - n.links.loc[urban_central + " Fischer-Tropsch", "efficiency"]
-            )
+            ) * options["use_fischer_tropsch_waste_heat"]
 
         if options["use_methanation_waste_heat"] and "Sabatier" in link_carriers:
             n.links.loc[urban_central + " Sabatier", "bus3"] = (
@@ -3399,7 +3399,7 @@ def add_waste_heat(n):
             )
             n.links.loc[urban_central + " H2 Electrolysis", "efficiency2"] = (
                 0.84 - n.links.loc[urban_central + " H2 Electrolysis", "efficiency"]
-            )
+            ) * options["use_electrolysis_waste_heat"]
 
         if options["use_fuel_cell_waste_heat"] and "H2 Fuel Cell" in link_carriers:
             n.links.loc[urban_central + " H2 Fuel Cell", "bus2"] = (

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3352,16 +3352,22 @@ def add_waste_heat(n):
                 0.95 - n.links.loc[urban_central + " Fischer-Tropsch", "efficiency"]
             ) * options["use_waste_heat"].get("fischer_tropsch", 1)
 
-        if options["use_waste_heat"].get("methanation", 1) and "Sabatier" in link_carriers:
+        if (
+            options["use_waste_heat"].get("methanation", 1)
+            and "Sabatier" in link_carriers
+        ):
             n.links.loc[urban_central + " Sabatier", "bus3"] = (
                 urban_central + " urban central heat"
             )
             n.links.loc[urban_central + " Sabatier", "efficiency3"] = (
                 0.95 - n.links.loc[urban_central + " Sabatier", "efficiency"]
-            )* options["use_waste_heat"].get("methanation", 1)
+            ) * options["use_waste_heat"].get("methanation", 1)
 
         # DEA quotes 15% of total input (11% of which are high-value heat)
-        if options["use_waste_heat"].get("haber_bosch", 1) and "Haber-Bosch" in link_carriers:
+        if (
+            options["use_waste_heat"].get("haber_bosch", 1)
+            and "Haber-Bosch" in link_carriers
+        ):
             n.links.loc[urban_central + " Haber-Bosch", "bus3"] = (
                 urban_central + " urban central heat"
             )
@@ -3375,7 +3381,7 @@ def add_waste_heat(n):
             )
             n.links.loc[urban_central + " Haber-Bosch", "efficiency3"] = (
                 0.15 * total_energy_input / electricity_input
-            )* options["use_waste_heat"].get("haber_bosch", 1)
+            ) * options["use_waste_heat"].get("haber_bosch", 1)
 
         if (
             options["use_waste_heat"].get("methanolisation", 1)
@@ -3387,11 +3393,11 @@ def add_waste_heat(n):
             n.links.loc[urban_central + " methanolisation", "efficiency4"] = (
                 costs.at["methanolisation", "heat-output"]
                 / costs.at["methanolisation", "hydrogen-input"]
-            )* options["use_waste_heat"].get("methanolisation", 1)
+            ) * options["use_waste_heat"].get("methanolisation", 1)
 
         # TODO integrate usable waste heat efficiency into technology-data from DEA
         if (
-           options["use_waste_heat"].get("electrolysis", 1)
+            options["use_waste_heat"].get("electrolysis", 1)
             and "H2 Electrolysis" in link_carriers
         ):
             n.links.loc[urban_central + " H2 Electrolysis", "bus2"] = (
@@ -3401,13 +3407,16 @@ def add_waste_heat(n):
                 0.84 - n.links.loc[urban_central + " H2 Electrolysis", "efficiency"]
             ) * options["use_waste_heat"].get("electrolysis", 1)
 
-        if options["use_waste_heat"].get("fuel_cell", 1) and "H2 Fuel Cell" in link_carriers:
+        if (
+            options["use_waste_heat"].get("fuel_cell", 1)
+            and "H2 Fuel Cell" in link_carriers
+        ):
             n.links.loc[urban_central + " H2 Fuel Cell", "bus2"] = (
                 urban_central + " urban central heat"
             )
             n.links.loc[urban_central + " H2 Fuel Cell", "efficiency2"] = (
                 0.95 - n.links.loc[urban_central + " H2 Fuel Cell", "efficiency"]
-            )* options["use_waste_heat"].get("fuel_cell", 1)
+            ) * options["use_waste_heat"].get("fuel_cell", 1)
 
 
 def add_agriculture(n, costs):


### PR DESCRIPTION
The waste heat of Fischer-Tropsch synthesis and electrolyzers is dominating the urban central heat mix for planning horizons > 2030 (https://github.com/PyPSA/pypsa-ariadne/issues/114). This PR allows for the multiplication of the link efficiency by a float in order to make more conservative assumptions regarding the usage of this waste heat.
