### PR TITLE
avoid infinity in sector rations

### DIFF
--- a/scripts/build_industry_sector_ratios_intermediate.py
+++ b/scripts/build_industry_sector_ratios_intermediate.py
@@ -79,8 +79,8 @@ with the following carriers are considered:
 Unit of the output file is MWh/t.
 """
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 from prepare_sector_network import get
 
 

--- a/scripts/build_industry_sector_ratios_intermediate.py
+++ b/scripts/build_industry_sector_ratios_intermediate.py
@@ -80,6 +80,7 @@ Unit of the output file is MWh/t.
 """
 
 import pandas as pd
+import numpy as np
 from prepare_sector_network import get
 
 
@@ -104,7 +105,7 @@ def build_industry_sector_ratios_intermediate():
         snakemake.input.industry_sector_ratios, index_col=0
     )
 
-    today_sector_ratios = demand.div(production, axis=1)
+    today_sector_ratios = demand.div(production, axis=1).replace([np.inf, -np.inf], 0)
 
     today_sector_ratios.dropna(how="all", axis=1, inplace=True)
 


### PR DESCRIPTION
Closes # (if applicable).
#1226
## Changes proposed in this Pull Request
replace infinity values in industry sector ratios caused by zero production by zero.
Thanks at @Timon-R !
## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
