### PR TITLE
retrieve: remove cutout protection

### DIFF
--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -85,7 +85,7 @@ if config["enable"]["retrieve"] and config["enable"].get("retrieve_cutout", True
                 "https://zenodo.org/records/12791128/files/{cutout}.nc",
             ),
         output:
-            protected("cutouts/" + CDIR + "{cutout}.nc"),
+            "cutouts/" + CDIR + "{cutout}.nc",
         log:
             "logs/" + CDIR + "retrieve_cutout_{cutout}.log",
         resources:


### PR DESCRIPTION
As reported internally, in combination with the `retry: 2` this leads to very weird behavior when retriggered. The rule is executed -> throws a ProtectedOuputException -> deletes the cutout (because it could be corrupted) -> execute the rule a second time -> wait for input from storage which was in the meanwhile removed -> throws a missing output file error 

I would leave control fully to the configuration where we allow to enable/disable cutout retrieval.