### PR TITLE
Follow-Up: Unsustainable Biomass

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -1114,6 +1114,7 @@ plotting:
     services rural biomass boiler: '#c6cf98'
     services urban decentral biomass boiler: '#dde5b5'
     biomass to liquid: '#32CD32'
+    unsustainable solid biomass: '#998622'
     unsustainable bioliquids: '#32CD32'
     electrobiofuels: 'red'
     BioSNG: '#123456'

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -340,7 +340,6 @@ rule build_heat_totals:
 rule build_biomass_potentials:
     params:
         biomass=config_provider("biomass"),
-        foresight=config_provider("foresight"),
     input:
         enspreso_biomass=storage(
             "https://zenodo.org/records/10356004/files/ENSPRESO_BIOMASS.xlsx",

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -340,6 +340,7 @@ rule build_heat_totals:
 rule build_biomass_potentials:
     params:
         biomass=config_provider("biomass"),
+        foresight=config_provider("foresight"),
     input:
         enspreso_biomass=storage(
             "https://zenodo.org/records/10356004/files/ENSPRESO_BIOMASS.xlsx",

--- a/scripts/build_biomass_potentials.py
+++ b/scripts/build_biomass_potentials.py
@@ -341,7 +341,7 @@ def add_unsustainable_potentials(df, foresight="overnight"):
     )
 
     share_sus = params.get("share_sustainable_potential_available").get(investment_year)
-    df *= share_sus
+    df.loc[df_wo_ch.index] *= share_sus
 
     df = df.join(df_wo_ch.filter(like="unsustainable")).fillna(0)
 

--- a/scripts/build_biomass_potentials.py
+++ b/scripts/build_biomass_potentials.py
@@ -251,7 +251,7 @@ def convert_nuts2_to_regions(bio_nuts2, regions):
     return bio_regions
 
 
-def add_unsustainable_potentials(df, foresight="overnight"):
+def add_unsustainable_potentials(df):
     """
     Add unsustainable biomass potentials to the given dataframe. The difference
     between the data of JRC and Eurostat is assumed to be unsustainable
@@ -269,15 +269,6 @@ def add_unsustainable_potentials(df, foresight="overnight"):
     pd.DataFrame
         The dataframe with added unsustainable biomass potentials.
     """
-    if foresight == "overnight":
-        df[
-            [
-                "unsustainable solid biomass",
-                "unsustainable biogas",
-                "unsustainable bioliquids",
-            ]
-        ] = 0
-        return df
     if "GB" in snakemake.config["countries"]:
         latest_year = 2019
     else:
@@ -407,7 +398,7 @@ if __name__ == "__main__":
     grouper = {v: k for k, vv in params["classes"].items() for v in vv}
     df = df.T.groupby(grouper).sum().T
 
-    df = add_unsustainable_potentials(df, foresight=snakemake.params.foresight)
+    df = add_unsustainable_potentials(df)
 
     df *= 1e6  # TWh/a to MWh/a
     df.index.name = "MWh/a"

--- a/scripts/build_biomass_potentials.py
+++ b/scripts/build_biomass_potentials.py
@@ -251,7 +251,7 @@ def convert_nuts2_to_regions(bio_nuts2, regions):
     return bio_regions
 
 
-def add_unsustainable_potentials(df):
+def add_unsustainable_potentials(df, foresight="overnight"):
     """
     Add unsustainable biomass potentials to the given dataframe. The difference
     between the data of JRC and Eurostat is assumed to be unsustainable
@@ -269,6 +269,15 @@ def add_unsustainable_potentials(df):
     pd.DataFrame
         The dataframe with added unsustainable biomass potentials.
     """
+    if foresight == "overnight":
+        df[
+            [
+                "unsustainable solid biomass",
+                "unsustainable biogas",
+                "unsustainable bioliquids",
+            ]
+        ] = 0
+        return df
     if "GB" in snakemake.config["countries"]:
         latest_year = 2019
     else:
@@ -347,8 +356,8 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "build_biomass_potentials",
             simpl="",
-            clusters="37",
-            planning_horizons=2020,
+            clusters="38",
+            planning_horizons=2050,
         )
 
     configure_logging(snakemake)
@@ -398,7 +407,7 @@ if __name__ == "__main__":
     grouper = {v: k for k, vv in params["classes"].items() for v in vv}
     df = df.T.groupby(grouper).sum().T
 
