### PR TITLE
Fixed PDF enconding in build_biomass_transport_cost with tabula-py update

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,6 +9,8 @@ Release Notes
 
 Upcoming Release
 ================
+* Fixed PDF encoding in ``build_biomass_transport_costs`` with update of tabula-py and jpype1
+
 * More modular and flexible handling of transmission projects. One can now add new transmission projects in a subfolder of `data/transmission projects` similar to the files in the template folder. After adding the new files and updating the config section `transmission_projects:`, transmission projects will be included if they are not duplicates of existing lines or other projects.
 
 * Add option to apply a gaussian kernel density smoothing to wind turbine power curves.

--- a/envs/environment.fixed.yaml
+++ b/envs/environment.fixed.yaml
@@ -391,7 +391,7 @@ dependencies:
 - stack_data=0.6.2
 - statsmodels=0.14.2
 - stopit=1.1.2
-- tabula-py=2.7.0
+- jpype1=1.5.0
 - tabulate=0.9.0
 - tbb=2021.11.0
 - tblib=3.0.0
@@ -466,3 +466,4 @@ dependencies:
   - snakemake-executor-plugin-slurm-jobstep==0.2.1
   - snakemake-storage-plugin-http==0.2.3
   - tsam==2.3.1
+  - tabula-py=2.9.3

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -43,7 +43,7 @@ dependencies:
 - geopy
 - tqdm
 - pytz
-- tabula-py
+- jpype1
 - pyxlsb
 - graphviz
 - pre-commit
@@ -63,3 +63,4 @@ dependencies:
   - snakemake-executor-plugin-slurm
   - snakemake-executor-plugin-cluster-generic
   - highspy
+  - tabula-py

--- a/scripts/build_biomass_transport_costs.py
+++ b/scripts/build_biomass_transport_costs.py
@@ -24,7 +24,7 @@ import tabula as tbl
 
 ENERGY_CONTENT = 4.8  # unit MWh/t (wood pellets)
 system = platform.system()
-encoding = "cp1252" if system == "Windows" else None
+encoding = "cp1252" if system == "Windows" else "utf-8"
 
 
 def get_countries():


### PR DESCRIPTION
While executing the workflow on the HPC cluster, there were recent issues reading PDF files with tabula-py, which were due to incorrect encoding of the PDFs. This PR solves the problem by modifying the environments.

1. The package tabula-py is installed in its latest version via pip instead of conda.
2. As an additional dependency of the new tabula-py version, jpype1 is installed with conda.
3. The update of tabula-py requires passing a string for the encoding parameter of the read_pdf() function. This was set to "utf-8", unless the script is executed on Windows machines. In the latter case, encoding remains "cp1252".


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] A release note `doc/release_notes.rst` is added.
