### PR TITLE
Fix simplify_network.py to handle more complex topologies

### DIFF
--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -298,13 +298,24 @@ def simplify_links(
     _, labels = connected_components(adjacency_matrix, directed=False)
     labels = pd.Series(labels, n.buses.index)
 
-    G = n.graph()
+    # Only span graph over the DC link components
+    G = n.graph(branch_components=["Link"])
 
     def split_links(nodes):
         nodes = frozenset(nodes)
 
         seen = set()
-        supernodes = {m for m in nodes if len(G.adj[m]) > 2 or (set(G.adj[m]) - nodes)}
+        
+        # Supernodes are endpoints of links, identified by having lass then two neighbours or being an AC Bus
+        # An example for the latter is if two different links are connected to the same AC bus.
+        supernodes = {
+            m
+            for m in nodes
+            if (
+                (len(G.adj[m]) < 2 or (set(G.adj[m]) - nodes))
+                or (n.buses.loc[m, "carrier"] == "AC")
+            )
+        }
 
         for u in supernodes:
             for m, ls in G.adj[u].items():

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -305,7 +305,7 @@ def simplify_links(
         nodes = frozenset(nodes)
 
         seen = set()
-        
+
         # Supernodes are endpoints of links, identified by having lass then two neighbours or being an AC Bus
         # An example for the latter is if two different links are connected to the same AC bus.
         supernodes = {


### PR DESCRIPTION
## Issue
- So far, ```simplify_network.py``` simplifies links by identifying so called "supernodes" (end points of links) and merging all components (e.g. converter-link-converter) to a simplified link. The components are then moved along, e.g. the simplified link is then directly connected to the neighbouring AC bus, to which the other components where previously connected to.
- For this purpose, a graph ```G``` was spanned over the entire network. In combination with how supernodes were identified, this leads to an issue in more complex network topologies (with PR https://github.com/PyPSA/pypsa-eur/pull/1079 and PR https://github.com/PyPSA/pypsa-eur/pull/1085/) , e.g. when two different links are connected to two neighbouring AC buses, separated by an AC line only. The function would try to locate all DC components (including erroneously the AC line, leading to a breaking error).

## Changes proposed in this Pull Request 
- (@p-glaum , @bobbyxng)
- In ```simplfy_links(...)```: Changed the graph to span over DC link components only
```
G = n.graph(branch_components=["Link"])
```

- In ```split_links(nodes)```: Change how supernodes (end points) are identified, i.e. having less then two neighbours or being an AC Bus. An example for the latter is if two different links are connected to the same AC bus.
```
supernodes = {
            m
            for m in nodes
            if (
                (len(G.adj[m]) < 2 or (set(G.adj[m]) - nodes))
                or (n.buses.loc[m, "carrier"] == "AC")
            )
        }
```

## Validation
I have tested the script up until and including rule ```solve_elec_networks```, yielding identical results. ```simplify_network.py``` yields the exact same output for the test case (entire European region):
```
INFO:pypsa.io:Imported network elec.nc has buses, carriers, generators, lines, links, loads, shapes, storage_units, transformers
INFO:__main__:Mapping all network lines onto a single 380kV layer
INFO:__main__:Simplifying connected link components
INFO:__main__:Joining the links 14808, 5575, 5586, 5582, 5587 connecting the buses 2383, 2379, 2380, 2381, 2382, 1377 to simple link 5586+4
INFO:__main__:Joining the links 5570, 5569 connecting the buses 5745, 8272, 5787 to simple link 5570+1
INFO:__main__:Joining the links 14822, 14827, 11679, 14810 connecting the buses 6398, 6366, 6365 to simple link 14822+1
INFO:__main__:Joining the links 14804, 8394 connecting the buses 5949, 6684, 6695 to simple link 14804+1
INFO:__main__:Displacing offwind-ac generator(s) and adding connection costs to capital_costs: 30427 Eur/MW/a for `2379 offwind-ac`, 34215 Eur/MW/a for `2380 offwind-ac`, 18506 Eur/MW/a for `2381 offwind-ac`, 11706 Eur/MW/a for `2382 offwind-ac` 
INFO:__main__:Removing stubs
INFO:__main__:Displacing offwind-ac generator(s) and adding connection costs to capital_costs: 43206 Eur/MW/a for `5741 offwind-ac`, 22699 Eur/MW/a for `5742 offwind-ac`, 23573 Eur/MW/a for `5743 offwind-ac`, 28142 Eur/MW/a for `5744 offwind-ac`, 32088 Eur/MW/a for `5745 offwind-ac`, 25896 Eur/MW/a for `5768 offwind-ac`, 27723 Eur/MW/a for `6300 offwind-ac` 
INFO:__main__:Displacing offwind-dc generator(s) and adding connection costs to capital_costs: 30234 Eur/MW/a for `5736 offwind-dc`, 28638 Eur/MW/a for `5737 offwind-dc`, 32184 Eur/MW/a for `5741 offwind-dc`, 16909 Eur/MW/a for `5742 offwind-dc`, 20966 Eur/MW/a for `5744 offwind-dc`, 23905 Eur/MW/a for `5745 offwind-dc`, 19293 Eur/MW/a for `5768 offwind-dc`, 20650 Eur/MW/a for `6300 offwind-dc` 
INFO:pyogrio._io:Created 3,606 records
INFO:pyogrio._io:Created 621 records
INFO:pypsa.io:Exported network elec_s.nc has generators, loads, lines, links, buses, carriers, shapes, storage_units
```


## Checklist
- [X] I tested my contribution locally and it seems to work fine.
- [X] Code and workflow changes are sufficiently documented.