-    df = add_unsustainable_potentials(df)
+    df = add_unsustainable_potentials(df, foresight=snakemake.params.foresight)
 
     df *= 1e6  # TWh/a to MWh/a
     df.index.name = "MWh/a"

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -63,7 +63,8 @@ def define_spatial(nodes, options):
 
     if options.get("biomass_spatial", options["biomass_transport"]):
         spatial.biomass.nodes = nodes + " solid biomass"
-        spatial.biomass.bioliquids = nodes + " bioliquids"
+        spatial.biomass.nodes_unsustainable = nodes + " unsustainable solid biomass"
+        spatial.biomass.bioliquids = nodes + " unsustainable bioliquids"
         spatial.biomass.locations = nodes
         spatial.biomass.industry = nodes + " solid biomass for industry"
         spatial.biomass.industry_cc = nodes + " solid biomass for industry CC"
@@ -71,6 +72,7 @@ def define_spatial(nodes, options):
         spatial.msw.locations = nodes
     else:
         spatial.biomass.nodes = ["EU solid biomass"]
+        spatial.biomass.nodes_unsustainable = ["EU unsustainable solid biomass"]
         spatial.biomass.bioliquids = ["EU unsustainable bioliquids"]
         spatial.biomass.locations = ["EU"]
         spatial.biomass.industry = ["solid biomass for industry"]
