### PR TITLE
prepare_sector_network: fix e_max_pu in unsustainable biomass stores

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2503,7 +2503,9 @@ def add_biomass(n, costs):
             unit="MWh_LHV",
         )
 
-        e_max_pu = pd.DataFrame(1, index=n.snapshots, columns=spatial.biomass.nodes)
+        e_max_pu = pd.DataFrame(
+            1, index=n.snapshots, columns=spatial.biomass.nodes_unsustainable
+        )
         e_max_pu.iloc[-1] = 0
 
         n.madd(
@@ -2694,9 +2696,12 @@ def add_biomass(n, costs):
                 + bus_transport_costs * average_distance,
             )
             # Set last snapshot of e_max_pu for unsustainable solid biomass to 1 to make operational limit work
-            unsus_stores_idx = n.stores.loc[
-                n.stores.carrier == "unsustainable solid biomass"
-            ].index
+            unsus_stores_idx = n.stores.query(
+                "carrier == 'unsustainable solid biomass'"
+            ).index
+            unsus_stores_idx = unsus_stores_idx.intersection(
+                n.stores_t.e_max_pu.columns
+            )
             n.stores_t.e_max_pu.loc[n.snapshots[-1], unsus_stores_idx] = 1
             n.add(
                 "GlobalConstraint",


### PR DESCRIPTION
Fixes the time series handling of e_max_pu in for unsustainable biomass stores

## Changes proposed in this Pull Request


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
