### PR TITLE
add option to use atlite to smooth wind turbine power curves

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -155,6 +155,7 @@ renewable:
     resource:
       method: wind
       turbine: Vestas_V112_3MW
+      smooth: true
       add_cutout_windspeed: true
     capacity_per_sqkm: 3
     # correction_factor: 0.93
@@ -174,6 +175,7 @@ renewable:
     resource:
       method: wind
       turbine: NREL_ReferenceTurbine_2020ATB_5.5MW
+      smooth: true
       add_cutout_windspeed: true
     capacity_per_sqkm: 2
     correction_factor: 0.8855
@@ -190,6 +192,7 @@ renewable:
     resource:
       method: wind
       turbine: NREL_ReferenceTurbine_2020ATB_5.5MW
+      smooth: true
       add_cutout_windspeed: true
     capacity_per_sqkm: 2
     correction_factor: 0.8855
@@ -206,6 +209,8 @@ renewable:
     resource:
       method: wind
       turbine: NREL_ReferenceTurbine_5MW_offshore
+      smooth: true
+      add_cutout_windspeed: true
     # ScholzPhd Tab 4.3.1: 10MW/km^2
     capacity_per_sqkm: 2
     correction_factor: 0.8855

--- a/doc/configtables/offwind-ac.csv
+++ b/doc/configtables/offwind-ac.csv
@@ -3,6 +3,7 @@ cutout,--,"Should be a folder listed in the configuration ``atlite: cutouts:`` (
 resource,,,
 -- method,--,"Must be 'wind'","A superordinate technology type."
 -- turbine,--,"One of turbine types included in `atlite <https://github.com/PyPSA/atlite/tree/master/atlite/resources/windturbine>`_.  Can be a string or a dictionary with years as keys which denote the year another turbine model becomes available.","Specifies the turbine type and its characteristic power curve."
+-- smooth,--,"{True, False}","Switch to apply a gaussian kernel density smoothing to the power curve."
 capacity_per_sqkm,:math:`MW/km^2`,float,"Allowable density of wind turbine placement."
 correction_factor,--,float,"Correction factor for capacity factor time series."
 excluder_resolution,m,float,"Resolution on which to perform geographical elibility analysis."

--- a/doc/configtables/offwind-dc.csv
+++ b/doc/configtables/offwind-dc.csv
@@ -3,6 +3,7 @@ cutout,--,"Should be a folder listed in the configuration ``atlite: cutouts:`` (
 resource,,,
 -- method,--,"Must be 'wind'","A superordinate technology type."
 -- turbine,--,"One of turbine types included in `atlite <https://github.com/PyPSA/atlite/tree/master/atlite/resources/windturbine>`_. Can be a string or a dictionary with years as keys which denote the year another turbine model becomes available.","Specifies the turbine type and its characteristic power curve."
+-- smooth,--,"{True, False}","Switch to apply a gaussian kernel density smoothing to the power curve."
 capacity_per_sqkm,:math:`MW/km^2`,float,"Allowable density of wind turbine placement."
 correction_factor,--,float,"Correction factor for capacity factor time series."
 excluder_resolution,m,float,"Resolution on which to perform geographical elibility analysis."

--- a/doc/configtables/onwind.csv
+++ b/doc/configtables/onwind.csv
@@ -3,6 +3,7 @@ cutout,--,"Should be a folder listed in the configuration ``atlite: cutouts:`` (
 resource,,,
 -- method,--,"Must be 'wind'","A superordinate technology type."
 -- turbine,--,"One of turbine types included in `atlite <https://github.com/PyPSA/atlite/tree/master/atlite/resources/windturbine>`_. Can be a string or a dictionary with years as keys which denote the year another turbine model becomes available.","Specifies the turbine type and its characteristic power curve."
+-- smooth,--,"{True, False}","Switch to apply a gaussian kernel density smoothing to the power curve."
 capacity_per_sqkm,:math:`MW/km^2`,float,"Allowable density of wind turbine placement."
 corine,,,
 -- grid_codes,--,"Any subset of the `CORINE Land Cover code list <http://www.eea.europa.eu/data-and-maps/data/corine-land-cover-2006-raster-1/corine-land-cover-classes-and/clc_legend.csv/at_download/file>`_","Specifies areas according to CORINE Land Cover codes which are generally eligible for wind turbine placement."

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,6 +9,9 @@ Release Notes
 
 Upcoming Release
 ================
+
+* Add option to apply a gaussian kernel density smoothing to wind turbine power curves.
+
 * Update JRC-IDEES-2015 to `JRC-IDEES-2021 <https://publications.jrc.ec.europa.eu/repository/handle/JRC137809>`__. The reference year is changed from 2015 to 2019.
 
 * Added unsustainable biomass potentials for solid, gaseous, and liquid biomass. The potentials can be phased-out and/or


### PR DESCRIPTION
- [ ] integrate rising hub height by year

### Effect

Will reduce our too high wind capacity factors.

### References

smoothing function in `atlite`: https://github.com/PyPSA/atlite/blob/55098dd838944ef17c7f99e6b4c8f1722987582f/atlite/resource.py#L212

https://essd.copernicus.org/articles/14/2749/2022/essd-14-2749-2022.pdf

![image](https://github.com/user-attachments/assets/da03aabf-d925-47a6-bbb2-c12468fbf12f)

Rising hub heights:

![image](https://github.com/user-attachments/assets/1356ff31-11b0-4929-be93-677a2cfe8ffd)

DEA has projected hub heights for onshore wind on p.229 https://ens.dk/sites/ens.dk/files/Analyser/technology_data_catalogue_for_el_and_dh.pdf
