### PR TITLE
use lower resolution EEZ shapes to reduce excessive RAM use

### DIFF
--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -92,7 +92,7 @@ rule build_shapes:
         countries=config_provider("countries"),
     input:
         naturalearth=ancient("data/naturalearth/ne_10m_admin_0_countries_deu.shp"),
-        eez=ancient("data/eez/World_EEZ_v12_20231025_gpkg/eez_v12.gpkg"),
+        eez=ancient("data/eez/World_EEZ_v12_20231025_LR/eez_v12_lowres.gpkg"),
         nuts3=ancient("data/bundle/NUTS_2013_60M_SH/data/NUTS_RG_60M_2013.shp"),
         nuts3pop=ancient("data/bundle/nama_10r_3popgdp.tsv.gz"),
         nuts3gdp=ancient("data/bundle/nama_10r_3gdp.tsv.gz"),

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -226,9 +226,9 @@ if config["enable"]["retrieve"]:
 
     rule retrieve_eez:
         params:
-            zip="data/eez/World_EEZ_v12_20231025_gpkg.zip",
+            zip="data/eez/World_EEZ_v12_20231025_LR.zip",
         output:
-            gpkg="data/eez/World_EEZ_v12_20231025_gpkg/eez_v12.gpkg",
+            gpkg="data/eez/World_EEZ_v12_20231025_LR/eez_v12_lowres.gpkg",
         run:
             import os
             import requests
@@ -239,7 +239,7 @@ if config["enable"]["retrieve"]:
 
             response = requests.post(
                 "https://www.marineregions.org/download_file.php",
-                params={"name": "World_EEZ_v12_20231025_gpkg.zip"},
+                params={"name": "World_EEZ_v12_20231025_LR.zip"},
                 data={
                     "name": name,
                     "organisation": org,


### PR DESCRIPTION
the resolution is still very good!

excessive RAM usage occurred when reading in PyPSA network shape components.

follow-up of #1188 