### PR TITLE
consider the planning horizon for biomass potentials input

### DIFF
--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1059,14 +1059,7 @@ rule prepare_sector_network:
         dsm_profile=resources("dsm_profile_s_{clusters}.csv"),
         co2_totals_name=resources("co2_totals.csv"),
         co2="data/bundle/eea/UNFCCC_v23.csv",
-        biomass_potentials=lambda w: (
-            resources(
-                "biomass_potentials_s_{clusters}_"
-                + "{}.csv".format(config_provider("biomass", "year")(w))
-            )
-            if config_provider("foresight")(w) == "overnight"
-            else resources("biomass_potentials_s_{clusters}_{planning_horizons}.csv")
-        ),
+        biomass_potentials=resources("biomass_potentials_s_{clusters}_{planning_horizons}.csv"),
         costs=lambda w: (
             resources("costs_{}.csv".format(config_provider("costs", "year")(w)))
             if config_provider("foresight")(w) == "overnight"

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1059,7 +1059,9 @@ rule prepare_sector_network:
         dsm_profile=resources("dsm_profile_s_{clusters}.csv"),
         co2_totals_name=resources("co2_totals.csv"),
         co2="data/bundle/eea/UNFCCC_v23.csv",
-        biomass_potentials=resources("biomass_potentials_s_{clusters}_{planning_horizons}.csv"),
+        biomass_potentials=resources(
+            "biomass_potentials_s_{clusters}_{planning_horizons}.csv"
+        ),
         costs=lambda w: (
             resources("costs_{}.csv".format(config_provider("costs", "year")(w)))
             if config_provider("foresight")(w) == "overnight"


### PR DESCRIPTION
build_sector.smk: always consider the planning horizon for biomass potentials input in prepare_sector_network

## Changes proposed in this Pull Request

The problem was that for overnight, not the planning horizon was considered for the biomass potential but the year set in the config under `biomass`. This led to the unwanted behavior that one could not do a 2050 optimization with the biomass potentials from ENSPRESO for 2030 and without unsustainable biomass. 

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
