### PR TITLE
Fix mocksnakemake

### DIFF
--- a/scripts/definitions/heat_system.py
+++ b/scripts/definitions/heat_system.py
@@ -5,8 +5,8 @@
 
 from enum import Enum
 
-from scripts.definitions.heat_sector import HeatSector
-from scripts.definitions.heat_system_type import HeatSystemType
+from definitions.heat_sector import HeatSector
+from definitions.heat_system_type import HeatSystemType
 
 
 class HeatSystem(Enum):


### PR DESCRIPTION
Mocksnakemake is not working since in `heat_system.py` the `from scripts.definitions.heat_sector import HeatSector` command is not working.
By removing the `scripts.` both the snakemake workflow and mocksnakemake are working again.

## Checklist
Since it's a minor bugfix, no major testing necessary.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
