### PR TITLE
fix: move pypsa dependency to pip

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -11,7 +11,6 @@ dependencies:
 - pip
 
 - atlite>=0.2.9
-- pypsa>=0.30.2
 - linopy
 - dask
 
@@ -63,3 +62,4 @@ dependencies:
   - snakemake-executor-plugin-slurm
   - snakemake-executor-plugin-cluster-generic
   - highspy
+  - pypsa>=0.30.2


### PR DESCRIPTION
Tried to set this project up, and seems like conda is experiencing some difficulties due to the following:
- pypsa is installed with conda, and requires highspy
- highspy is not available on conda for arm64 on osx
- highspy is being installed in the environment.yml file, but with pip

Seems like this causes conda to error out with highspy not being available to install. 