### PR TITLE
build_electricity: raise memory for build_transmission_projects

### DIFF
--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -373,7 +373,7 @@ rule build_transmission_projects:
     benchmark:
         benchmarks("build_transmission_projects")
     resources:
-        mem_mb=2000,
+        mem_mb=4000,
     threads: 1
     conda:
         "../envs/environment.yaml"


### PR DESCRIPTION
2 GB RAM was not enough to avoid out-of-memory problems; raised to 4 GB.
