### PR TITLE
fix: connection check failing

### DIFF
--- a/rules/common.smk
+++ b/rules/common.smk
@@ -115,20 +115,26 @@ def input_custom_extra_functionality(w):
     return []
 
 
-# Check if the workflow has access to the internet by trying to access the HEAD of specified url
-def has_internet_access(url="www.zenodo.org") -> bool:
-    import http.client as http_client
+def has_internet_access(url: str = "https://www.zenodo.org", timeout: int = 3) -> bool:
+    """
+    Checks if internet connection is available by sending a HEAD request
+    to a reliable server like Google.
 
-    # based on answer and comments from
-    # https://stackoverflow.com/a/29854274/11318472
-    conn = http_client.HTTPConnection(url, timeout=5)  # need access to zenodo anyway
+    Parameters:
+    - url (str): The URL to check for internet connection. Default is Google.
+    - timeout (int | float): The maximum time (in seconds) the request should wait.
+
+    Returns:
+    - bool: True if the internet is available, otherwise False.
+    """
     try:
-        conn.request("HEAD", "/")
-        return True
-    except:
+        # Send a HEAD request to avoid fetching full response
+        response = requests.head(url, timeout=timeout, allow_redirects=True)
+        return response.status_code == 200
+    except requests.ConnectionError:  # (e.g., no internet, DNS issues)
         return False
-    finally:
-        conn.close()
+    except requests.Timeout:  # (e.g., slow or no network)
+        return False
 
 
 def solved_previous_horizon(w):


### PR DESCRIPTION
## Changes proposed in this Pull Request
- fixes bug where `retrieve.enable: auto` reported no internet connection, even if connection was available (z1)
- I think low level `http` doesn't handle proxies or port 53 is blocked for dns
- use `requests` instead which is more robust

## Checklist

- [x] I tested my contribution locally and it seems to work fine.