### PR TITLE
Updated osm-prebuilt network to v0.4 and added version control to config

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -88,6 +88,7 @@ co2_budget:
 electricity:
   voltages: [200., 220., 300., 380., 500., 750.]
   base_network: osm-prebuilt
+  osm-prebuilt-version: 0.4
   gaslimit_enable: false
   gaslimit: false
   co2limit_enable: false

--- a/doc/configtables/electricity.csv
+++ b/doc/configtables/electricity.csv
@@ -1,6 +1,7 @@
 ,Unit,Values,Description
 voltages,kV,"Any subset of {200., 220., 300., 380., 500., 750.}",Voltage levels to consider
 base_network, --, "Any value in {'entsoegridkit', 'osm-prebuilt', 'osm-raw}", "Specify the underlying base network, i.e. GridKit (based on ENTSO-E web map extract, OpenStreetMap (OSM) prebuilt or raw (built from raw OSM data), takes longer."
+osm-prebuilt-version, --, "float, any value in range 0.1-0.4", "Choose the version of the prebuilt OSM network. Defaults to latest Zenodo release."
 gaslimit_enable,bool,true or false,Add an overall absolute gas limit configured in ``electricity: gaslimit``.
 gaslimit,MWhth,float or false,Global gas usage limit
 co2limit_enable,bool,true or false,Add an overall absolute carbon-dioxide emissions limit configured in ``electricity: co2limit`` in :mod:`prepare_network`. **Warning:** This option should currently only be used with electricity-only networks, not for sector-coupled networks..

--- a/doc/data_sources.rst
+++ b/doc/data_sources.rst
@@ -299,10 +299,10 @@ Data in this section is retrieved and extracted in rules specified in ``rules/re
 ``data/osm-prebuilt``
 
 - **Source:** OpenStreetMap; Xiong, B., Neumann, F., & Brown, T. (2024).
-  Prebuilt Electricity Network for PyPSA-Eur based on OpenStreetMap Data (0.3)
-  [Data set]. Zenodo. https://doi.org/10.5281/zenodo.13358976
-- **Link:** https://zenodo.org/records/13358976
-- **License:** ODbL (`reference <https://zenodo.org/records/13358976>`)
+  Prebuilt Electricity Network for PyPSA-Eur based on OpenStreetMap Data (0.4)
+  [Data set]. Zenodo. https://doi.org/10.5281/zenodo.13759222
+- **Link:** https://zenodo.org/records/13759222
+- **License:** ODbL (`reference <https://zenodo.org/records/13759222>`)
 - **Description:** Pre-built data of high-voltage transmission grid in Europe from OpenStreetMap.
 
 ``data/osm-raw``

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -32,6 +32,10 @@ Release Notes
 
 * The sources of nearly all data files are now listed in the documentation.
 
+* Updated osm-prebuilt network to version 0.4: https://doi.org/10.5281/zenodo.13759222 : Added Kosovo (XK) as dedicated region. Fixed major 330 kV line in Moldova (MD) (https://www.openstreetmap.org/way/33360284).
+
+* Add version control to osm-prebuilt: `config["electricity"]["osm-prebuilt-version"]`. Defaults to latest Zenodo release, i.e. v0.4, Config is only considered when selecting `osm-prebuilt` as `base_network`.
+
 PyPSA-Eur 0.12.0 (30th August 2024)
 ===================================
 

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -52,12 +52,14 @@ rule build_powerplants:
 
 def input_base_network(w):
     base_network = config_provider("electricity", "base_network")(w)
+    osm_prebuilt_version = config_provider("electricity", "osm-prebuilt-version")(w)
     components = {"buses", "lines", "links", "converters", "transformers"}
     if base_network == "osm-raw":
         inputs = {c: resources(f"osm-raw/build/{c}.csv") for c in components}
-    else:
-        inputs = {c: f"data/{base_network}/{c}.csv" for c in components}
-    if base_network == "entsoegridkit":
+    elif base_network == "osm-prebuilt":
+        inputs = {c: f"data/{base_network}/{osm_prebuilt_version}/{c}.csv" for c in components}
+    elif base_network == "entsoegridkit":
+        inputs= {c: f"data/{base_network}/{c}.csv" for c in components}
         inputs["parameter_corrections"] = "data/parameter_corrections.yaml"
         inputs["links_p_nom"] = "data/links_p_nom.csv"
     return inputs

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -57,9 +57,11 @@ def input_base_network(w):
     if base_network == "osm-raw":
         inputs = {c: resources(f"osm-raw/build/{c}.csv") for c in components}
     elif base_network == "osm-prebuilt":
