### PR TITLE
Excluding Emissions from Sector Ratios Development

### DIFF
--- a/scripts/build_industry_sector_ratios_intermediate.py
+++ b/scripts/build_industry_sector_ratios_intermediate.py
@@ -63,6 +63,8 @@ def build_industry_sector_ratios_intermediate():
             today_sector_ratios_ct * (1 - fraction_future)
             + future_sector_ratios * fraction_future
         )
+        intermediate_sector_ratios[ct].loc["process emission"] = future_sector_ratios.loc["process emission"]
+        intermediate_sector_ratios[ct].loc["process emission from feedstock"] = future_sector_ratios.loc["process emission from feedstock"]
     intermediate_sector_ratios = pd.concat(intermediate_sector_ratios, axis=1)
 
     intermediate_sector_ratios.to_csv(snakemake.output.industry_sector_ratios)

--- a/scripts/build_industry_sector_ratios_intermediate.py
+++ b/scripts/build_industry_sector_ratios_intermediate.py
@@ -58,17 +58,12 @@ def build_industry_sector_ratios_intermediate():
         ]
         today_sector_ratios_ct.loc[:, ~missing_mask] = today_sector_ratios_ct.loc[
             :, ~missing_mask
-        ].fillna(0)
+        ].fillna(future_sector_ratios)
         intermediate_sector_ratios[ct] = (
             today_sector_ratios_ct * (1 - fraction_future)
             + future_sector_ratios * fraction_future
         )
-        intermediate_sector_ratios[ct].loc["process emission"] = (
-            future_sector_ratios.loc["process emission"]
-        )
-        intermediate_sector_ratios[ct].loc["process emission from feedstock"] = (
-            future_sector_ratios.loc["process emission from feedstock"]
-        )
+
     intermediate_sector_ratios = pd.concat(intermediate_sector_ratios, axis=1)
 
     intermediate_sector_ratios.to_csv(snakemake.output.industry_sector_ratios)

--- a/scripts/build_industry_sector_ratios_intermediate.py
+++ b/scripts/build_industry_sector_ratios_intermediate.py
@@ -63,8 +63,12 @@ def build_industry_sector_ratios_intermediate():
             today_sector_ratios_ct * (1 - fraction_future)
             + future_sector_ratios * fraction_future
         )
-        intermediate_sector_ratios[ct].loc["process emission"] = future_sector_ratios.loc["process emission"]
-        intermediate_sector_ratios[ct].loc["process emission from feedstock"] = future_sector_ratios.loc["process emission from feedstock"]
+        intermediate_sector_ratios[ct].loc["process emission"] = (
+            future_sector_ratios.loc["process emission"]
+        )
+        intermediate_sector_ratios[ct].loc["process emission from feedstock"] = (
+            future_sector_ratios.loc["process emission from feedstock"]
+        )
     intermediate_sector_ratios = pd.concat(intermediate_sector_ratios, axis=1)
 
     intermediate_sector_ratios.to_csv(snakemake.output.industry_sector_ratios)


### PR DESCRIPTION
Closes (https://github.com/PyPSA/pypsa-ariadne/issues/124)

## Changes proposed in this Pull Request
Currently a linear interpolation between current sector ratios and future sector ratios is assumed. However, in the current sector ratios, `process emission` and `process emission from feedstock` do not exist. Together with the config `sector_ratios_fraction_future`, this leads to 0 emissions in the industry sector in 2020 and a linear growth until 2045.

I assumed that the emissions in the industry currently are not going to magically disappear in 2020 and increase until 2045 so I set it to be constant.

![image](https://github.com/user-attachments/assets/d9221d73-11bf-44b5-bee3-e83fb7ae6c7f)


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