@@ -2467,8 +2469,7 @@ def add_biomass(n, costs):
 
         n.madd(
             "Bus",
-            spatial.biomass.nodes,
-            suffix=" unsustainable",
+            spatial.biomass.nodes_unsustainable,
             location=spatial.biomass.locations,
             carrier="unsustainable solid biomass",
             unit="MWh_LHV",
@@ -2479,9 +2480,8 @@ def add_biomass(n, costs):
 
         n.madd(
             "Store",
-            spatial.biomass.nodes,
-            suffix=" unsustainable",
-            bus=spatial.biomass.nodes + " unsustainable",
+            spatial.biomass.nodes_unsustainable,
+            bus=spatial.biomass.nodes_unsustainable,
             carrier="unsustainable solid biomass",
             e_nom=unsustainable_solid_biomass_potentials_spatial,
             marginal_cost=costs.at["fuelwood", "fuel"],
@@ -2492,9 +2492,8 @@ def add_biomass(n, costs):
 
         n.madd(
             "Link",
-            spatial.biomass.nodes,
-            suffix=" unsustainable",
-            bus0=spatial.biomass.nodes + " unsustainable",
+            spatial.biomass.nodes_unsustainable,
+            bus0=spatial.biomass.nodes_unsustainable,
             bus1=spatial.biomass.nodes,
             carrier="unsustainable solid biomass",
             efficiency=1,
@@ -2517,7 +2516,6 @@ def add_biomass(n, costs):
         n.madd(
             "Store",
             spatial.biomass.bioliquids,
-            suffix=" unsustainable",
             bus=spatial.biomass.bioliquids,
             carrier="unsustainable bioliquids",
             e_nom=unsustainable_liquid_biofuel_potentials_spatial,
@@ -2658,9 +2656,8 @@ def add_biomass(n, costs):
         if biomass_potentials["unsustainable solid biomass"].sum() > 0:
             n.madd(
                 "Generator",
-                spatial.biomass.nodes,
-                suffix=" unsustainable",
-                bus=spatial.biomass.nodes + " unsustainable",
+                spatial.biomass.nodes_unsustainable,
+                bus=spatial.biomass.nodes_unsustainable,
                 carrier="unsustainable solid biomass",
                 p_nom=10000,
                 marginal_cost=costs.at["fuelwood", "fuel"]

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2639,6 +2639,7 @@ def add_biomass(n, costs):
             n.madd(
                 "Generator",
                 spatial.biomass.nodes,
+                suffix=" unsustainable",
                 bus=spatial.biomass.nodes,
                 carrier="unsustainable solid biomass",
                 p_nom=10000,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2632,9 +2632,27 @@ def add_biomass(n, costs):
             "biomass limit",
             carrier_attribute="solid biomass",
             sense="<=",
-            constant=biomass_potentials.filter(like="solid biomass").sum().sum(),
+            constant=biomass_potentials["solid biomass"].sum(),
             type="operational_limit",
         )
+        if biomass_potentials["unsustainable solid biomass"].sum() > 0:
+            n.madd(
+                "Generator",
+                spatial.biomass.nodes,
+                bus=spatial.biomass.nodes,
+                carrier="unsustainable solid biomass",
+                p_nom=10000,
+                marginal_cost=costs.at["fuelwood", "fuel"]
+                + bus_transport_costs * average_distance,
+            )
+            n.add(
+                "GlobalConstraint",
+                "unsustainable biomass limit",
+                carrier_attribute="unsustainable solid biomass",
+                sense="<=",
+                constant=biomass_potentials["unsustainable solid biomass"].sum(),
+                type="operational_limit",
+            )
 
         if options["municipal_solid_waste"]:
             # Add municipal solid waste
@@ -4251,7 +4269,7 @@ if __name__ == "__main__":
             clusters="38",
             ll="vopt",
             sector_opts="",
-            planning_horizons="2050",
+            planning_horizons="2030",
         )
 
     configure_logging(snakemake)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2474,6 +2474,9 @@ def add_biomass(n, costs):
             unit="MWh_LHV",
         )
 
+        e_max_pu = pd.DataFrame(1, index=n.snapshots, columns=spatial.biomass.nodes)
+        e_max_pu.iloc[-1] = 0
+
         n.madd(
             "Store",
             spatial.biomass.nodes,
@@ -2648,7 +2651,7 @@ def add_biomass(n, costs):
             "GlobalConstraint",
             "biomass limit",
             carrier_attribute="solid biomass",
-            sense="==",
+            sense="<=",
             constant=biomass_potentials["solid biomass"].sum(),
             type="operational_limit",
         )
@@ -2663,6 +2666,11 @@ def add_biomass(n, costs):
                 marginal_cost=costs.at["fuelwood", "fuel"]
                 + bus_transport_costs * average_distance,
             )
+            # Set last snapshot of e_max_pu for unsustainable solid biomass to 1 to make operational limit work
+            unsus_stores_idx = n.stores.loc[
+                n.stores.carrier == "unsustainable solid biomass"
+            ].index
+            n.stores_t.e_max_pu.loc[n.snapshots[-1], unsus_stores_idx] = 1
             n.add(
                 "GlobalConstraint",
                 "unsustainable biomass limit",

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -4286,12 +4286,7 @@ def add_enhanced_geothermal(n, egs_potentials, egs_overlap, costs):
 if __name__ == "__main__":
     if "snakemake" not in globals():
 
-        import os
-
         from _helpers import mock_snakemake
-
-        # Change directory to this script
-        os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
         snakemake = mock_snakemake(
             "prepare_sector_network",

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2507,6 +2507,8 @@ def add_biomass(n, costs):
             e_max_pu=e_max_pu,
         )
 
+        add_carrier_buses(n, "oil")
+
         n.madd(
             "Link",
             spatial.biomass.bioliquids,
@@ -2630,7 +2632,7 @@ def add_biomass(n, costs):
             "biomass limit",
             carrier_attribute="solid biomass",
             sense="<=",
-            constant=biomass_potentials["solid biomass"].sum(),
+            constant=biomass_potentials.filter(like="solid biomass").sum().sum(),
             type="operational_limit",
         )
 
@@ -4246,7 +4248,7 @@ if __name__ == "__main__":
             "prepare_sector_network",
             simpl="",
             opts="",
-            clusters="37",
+            clusters="38",
             ll="vopt",
             sector_opts="",
             planning_horizons="2050",


### PR DESCRIPTION
1. Using the unsustainable biomass potentials introduced in #1139, the model becomes infeasible for setups with spatially resolved biomass demand because no statistics are provided for Switzerland in the Eurostat data. Consequently, the country's unsustainable biomass potential cannot be determined and is set to zero. As a result, for networks with deactivated solid biomass transport and zero sustainable biomass potentials, there is no source to cover the unavoidable solid biomass load ("solid biomass for industry"). With this PR, the sustainable biomass potentials for Switzerland are retained in build_biomass_potentials, independent of the configuration setting biomass:share_sustainable_potential_available.
2. The global biomass constraint, which sets the biomass potentials as the upper bound for solid biomass usage in the model within prepare_sector_network, has been adjusted to include the unsustainable potentials.
3. In prepare_sector_network, oil buses are added when incorporating unsustainable bioliquids. Otherwise, there is a risk that the bioliquid-to-oil link may use undefined buses.
4. For overnight scenarios, the biomass potentials are adjusted to include only sustainable sources in build_biomass_potentials.
