### PR TITLE
Only add buses in specified countries

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -73,6 +73,8 @@ Upcoming Release
 
 * Added 98% imperfect capture rate of Allam cycle gas turbine.
 
+* Resolved a problem where excluding certain countries from `countries` configuration led to clustering errors.
+
 PyPSA-Eur 0.13.0 (13th September 2024)
 ======================================
 

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -135,7 +135,7 @@ def _find_closest_links(links, new_links, distance_upper_bound=1.5):
     )
 
 
-def _load_buses(buses, europe_shape, config):
+def _load_buses(buses, europe_shape, countries, config):
     buses = (
         pd.read_csv(
             buses,
@@ -161,6 +161,12 @@ def _load_buses(buses, europe_shape, config):
         lambda p: europe_shape_prepped.contains(Point(p)), axis=1
     )
 
+    buses_in_countries_b = (
+        buses.country.isin(countries)
+        if "country" in buses
+        else pd.Series(True, buses.index)
+    )
+
     v_nom_min = min(config["electricity"]["voltages"])
     v_nom_max = max(config["electricity"]["voltages"])
 
@@ -173,7 +179,9 @@ def _load_buses(buses, europe_shape, config):
     )
 
     logger.info(f"Removing buses outside of range AC {v_nom_min} - {v_nom_max} V")
-    return pd.DataFrame(buses.loc[buses_in_europe_b & buses_with_v_nom_to_keep_b])
+    return pd.DataFrame(
+        buses.loc[buses_in_europe_b & buses_in_countries_b & buses_with_v_nom_to_keep_b]
+    )
 
 
 def _load_transformers(buses, transformers):
@@ -712,6 +720,7 @@ def base_network(
     europe_shape,
     country_shapes,
     offshore_shapes,
+    countries,
     parameter_corrections,
     config,
 ):
@@ -736,7 +745,7 @@ def base_network(
     )
     logger.info(logger_str)
 
-    buses = _load_buses(buses, europe_shape, config)
+    buses = _load_buses(buses, europe_shape, countries, config)
     transformers = _load_transformers(buses, transformers)
     lines = _load_lines(buses, lines)
 
@@ -1006,6 +1015,7 @@ if __name__ == "__main__":
         europe_shape,
         country_shapes,
         offshore_shapes,
+        countries,
         parameter_corrections,
         config,
     )


### PR DESCRIPTION
This is necessary for the new OSM-based base network, where loaded buses already have a "country" attribute.

Closes https://github.com/PyPSA/pypsa-eur/issues/1306

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
