### PR TITLE
Simplify integration of unsustainable solid biomass

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
 - pip
 
 - atlite>=0.2.9
-- pypsa>=0.29
+- pypsa>=0.30.2
 - linopy
 - dask
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2477,7 +2477,6 @@ def add_biomass(n, costs):
         )
 
     if biomass_potentials.filter(like="unsustainable").sum().sum() > 0:
-        add_carrier_buses(n, "oil")
         # Create timeseries to force usage of unsustainable potentials
         e_max_pu = pd.DataFrame(1, index=n.snapshots, columns=spatial.gas.biogas)
         e_max_pu.iloc[-1] = 0

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2495,14 +2495,6 @@ def add_biomass(n, costs):
             e_max_pu=e_max_pu,
         )
 
-        n.madd(
-            "Bus",
-            spatial.biomass.nodes_unsustainable,
-            location=spatial.biomass.locations,
-            carrier="unsustainable solid biomass",
-            unit="MWh_LHV",
-        )
-
         e_max_pu = pd.DataFrame(
             1, index=n.snapshots, columns=spatial.biomass.nodes_unsustainable
         )
@@ -2511,23 +2503,13 @@ def add_biomass(n, costs):
         n.madd(
             "Store",
             spatial.biomass.nodes_unsustainable,
-            bus=spatial.biomass.nodes_unsustainable,
+            bus=spatial.biomass.nodes,
             carrier="unsustainable solid biomass",
             e_nom=unsustainable_solid_biomass_potentials_spatial,
             marginal_cost=costs.at["fuelwood", "fuel"],
             e_initial=unsustainable_solid_biomass_potentials_spatial,
             e_nom_extendable=False,
             e_max_pu=e_max_pu,
-        )
-
-        n.madd(
-            "Link",
-            spatial.biomass.nodes_unsustainable,
-            bus0=spatial.biomass.nodes_unsustainable,
-            bus1=spatial.biomass.nodes,
-            carrier="unsustainable solid biomass",
-            efficiency=1,
-            p_nom=unsustainable_solid_biomass_potentials_spatial,
         )
 
         n.madd(
@@ -2689,7 +2671,7 @@ def add_biomass(n, costs):
             n.madd(
                 "Generator",
                 spatial.biomass.nodes_unsustainable,
-                bus=spatial.biomass.nodes_unsustainable,
+                bus=spatial.biomass.nodes,
                 carrier="unsustainable solid biomass",
                 p_nom=10000,
                 marginal_cost=costs.at["fuelwood", "fuel"]


### PR DESCRIPTION
This PR attaches the Store for unsustainable solid biomass directly to the (sustainable) solid biomass nodes, eliminating the need for an extra Bus and Link component. This change is enabled by the new operational limit definition of the GlobalConstraint component, addressed in [PyPSA PR #1029](https://github.com/PyPSA/PyPSA/pull/1029). Therefore, some changes introduced in #1254 are now obsolete.
