### PR TITLE
Fix for Corsica in simplify_network: Include local substation

### DIFF
--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -306,12 +306,12 @@ def simplify_links(
 
         seen = set()
 
-         # Corsica substation
+        # Corsica substation
         node_corsica = find_closest_bus(
             n,
             x=9.44802,
             y=42.52842,
-            tol=2000    # Tolerance needed to only return the bus if the region is actually modelled
+            tol=2000,  # Tolerance needed to only return the bus if the region is actually modelled
         )
 
         # Supernodes are endpoints of links, identified by having lass then two neighbours or being an AC Bus
@@ -554,13 +554,18 @@ def find_closest_bus(n, x, y, tol=2000):
     """
     # Conversion factors
     meters_per_degree_lat = 111139  # Meters per degree of latitude
-    meters_per_degree_lon = 111139 * np.cos(np.radians(y))  # Meters per degree of longitude at the given latitude
+    meters_per_degree_lon = 111139 * np.cos(
+        np.radians(y)
+    )  # Meters per degree of longitude at the given latitude
 
     x0 = np.array(n.buses.x)
     y0 = np.array(n.buses.y)
 
     # Calculate distances in meters
-    dist = np.sqrt(((x - x0)*meters_per_degree_lon) ** 2 + ((y - y0)*meters_per_degree_lat) ** 2)
+    dist = np.sqrt(
+        ((x - x0) * meters_per_degree_lon) ** 2
+        + ((y - y0) * meters_per_degree_lat) ** 2
+    )
 
     # Find the closest bus within the tolerance
     min_dist = dist.min()

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -298,13 +298,24 @@ def simplify_links(
     _, labels = connected_components(adjacency_matrix, directed=False)
     labels = pd.Series(labels, n.buses.index)
 
-    G = n.graph()
+    # Only span graph over the DC link components
+    G = n.graph(branch_components=["Link"])
 
     def split_links(nodes):
         nodes = frozenset(nodes)
 
         seen = set()
-        supernodes = {m for m in nodes if len(G.adj[m]) > 2 or (set(G.adj[m]) - nodes)}
+        
+        # Supernodes are endpoints of links, identified by having lass then two neighbours or being an AC Bus
+        # An example for the latter is if two different links are connected to the same AC bus.
+        supernodes = {
+            m
+            for m in nodes
+            if (
+                (len(G.adj[m]) < 2 or (set(G.adj[m]) - nodes))
+                or (n.buses.loc[m, "carrier"] == "AC")
+            )
+        }
 
         for u in supernodes:
             for m, ls in G.adj[u].items():

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -305,7 +305,7 @@ def simplify_links(
         nodes = frozenset(nodes)
 
         seen = set()
-        
+
         # Supernodes are endpoints of links, identified by having lass then two neighbours or being an AC Bus
         # An example for the latter is if two different links are connected to the same AC bus.
         supernodes = {

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -306,6 +306,14 @@ def simplify_links(
 
         seen = set()
 
+         # Corsica substation
+        node_corsica = find_closest_bus(
+            n,
+            x=9.44802,
+            y=42.52842,
+            tol=2000    # Tolerance needed to only return the bus if the region is actually modelled
+        )
+
         # Supernodes are endpoints of links, identified by having lass then two neighbours or being an AC Bus
         # An example for the latter is if two different links are connected to the same AC bus.
         supernodes = {
@@ -314,6 +322,7 @@ def simplify_links(
             if (
                 (len(G.adj[m]) < 2 or (set(G.adj[m]) - nodes))
                 or (n.buses.loc[m, "carrier"] == "AC")
+                or (m == node_corsica)
             )
         }
 
@@ -528,6 +537,37 @@ def cluster(
     )
 
     return clustering.network, clustering.busmap
+
+
+def find_closest_bus(n, x, y, tol=2000):
+    """
+    Find the index of the closest bus to the given coordinates within a specified tolerance.
+    Parameters:
+        n (pypsa.Network): The network object.
+        x (float): The x-coordinate (longitude) of the target location.
+        y (float): The y-coordinate (latitude) of the target location.
+        tol (float): The distance tolerance in meters. Default is 2000 meters.
+
+    Returns:
+        int: The index of the closest bus to the target location within the tolerance.
+             Returns None if no bus is within the tolerance.
+    """
+    # Conversion factors
+    meters_per_degree_lat = 111139  # Meters per degree of latitude
+    meters_per_degree_lon = 111139 * np.cos(np.radians(y))  # Meters per degree of longitude at the given latitude
+
+    x0 = np.array(n.buses.x)
+    y0 = np.array(n.buses.y)
+
+    # Calculate distances in meters
+    dist = np.sqrt(((x - x0)*meters_per_degree_lon) ** 2 + ((y - y0)*meters_per_degree_lat) ** 2)
+
+    # Find the closest bus within the tolerance
+    min_dist = dist.min()
+    if min_dist <= tol:
+        return n.buses.index[dist.argmin()]
+    else:
+        return None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes # (if applicable).
Issue: https://github.com/PyPSA/pypsa-eur/issues/152

## Changes proposed in this Pull Request
- Identify the substation node on Corsica in the base network by geo coordinates and within a tolerance of 2000 meters. This makes the script compatible with the current ENTSO-map based network and PR https://github.com/PyPSA/pypsa-eur/pull/1079
- Add identified substation node to supernodes (end points), across which HVDC links are split (or not merged).

## Validation
ENTSO-E map (GridKit) based network - Before (without Corsica)
![gridkit](https://github.com/user-attachments/assets/b862b085-be2c-4ec9-a087-b5a94b9cfb30)

ENTSO-E map (GridKit) based network - After (with Corsica)
![gridkit_with_corsica](https://github.com/user-attachments/assets/86d51dea-19e0-44a8-90d0-16ee84556fcf)

OSM-based network - Before (without Corsica)
![osm](https://github.com/user-attachments/assets/c0888bfc-747e-467b-8849-83eb9308378f)

OSM-based network - After (with Corsica)
![osm_with_corsica](https://github.com/user-attachments/assets/e71bcbaf-1703-4c26-99c1-9fa4a6edd4c9)

## Checklist

- [X] I tested my contribution locally and it seems to work fine.
- [X] Code and workflow changes are sufficiently documented.

