### PR TITLE
Make overdimensioning factor for heating systems specific to central/decentral heating

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -590,7 +590,7 @@ sector:
   resistive_heaters: true
   oil_boilers: false
   biomass_boiler: true
-  overdimension_heat_generators: 
+  overdimension_heat_generators:
     decentral: 1.1  #to cover demand peaks bigger than data
     central: 1.0
   chp: true

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -590,7 +590,9 @@ sector:
   resistive_heaters: true
   oil_boilers: false
   biomass_boiler: true
-  overdimension_individual_heating: 1.1  #to cover demand peaks bigger than data
+  overdimension_heat_generators: 
+    decentral: 1.1  #to cover demand peaks bigger than data
+    central: 1.0
   chp: true
   micro_chp: false
   solar_thermal: true

--- a/doc/configtables/sector.csv
+++ b/doc/configtables/sector.csv
@@ -89,7 +89,9 @@ boilers,--,"{true, false}",Add option for transforming gas into heat using gas b
 resistive_heaters,--,"{true, false}",Add option for transforming electricity into heat using resistive heaters (independently from gas boilers)
 oil_boilers,--,"{true, false}",Add option for transforming oil into heat using boilers
 biomass_boiler,--,"{true, false}",Add option for transforming biomass into heat using boilers
-overdimension_individual_heating,--,float,Add option for overdimensioning individual heating systems by a certain factor. This allows them to cover heat demand peaks e.g. 10% higher than those in the data with a setting of 1.1.
+overdimension_heat_generators,,,Add option for overdimensioning heating systems by a certain factor. This allows them to cover heat demand peaks e.g. 10% higher than those in the data with a setting of 1.1.
+-- decentral,--,float,The factor for overdimensioning (increasing CAPEX) decentral heating systems
+-- central,--,float,The factor for overdimensioning (increasing CAPEX) central heating systems
 chp,--,"{true, false}",Add option for using Combined Heat and Power (CHP)
 micro_chp,--,"{true, false}",Add option for using Combined Heat and Power (CHP) for decentral areas.
 solar_thermal,--,"{true, false}",Add option for using solar thermal to generate heat.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,7 @@ Release Notes
 .. Upcoming Release
 .. ================
 
+* Made the overdimensioning factor for heating systems specific for central/decentral heating, defaults to no overdimensionining for central heating and no changes to decentral heating compared to previous version.
 * bugfix: The oil generator was incorrectly dropped when the config `oil_refining_emissions` was greater than zero. This was the default behaviour in 0.12.0.
 
 PyPSA-Eur 0.12.0 (30th August 2024)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1875,7 +1875,6 @@ def add_heat(n: pypsa.Network, costs: pd.DataFrame, cop: xr.DataArray):
 
     heat_demand = build_heat_demand(n)
 
-
     district_heat_info = pd.read_csv(snakemake.input.district_heat_share, index_col=0)
     dist_fraction = district_heat_info["district fraction of node"]
     urban_fraction = district_heat_info["urban fraction"]
@@ -1904,7 +1903,9 @@ def add_heat(n: pypsa.Network, costs: pd.DataFrame, cop: xr.DataArray):
         HeatSystem
     ):  # this loops through all heat systems defined in _entities.HeatSystem
 
-        overdim_factor = options["overdimension_heat_generators"][heat_system.central_or_decentral]
+        overdim_factor = options["overdimension_heat_generators"][
+            heat_system.central_or_decentral
+        ]
         if heat_system == HeatSystem.URBAN_CENTRAL:
             nodes = dist_fraction.index[dist_fraction > 0]
         else:
@@ -2753,7 +2754,9 @@ def add_biomass(n, costs):
                 efficiency=costs.at["biomass boiler", "efficiency"],
                 capital_cost=costs.at["biomass boiler", "efficiency"]
                 * costs.at["biomass boiler", "fixed"]
