### PR TITLE
fix bug in simplyfy network

### DIFF
--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -301,7 +301,7 @@ def simplify_links(
     # Only span graph over the DC link components
     G = n.graph(branch_components=["Link"])
 
-    def split_links(nodes, added_supernodes=None):
+    def split_links(nodes, added_supernodes):
         nodes = frozenset(nodes)
 
         seen = set()
@@ -363,7 +363,9 @@ def simplify_links(
         added_supernodes.append(node_corsica)
 
     for lbl in labels.value_counts().loc[lambda s: s > 2].index:
-        for b, buses, links in split_links(labels.index[labels == lbl]):
+        for b, buses, links in split_links(
+            labels.index[labels == lbl], added_supernodes
+        ):
             if len(buses) <= 2:
                 continue
 


### PR DESCRIPTION
In the last commit of the master, the PR #1221 was integrated. However, there is a bug related to the ``added_supernodes`` variable which is as default `None`. Then in the function ``split_links`` we check if ``m is in added_supernodes`` which leads to an error when ``added_supernodes`` is `None` :

```
{
	"name": "TypeError",
	"message": "argument of type 'NoneType' is not iterable",
	"stack": "---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[1], line 1
----> 1 \"A\" in None

TypeError: argument of type 'NoneType' is not iterable"
}
```


## Changes proposed in this Pull Request


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
