### PR TITLE
Fix negative district heating progress

### DIFF
--- a/doc/configtables/sector.csv
+++ b/doc/configtables/sector.csv
@@ -5,7 +5,7 @@ biomass,--,"{true, false}",Flag to include biomass sector.
 industry,--,"{true, false}",Flag to include industry sector.
 agriculture,--,"{true, false}",Flag to include agriculture sector.
 district_heating,--,,`prepare_sector_network.py <https://github.com/PyPSA/pypsa-eur-sec/blob/master/scripts/prepare_sector_network.py>`_
--- potential,--,float,maximum fraction of urban demand which can be supplied by district heating
+-- potential,--,float,maximum fraction of urban demand which can be supplied by district heating. Ignored where below current fraction.
 -- progress,--,Dictionary with planning horizons as keys., Increase of today's district heating demand to potential maximum district heating share. Progress = 0 means today's district heating share. Progress = 1 means maximum fraction of urban demand is supplied by district heating
 -- district_heating_loss,--,float,Share increase in district heat demand in urban central due to heat losses
 cluster_heat_buses,--,"{true, false}",Cluster residential and service heat buses in `prepare_sector_network.py <https://github.com/PyPSA/pypsa-eur-sec/blob/master/scripts/prepare_sector_network.py>`_  to one to save memory.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -31,6 +31,8 @@ Upcoming Release
 
 * Bugfix: Correctly read in threshold capacity below which to remove components from previous planning horizons in :mod:`add_brownfield`.
 
+* Bugfix: Impose minimum value of zero for district heating progress between current and future market share in :mod:`build_district_heat_share`.
+
 PyPSA-Eur 0.11.0 (25th May 2024)
 =====================================
 

--- a/scripts/build_district_heat_share.py
+++ b/scripts/build_district_heat_share.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
     urban_fraction = pd.concat([urban_fraction, dist_fraction_node], axis=1).max(axis=1)
 
     # difference of max potential and today's share of district heating
-    diff = (urban_fraction * central_fraction) - dist_fraction_node
+    diff = ((urban_fraction * central_fraction) - dist_fraction_node).clip(lower=0)
     progress = get(
         snakemake.config["sector"]["district_heating"]["progress"], investment_year
     )


### PR DESCRIPTION
Currently, district heating progress, i.e. the evolution between current and future district heating market share can be negative if `potential` is set to a value smaller than the current district heating market share in the `config`.


Closes #1161 .

## Changes proposed in this Pull Request
This PR fixes this behaviour by applying a minimum progress of 0 in `build_district_heat_share.py`:
`diff = ((urban_fraction * central_fraction) - dist_fraction_node).clip(lower=0)`


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
