### PR TITLE
Reduce retrofit potential in myopic optimization

### DIFF
--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -87,30 +87,42 @@ def add_brownfield(n, n_p, year):
             n.import_series_from_dataframe(c.pnl[tattr], c.name, tattr)
 
     # deal with gas network
-    pipe_carrier = ["gas pipeline"]
     if snakemake.params.H2_retrofit:
-        # subtract the already retrofitted from today's gas grid capacity
+        # subtract the already retrofitted from the maximum capacity
         h2_retrofitted_fixed_i = n.links[
             (n.links.carrier == "H2 pipeline retrofitted")
             & (n.links.build_year != year)
         ].index
-        gas_pipes_i = n.links[n.links.carrier.isin(pipe_carrier)].index
-        CH4_per_H2 = 1 / snakemake.params.H2_retrofit_capacity_per_CH4
-        fr = "H2 pipeline retrofitted"
-        to = "gas pipeline"
+        h2_retrofitted = n.links[(n.links.carrier=="H2 pipeline retrofitted") & 
+                                 (n.links.build_year == year)].index
+
         # today's pipe capacity
-        pipe_capacity = n.links.loc[gas_pipes_i, "p_nom"]
+        pipe_capacity = n.links.loc[h2_retrofitted, "p_nom_max"]
         # already retrofitted capacity from gas -> H2
         already_retrofitted = (
             n.links.loc[h2_retrofitted_fixed_i, "p_nom"]
-            .rename(lambda x: x.split("-2")[0].replace(fr, to) + f"-{year}")
+            .rename(lambda x: x.split("-2")[0] + f"-{year}")
             .groupby(level=0)
             .sum()
         )
-        remaining_capacity = pipe_capacity - CH4_per_H2 * already_retrofitted.reindex(
+        remaining_capacity = pipe_capacity - already_retrofitted.reindex(
             index=pipe_capacity.index
         ).fillna(0)
-        n.links.loc[gas_pipes_i, "p_nom"] = remaining_capacity
+        n.links.loc[h2_retrofitted, "p_nom_max"] = remaining_capacity
+
+        #reduce gas network capacity
+        gas_pipes_i = n.links[n.links.carrier=="gas pipeline"].index
+        if not gas_pipes_i.empty:
+            # subtract the already retrofitted from today's gas grid capacity
+            pipe_capacity = n.links.loc[gas_pipes_i, "p_nom"]
+            fr = "H2 pipeline retrofitted"
+            to = "gas pipeline"
+            CH4_per_H2 = 1 / snakemake.params.H2_retrofit_capacity_per_CH4
+            already_retrofitted.index = already_retrofitted.index.str.replace(fr, to)
+            remaining_capacity = pipe_capacity - CH4_per_H2 * already_retrofitted.reindex(
+            index=pipe_capacity.index
+            ).fillna(0)
+            n.links.loc[gas_pipes_i, "p_nom"] = remaining_capacity
 
 
 def disable_grid_expansion_if_limit_hit(n):

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -98,7 +98,8 @@ def add_brownfield(n, n_p, year):
             & (n.links.build_year == year)
         ].index
 
-        # today's pipe capacity
+        # pipe capacity always set in prepare_sector_network to todays gas grid capacity * H2_per_CH4
+        # and is therefore constant up to this point
         pipe_capacity = n.links.loc[h2_retrofitted, "p_nom_max"]
         # already retrofitted capacity from gas -> H2
         already_retrofitted = (
@@ -127,6 +128,7 @@ def add_brownfield(n, n_p, year):
                 * already_retrofitted.reindex(index=pipe_capacity.index).fillna(0)
             )
             n.links.loc[gas_pipes_i, "p_nom"] = remaining_capacity
+            n.links.loc[gas_pipes_i, "p_nom_max"] = remaining_capacity
 
 
 def disable_grid_expansion_if_limit_hit(n):

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -93,8 +93,10 @@ def add_brownfield(n, n_p, year):
             (n.links.carrier == "H2 pipeline retrofitted")
             & (n.links.build_year != year)
         ].index
