### PR TITLE
Fix industrial demand for ammonia when endogenously modelled

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -75,6 +75,8 @@ Upcoming Release
 
 * Resolved a problem where excluding certain countries from `countries` configuration led to clustering errors.
 
+* Bugfix: demand for ammonia was double-counted at current/near-term planning horizons when ``sector['ammonia']`` was set to ``True``.
+
 PyPSA-Eur 0.13.0 (13th September 2024)
 ======================================
 

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -716,6 +716,7 @@ rule build_industrial_energy_demand_per_country_today:
     params:
         countries=config_provider("countries"),
         industry=config_provider("industry"),
+        ammonia=config_provider("sector", "ammonia", default=False),
     input:
         transformation_output_coke=resources("transformation_output_coke.csv"),
         jrc="data/jrc-idees-2021",


### PR DESCRIPTION
In calculating industrial energy demand today, demand for ammonia must be resolved into just "ammonia" when endogenously modelled, or into electricity and hydrogen if not. Before this fix, energy demand for ammonia was double-counted at current and near-term planning horizons when `sector['ammonia'] = True`; both in terms of ammonia and in terms of electricity and hydrogen.

While not incredibly large in magnitude, hydrogen demand at 2025 planning horizon was essentially double what it should have been before this fix.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