-        inputs = {c: f"data/{base_network}/{osm_prebuilt_version}/{c}.csv" for c in components}
+        inputs = {
+            c: f"data/{base_network}/{osm_prebuilt_version}/{c}.csv" for c in components
+        }
     elif base_network == "entsoegridkit":
-        inputs= {c: f"data/{base_network}/{c}.csv" for c in components}
+        inputs = {c: f"data/{base_network}/{c}.csv" for c in components}
         inputs["parameter_corrections"] = "data/parameter_corrections.yaml"
         inputs["links_p_nom"] = "data/links_p_nom.csv"
     return inputs

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -545,11 +545,21 @@ if config["enable"]["retrieve"] and (
     # update rule to use the correct version
     rule retrieve_osm_prebuilt:
         input:
-            buses=storage(f"https://zenodo.org/records/{osm_prebuilt_version[config['electricity']['osm-prebuilt-version']]}/files/buses.csv"),
-            converters=storage(f"https://zenodo.org/records/{osm_prebuilt_version[config['electricity']['osm-prebuilt-version']]}/files/converters.csv"),
-            lines=storage(f"https://zenodo.org/records/{osm_prebuilt_version[config['electricity']['osm-prebuilt-version']]}/files/lines.csv"),
-            links=storage(f"https://zenodo.org/records/{osm_prebuilt_version[config['electricity']['osm-prebuilt-version']]}/files/links.csv"),
-            transformers=storage(f"https://zenodo.org/records/{osm_prebuilt_version[config['electricity']['osm-prebuilt-version']]}/files/transformers.csv"),
+            buses=storage(
+                f"https://zenodo.org/records/{osm_prebuilt_version[config['electricity']['osm-prebuilt-version']]}/files/buses.csv"
+            ),
+            converters=storage(
+                f"https://zenodo.org/records/{osm_prebuilt_version[config['electricity']['osm-prebuilt-version']]}/files/converters.csv"
+            ),
+            lines=storage(
+                f"https://zenodo.org/records/{osm_prebuilt_version[config['electricity']['osm-prebuilt-version']]}/files/lines.csv"
+            ),
+            links=storage(
+                f"https://zenodo.org/records/{osm_prebuilt_version[config['electricity']['osm-prebuilt-version']]}/files/links.csv"
+            ),
+            transformers=storage(
+                f"https://zenodo.org/records/{osm_prebuilt_version[config['electricity']['osm-prebuilt-version']]}/files/transformers.csv"
+            ),
         output:
             buses=f"data/osm-prebuilt/{config['electricity']['osm-prebuilt-version']}/buses.csv",
             converters=f"data/osm-prebuilt/{config['electricity']['osm-prebuilt-version']}/converters.csv",

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -539,7 +539,7 @@ if config["enable"]["retrieve"] and (
         0.1: "12799202",
         0.2: "13342577",
         0.3: "13358976",
-        0.4: "13358976",
+        0.4: "13759222",
     }
 
     # update rule to use the correct version

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -534,24 +534,28 @@ if config["enable"]["retrieve"]:
 if config["enable"]["retrieve"] and (
     config["electricity"]["base_network"] == "osm-prebuilt"
 ):
+    # Dictionary of prebuilt versions, e.g. 0.3 : "13358976"
+    osm_prebuilt_version = {
+        0.1: "12799202",
+        0.2: "13342577",
+        0.3: "13358976",
+        0.4: "13358976",
+    }
 
+    # update rule to use the correct version
     rule retrieve_osm_prebuilt:
         input:
-            buses=storage("https://zenodo.org/records/13358976/files/buses.csv"),
-            converters=storage(
-                "https://zenodo.org/records/13358976/files/converters.csv"
-            ),
-            lines=storage("https://zenodo.org/records/13358976/files/lines.csv"),
-            links=storage("https://zenodo.org/records/13358976/files/links.csv"),
-            transformers=storage(
-                "https://zenodo.org/records/13358976/files/transformers.csv"
-            ),
+            buses=storage(f"https://zenodo.org/records/{osm_prebuilt_version[config['electricity']['osm-prebuilt-version']]}/files/buses.csv"),
+            converters=storage(f"https://zenodo.org/records/{osm_prebuilt_version[config['electricity']['osm-prebuilt-version']]}/files/converters.csv"),
+            lines=storage(f"https://zenodo.org/records/{osm_prebuilt_version[config['electricity']['osm-prebuilt-version']]}/files/lines.csv"),
+            links=storage(f"https://zenodo.org/records/{osm_prebuilt_version[config['electricity']['osm-prebuilt-version']]}/files/links.csv"),
+            transformers=storage(f"https://zenodo.org/records/{osm_prebuilt_version[config['electricity']['osm-prebuilt-version']]}/files/transformers.csv"),
         output:
-            buses="data/osm-prebuilt/buses.csv",
-            converters="data/osm-prebuilt/converters.csv",
-            lines="data/osm-prebuilt/lines.csv",
-            links="data/osm-prebuilt/links.csv",
-            transformers="data/osm-prebuilt/transformers.csv",
+            buses=f"data/osm-prebuilt/{config['electricity']['osm-prebuilt-version']}/buses.csv",
+            converters=f"data/osm-prebuilt/{config['electricity']['osm-prebuilt-version']}/converters.csv",
+            lines=f"data/osm-prebuilt/{config['electricity']['osm-prebuilt-version']}/lines.csv",
+            links=f"data/osm-prebuilt/{config['electricity']['osm-prebuilt-version']}/links.csv",
+            transformers=f"data/osm-prebuilt/{config['electricity']['osm-prebuilt-version']}/transformers.csv",
         log:
             "logs/retrieve_osm_prebuilt.log",
         threads: 1

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -717,6 +717,7 @@ def base_network(
 ):
 
     base_network = config["electricity"].get("base_network")
+    osm_prebuilt_version = config["electricity"].get("osm-prebuilt-version")
     assert base_network in {
         "entsoegridkit",
         "osm-raw",
@@ -728,7 +729,8 @@ def base_network(
             DeprecationWarning,
         )
 
-    logger.info(f"Creating base network using {base_network}.")
+    logger_str = f"Creating base network using {base_network}" + (f" v{osm_prebuilt_version}" if base_network == "osm-prebuilt" else "") + "."
+    logger.info(logger_str)
 
     buses = _load_buses(buses, europe_shape, config)
     transformers = _load_transformers(buses, transformers)
@@ -764,7 +766,7 @@ def base_network(
     converters = _set_electrical_parameters_converters(converters, config)
 
     n = pypsa.Network()
-    n.name = f"PyPSA-Eur ({base_network})"
+    n.name = f"PyPSA-Eur ({base_network}" + (f" v{osm_prebuilt_version}" if base_network == "osm-prebuilt" else "") +")"
 
     time = get_snapshots(snakemake.params.snapshots, snakemake.params.drop_leap_day)
     n.set_snapshots(time)

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -729,7 +729,11 @@ def base_network(
             DeprecationWarning,
         )
 
-    logger_str = f"Creating base network using {base_network}" + (f" v{osm_prebuilt_version}" if base_network == "osm-prebuilt" else "") + "."
+    logger_str = (
+        f"Creating base network using {base_network}"
+        + (f" v{osm_prebuilt_version}" if base_network == "osm-prebuilt" else "")
+        + "."
+    )
     logger.info(logger_str)
 
     buses = _load_buses(buses, europe_shape, config)
@@ -766,7 +770,11 @@ def base_network(
     converters = _set_electrical_parameters_converters(converters, config)
 
     n = pypsa.Network()
-    n.name = f"PyPSA-Eur ({base_network}" + (f" v{osm_prebuilt_version}" if base_network == "osm-prebuilt" else "") +")"
+    n.name = (
+        f"PyPSA-Eur ({base_network}"
+        + (f" v{osm_prebuilt_version}" if base_network == "osm-prebuilt" else "")
+        + ")"
+    )
 
     time = get_snapshots(snakemake.params.snapshots, snakemake.params.drop_leap_day)
     n.set_snapshots(time)


### PR DESCRIPTION
## Changes proposed in this Pull Request
-  Updated osm-prebuilt Zenodo repository to v0.4: https://doi.org/10.5281/zenodo.13759222:
`Added Kosovo (XK) as dedicated region. Fixed major 330 kV line in Moldova (MD).`
Fixed line: https://www.openstreetmap.org/way/33360284
- Quick validation: Updated network converged for 300 nodes using `solve_elec_networks`
- Added version control to osm-prebuilt: `config["electricity"]["osm-prebuilt-version"]`. Defaults to latest Zenodo release, i.e. v0.4, Config is only considered when selecting `osm-prebuilt` as `base_network`.

![image](https://github.com/user-attachments/assets/1c027078-2cbc-4d4b-bbfc-48e143645e5e)


## Checklist

- [X] I tested my contribution locally and it works as intended.
- [X] Code and workflow changes are sufficiently documented.
- [X] Changes in configuration options are added in `config/config.default.yaml`.
- [X] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [X] Sources of newly added data are documented in `doc/data_sources.rst`.
- [X] A release note `doc/release_notes.rst` is added.