-                * options["overdimension_heat_generators"][HeatSystem(name).central_or_decentral],
+                * options["overdimension_heat_generators"][
+                    HeatSystem(name).central_or_decentral
+                ],
                 marginal_cost=costs.at["biomass boiler", "pelletizing cost"],
                 lifetime=costs.at["biomass boiler", "lifetime"],
             )

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3278,7 +3278,7 @@ def add_industry(n, costs):
                     efficiency2=costs.at["oil", "CO2 intensity"],
                     capital_cost=costs.at["decentral oil boiler", "efficiency"]
                     * costs.at["decentral oil boiler", "fixed"]
-                    * overdim_factor,
+                    * options["overdimension_heat_generators"][heat_system.central_or_decentral],
                     lifetime=costs.at["decentral oil boiler", "lifetime"],
                 )
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3278,7 +3278,9 @@ def add_industry(n, costs):
                     efficiency2=costs.at["oil", "CO2 intensity"],
                     capital_cost=costs.at["decentral oil boiler", "efficiency"]
                     * costs.at["decentral oil boiler", "fixed"]
-                    * options["overdimension_heat_generators"][heat_system.central_or_decentral],
+                    * options["overdimension_heat_generators"][
+                        heat_system.central_or_decentral
+                    ],
                     lifetime=costs.at["decentral oil boiler", "lifetime"],
                 )
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1875,7 +1875,6 @@ def add_heat(n: pypsa.Network, costs: pd.DataFrame, cop: xr.DataArray):
 
     heat_demand = build_heat_demand(n)
 
-    overdim_factor = options["overdimension_individual_heating"]
 
     district_heat_info = pd.read_csv(snakemake.input.district_heat_share, index_col=0)
     dist_fraction = district_heat_info["district fraction of node"]
@@ -1905,6 +1904,7 @@ def add_heat(n: pypsa.Network, costs: pd.DataFrame, cop: xr.DataArray):
         HeatSystem
     ):  # this loops through all heat systems defined in _entities.HeatSystem
 
+        overdim_factor = options["overdimension_heat_generators"][heat_system.central_or_decentral]
         if heat_system == HeatSystem.URBAN_CENTRAL:
             nodes = dist_fraction.index[dist_fraction > 0]
         else:
@@ -2753,7 +2753,7 @@ def add_biomass(n, costs):
                 efficiency=costs.at["biomass boiler", "efficiency"],
                 capital_cost=costs.at["biomass boiler", "efficiency"]
                 * costs.at["biomass boiler", "fixed"]
-                * options["overdimension_individual_heating"],
+                * options["overdimension_heat_generators"][HeatSystem(name).central_or_decentral],
                 marginal_cost=costs.at["biomass boiler", "pelletizing cost"],
                 lifetime=costs.at["biomass boiler", "lifetime"],
             )
@@ -3275,7 +3275,7 @@ def add_industry(n, costs):
                     efficiency2=costs.at["oil", "CO2 intensity"],
                     capital_cost=costs.at["decentral oil boiler", "efficiency"]
                     * costs.at["decentral oil boiler", "fixed"]
-                    * options["overdimension_individual_heating"],
+                    * overdim_factor,
                     lifetime=costs.at["decentral oil boiler", "lifetime"],
                 )
 


### PR DESCRIPTION
Currently, the factor `overdimension_individual_heating = 1.1` is applied to both central and decentral heating for adequate investment decisions at heat demand above model input. This disadvantages CAPEX-heavy technologies like heat pumps and is probably not necessary, at least for central heating, due to heat storage and the possibility to invest in inexpensive boilers.

## Changes proposed in this Pull Request
- The config setting `sector/overdimension_individual_heating` is renamed to `sector/overdimension_heat_generators` made heat-system specific allowing to set different values for central and decentral heating:
```
 overdimension_heat_generators: 
    decentral: 1.1  #to cover demand peaks bigger than data
    central: 1.0
```
- It defaults to 10% overdimensioning for decentral and none for central heating

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.


## Testing
In a simple test case (Germany, 1 node)
```
scenario:
  clusters:
  - 1
  planning_horizons:
  - 2030
countries: ['DE']
```

Urban central heat mix increases in favour of heat pumps:

Master:
![image](https://github.com/user-attachments/assets/910ce761-31cd-4e5f-9648-496b5765ff01)

Feature:
![image](https://github.com/user-attachments/assets/91b8e7a5-77aa-4a7c-a03a-570fde9d6aab)
