### PR TITLE
Lifetime of Gas Pipelines

### DIFF
--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -89,10 +89,6 @@ def add_brownfield(n, n_p, year):
     # deal with gas network
     pipe_carrier = ["gas pipeline"]
     if snakemake.params.H2_retrofit:
-        # drop capacities of previous year to avoid duplicating
-        to_drop = n.links.carrier.isin(pipe_carrier) & (n.links.build_year != year)
-        n.mremove("Link", n.links.loc[to_drop].index)
-
         # subtract the already retrofitted from today's gas grid capacity
         h2_retrofitted_fixed_i = n.links[
             (n.links.carrier == "H2 pipeline retrofitted")
@@ -115,10 +111,6 @@ def add_brownfield(n, n_p, year):
             index=pipe_capacity.index
         ).fillna(0)
         n.links.loc[gas_pipes_i, "p_nom"] = remaining_capacity
-    else:
-        new_pipes = n.links.carrier.isin(pipe_carrier) & (n.links.build_year == year)
-        n.links.loc[new_pipes, "p_nom"] = 0.0
-        n.links.loc[new_pipes, "p_nom_min"] = 0.0
 
 
 def disable_grid_expansion_if_limit_hit(n):

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1259,7 +1259,7 @@ def add_storage_and_grids(n, costs):
             capital_cost=gas_pipes.capital_cost,
             tags=gas_pipes.name,
             carrier="gas pipeline",
-            lifetime=costs.at["CH4 (g) pipeline", "lifetime"],
+            lifetime=np.inf,
         )
 
         # remove fossil generators where there is neither

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1238,7 +1238,7 @@ def add_storage_and_grids(n, costs):
             gas_pipes["p_nom_min"] = 0.0
             # 0.1 EUR/MWkm/a to prefer decommissioning to address degeneracy
             gas_pipes["capital_cost"] = 0.1 * gas_pipes.length
-            gas_pipes["p_nom_extendable"] = True            
+            gas_pipes["p_nom_extendable"] = True
         else:
             gas_pipes["p_nom_max"] = np.inf
             gas_pipes["p_nom_min"] = gas_pipes.p_nom

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1238,12 +1238,14 @@ def add_storage_and_grids(n, costs):
             gas_pipes["p_nom_min"] = 0.0
             # 0.1 EUR/MWkm/a to prefer decommissioning to address degeneracy
             gas_pipes["capital_cost"] = 0.1 * gas_pipes.length
+            gas_pipes["p_nom_extendable"] = True            
         else:
             gas_pipes["p_nom_max"] = np.inf
             gas_pipes["p_nom_min"] = gas_pipes.p_nom
             gas_pipes["capital_cost"] = (
                 gas_pipes.length * costs.at["CH4 (g) pipeline", "fixed"]
             )
+            gas_pipes["p_nom_extendable"] = False
 
         n.madd(
             "Link",
@@ -1252,7 +1254,7 @@ def add_storage_and_grids(n, costs):
             bus1=gas_pipes.bus1 + " gas",
             p_min_pu=gas_pipes.p_min_pu,
             p_nom=gas_pipes.p_nom,
-            p_nom_extendable=True,
+            p_nom_extendable=gas_pipes.p_nom_extendable,
             p_nom_max=gas_pipes.p_nom_max,
             p_nom_min=gas_pipes.p_nom_min,
             length=gas_pipes.length,


### PR DESCRIPTION
Lifetime of gas pipelines is set to np.inf. This avoids adding new extendable links each planning_horizon which reduces the number of links tremendously.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