-        h2_retrofitted = n.links[(n.links.carrier=="H2 pipeline retrofitted") & 
-                                 (n.links.build_year == year)].index
+        h2_retrofitted = n.links[
+            (n.links.carrier == "H2 pipeline retrofitted")
+            & (n.links.build_year == year)
+        ].index
 
         # today's pipe capacity
         pipe_capacity = n.links.loc[h2_retrofitted, "p_nom_max"]
@@ -110,8 +112,8 @@ def add_brownfield(n, n_p, year):
         ).fillna(0)
         n.links.loc[h2_retrofitted, "p_nom_max"] = remaining_capacity
 
-        #reduce gas network capacity
-        gas_pipes_i = n.links[n.links.carrier=="gas pipeline"].index
+        # reduce gas network capacity
+        gas_pipes_i = n.links[n.links.carrier == "gas pipeline"].index
         if not gas_pipes_i.empty:
             # subtract the already retrofitted from today's gas grid capacity
             pipe_capacity = n.links.loc[gas_pipes_i, "p_nom"]
@@ -119,9 +121,11 @@ def add_brownfield(n, n_p, year):
             to = "gas pipeline"
             CH4_per_H2 = 1 / snakemake.params.H2_retrofit_capacity_per_CH4
             already_retrofitted.index = already_retrofitted.index.str.replace(fr, to)
-            remaining_capacity = pipe_capacity - CH4_per_H2 * already_retrofitted.reindex(
-            index=pipe_capacity.index
-            ).fillna(0)
+            remaining_capacity = (
+                pipe_capacity
+                - CH4_per_H2
+                * already_retrofitted.reindex(index=pipe_capacity.index).fillna(0)
+            )
             n.links.loc[gas_pipes_i, "p_nom"] = remaining_capacity
 
 


### PR DESCRIPTION
Closes https://github.com/PyPSA/pypsa-eur/issues/1240.

## Changes proposed in this Pull Request
The reduction of retrofitting of the gas grid to hydrogen is now more robust.
In `prepare_sector_network` the original capacity of a gas connection is written into `p_nom_max` of the `gas pipeline` and `H2 pipeline retrofitted`. However, in a myopic optimization, this capacity is/can be reduced from baseyear to baseyear.
So far the capacity of the retrofitting potential was not decreased if the gas network is not explicitly modeled.
This PR closes that gap.

## Check
The `p_nom_max` of a `H2 pipeline retrofitted` link plus the already retrofitted capacity should be constant over a myopic optimization. Also the `p_nom` of the corresponding gas pipeline should be reduced to match the equivalent capacity of the `p_nom_max` value.

![image](https://github.com/user-attachments/assets/0e924ce6-23ae-4666-9098-e2007f710d01)

```
# myopic optimization [2020, 2030, 2040, 2050] since H2 retrofit is allowed from 2030 on, code gets easier
year = 2040 
CH4_per_H2 = 0.6
# already retrofitted
h2_retrofitted_fixed_i = n.links[
    (n.links.carrier == "H2 pipeline retrofitted")
    & (n.links.build_year != year)
].index
h2_retrofitted = n.links[(n.links.carrier=="H2 pipeline retrofitted") & 
                         (n.links.build_year == year)].index

potential = n.links.loc[h2_retrofitted].p_nom_max
already_retro = n.links.loc[h2_retrofitted_fixed_i].p_nom

# gas pipelines
gas_index = potential.index.str[:-5]
gas_index = gas_index.str.replace("H2 pipeline retrofitted", "gas pipeline")
gas_cap = n.links.loc[gas_index].p_nom*CH4_per_H2

# plotting
potential.index = potential.index.str.replace("H2 pipeline retrofitted ", "")
potential.index = potential.index.str[:-5]
already_retro.index = already_retro.index.str.replace("H2 pipeline retrofitted ", "")
already_retro.index = already_retro.index.str[:-5]
gas_cap.index = gas_cap.index.str.replace("gas pipeline ","")

df = pd.concat([-gas_cap, potential, already_retro], axis=1)
df = df.fillna(0)
df.columns = ['gas', 'H2 retro potential', 'H2 retro']
df.plot.bar(stacked=True)
```

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
