### PR TITLE
add validator report

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -16,12 +16,11 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     steps:
-    - uses: lkstrp/pypsa-validator@dev
+    - uses: lkstrp/pypsa-validator@v0.2.0
       with:
         step: run-self-hosted-validation
         env_file: envs/environment.yaml
         snakemake_config: config/test/config.validator.yaml
-        dev: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -31,7 +30,7 @@ jobs:
     needs: run-validation
     runs-on: ubuntu-latest
     steps:
-    - uses: lkstrp/pypsa-validator@dev
+    - uses: lkstrp/pypsa-validator@v0.2.0
       with:
         step: create-comment
         snakemake_config: config/test/config.validator.yaml
@@ -45,4 +44,3 @@ jobs:
           graphs/balances-energy.svg
           "
         validator_key: ${{ secrets.VALIDATOR_KEY }}
-        dev: true

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     steps:
-    - uses: lkstrp/pypsa-validator@v0.2.0
+    - uses: lkstrp/pypsa-validator@v0.2.1
       with:
         step: run-self-hosted-validation
         env_file: envs/environment.yaml
@@ -30,7 +30,7 @@ jobs:
     needs: run-validation
     runs-on: ubuntu-latest
     steps:
-    - uses: lkstrp/pypsa-validator@v0.2.0
+    - uses: lkstrp/pypsa-validator@v0.2.1
       with:
         step: create-comment
         snakemake_config: config/test/config.validator.yaml

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,48 @@
+name: Validator Bot
+
+on:
+  pull_request:
+    branches:
+    - master
+    - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run-validation:
+    name: Run validation
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: self-hosted
+    steps:
+    - uses: lkstrp/pypsa-validator@dev
+      with:
+        step: run-self-hosted-validation
+        env_file: envs/environment.yaml
+        snakemake_config: config/test/config.validator.yaml
+        dev: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  create-report:
+    name: Create report
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs: run-validation
+    runs-on: ubuntu-latest
+    steps:
+    - uses: lkstrp/pypsa-validator@dev
+      with:
+        step: create-comment
+        snakemake_config: config/test/config.validator.yaml
+        # The path starting from prefix in config
+        # For plot results/<prefix>/<scenario>/<plot_name>.png pass
+        # <scenario>/<plot_name>.png
+        plots: >
+          "
+          graphs/energy.svg
+          graphs/costs.svg
+          graphs/balances-energy.svg
+          "
+        validator_key: ${{ secrets.VALIDATOR_KEY }}
+        dev: true


### PR DESCRIPTION
Adds Validator CI. See the report below.
- It is triggered by any new commit in pr.
- Runs on a self-hosted github runner and solves on z1, so basically any configuration can be set. No restrictions. It just takes a while to update the comment if you choose a computationally intensive config.
- Compares the base branch (main) with the latest commit in the pr branch. So runs both, but also caches (in addition to snakemake caching) based on commit hashes. -  Edits one main report comment when new commits are pushed to the repo, to avoid spamming.
- Set all settings in workflow file (mainly which plots to show, pre-commands, environment selection, etc.)

- Some things which are missing: 
  - Better comparison (use `n.statistics`)
  - Doesn't run on PRs from forks
  - Handle environment updates
  - More file filters to avoid unnecessary runs
  - Concurrent runs

Also have a look at the [Wishlist](https://github.com/lkstrp/pypsa-validator/issues/10) and see action [repo](https://github.com/lkstrp/pypsa-validator/issues) to create any issues. This will be moved to the PyPSA org at some point.