### PR TITLE
Add emissions and fuel consumption from fuel refinieries

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -711,6 +711,9 @@ industry:
   MWh_MeOH_per_tMeOH: 5.528
   hotmaps_locate_missing: false
   reference_year: 2015
+  fuel_refining:
+    oil:
+      emissions: 0.013
 
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#costs
@@ -1005,6 +1008,8 @@ plotting:
     gas pipeline new: '#a87c62'
     # oil
     oil: '#c9c9c9'
+    oil primary: '#d2d2d2'
+    oil refining: '#e6e6e6'
     imported oil: '#a3a3a3'
     oil boiler: '#adadad'
     residential rural oil boiler: '#a9a9a9'

--- a/doc/configtables/industry.csv
+++ b/doc/configtables/industry.csv
@@ -38,3 +38,4 @@ reference_year,year,YYYY,The year used as the baseline for industrial energy dem
 steam_biomass_fraction,--,float,The fraction of steam produced from biomass. The sum of all steam fractions should be 1.
 steam_hydrogen_fraction,--,float,The fraction of steam produced from hydrogen. The sum of all steam fractions should be 1.
 steam_electricity_fraction,--,float,The fraction of steam produced from electricity. The sum of all steam fractions should be 1.
+fuel_refining carrier emissions,tCO2/MWh,float,"The emissions from fuel processing (e.g. oil in petrochemical refinieries). The default value of 0.013 tCO2/MWh is based on DE statistics for 2019. The EU value is very similar. This is also used for energy losses to be consistent with CO2 loss."

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,8 @@ Release Notes
 Upcoming Release
 ================
 
+* Added `fuel_refining` option to the `industry` config. It allows to specify emissions from fuel processing (e.g. oil in petrochemical refinieries).
+
 * Added `overnight_cost` column to all components. These are the total upfront investments. The column is intended only for reporting and has no effect on the optimisation. For offshore wind, the `overnight_cost` column contains only investments into the wind park, the `connection_overnight_cost` is reported in a separate column.
 
 * New config ``industry: steam_biomass_fraction``, ``industry: steam_hydrogen_fraction``, ``industry: steam_electricity_fraction`` to specify the fraction of steam produced from biomass, hydrogen, and electricity, respectively. This is used to calculate custom industry sector ratios.

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3040,36 +3040,7 @@ def add_industry(n, costs):
             ],  # CO2 intensity methanol based on stoichiometric calculation with 22.7 GJ/t methanol (32 g/mol), CO2 (44 g/mol), 277.78 MWh/TJ = 0.218 t/MWh
         )
 
-    if "oil" not in n.buses.carrier.unique():
-        n.madd(
-            "Bus",
-            spatial.oil.nodes,
-            location=spatial.oil.locations,
-            carrier="oil",
-            unit="MWh_LHV",
-        )
-
-    if "oil" not in n.stores.carrier.unique():
-        # could correct to e.g. 0.001 EUR/kWh * annuity and O&M
-        n.madd(
-            "Store",
-            spatial.oil.nodes,
-            suffix=" Store",
-            bus=spatial.oil.nodes,
-            e_nom_extendable=True,
-            e_cyclic=True,
-            carrier="oil",
-        )
-
-    if "oil" not in n.generators.carrier.unique():
-        n.madd(
-            "Generator",
-            spatial.oil.nodes,
-            bus=spatial.oil.nodes,
-            p_nom_extendable=True,
-            carrier="oil",
-            marginal_cost=costs.at["oil", "fuel"],
-        )
+    add_carrier_buses(n, "oil")
 
     if shipping_oil_share:
         p_set_oil = shipping_oil_share * p_set.rename(lambda x: x + " shipping oil")

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -577,12 +577,41 @@ def add_carrier_buses(n, carrier, nodes=None):
         overnight_cost=overnight_cost,
     )
 
+    generator_nodes = nodes
+    generator_carrier = carrier
+
+    if carrier in cf_industry["fuel_refining"]:
+
+        n.madd(
+            "Bus",
+            nodes + " primary",
+            location=location,
+            carrier=carrier + " primary",
+            unit=unit,
+        )
+
+        n.madd(
+            "Link",
+            nodes + " refining",
+            bus0=nodes + " primary",
+            bus1=nodes,
+            bus2="co2 atmosphere",
+            location=location,
+            carrier=carrier + " refining",
+            p_nom=1e6,
+            efficiency=1 - (cf_industry["fuel_refining"][carrier]["emissions"] / costs.at[carrier, "CO2 intensity"]),
+            efficiency2=cf_industry["fuel_refining"][carrier]["emissions"],
+        )
+
+        generator_nodes = nodes + " primary"
+        generator_carrier = carrier + " primary"
+
     n.madd(
         "Generator",
-        nodes,
-        bus=nodes,
+        generator_nodes,
+        bus=generator_nodes,
         p_nom_extendable=True,
-        carrier=carrier,
+        carrier=generator_carrier,
         marginal_cost=costs.at[carrier, "fuel"],
     )
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Add option to add energy losses and emissions for fuel refining, e.g. for petrochemical refining of crude oil to oil products. The emissions are based on DE statistics for 2019, which are similar to EU on per-MWh basis. The emissions from refining then align with the final consumption of oil in each country. The energy losses are consistent with the CO2 emitted from the fuel.


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
