### PR TITLE
fix: failing macos pypsa installation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,17 +76,8 @@ jobs:
       id: cache-env
 
     - name: Update environment
-      if: steps.cache-env.outputs.cache-hit != 'true' && matrix.os != 'macos'
+      if: steps.cache-env.outputs.cache-hit != 'true'
       run: conda env update -n pypsa-eur -f envs/environment.yaml
-
-    # Temporary fix for MacOS, since highspy with pypsa can not be resolved
-    - name: Update environment (macos specific)
-      if: steps.cache-env.outputs.cache-hit != 'true' && matrix.os == 'macos'
-      run: |
-        sed -i '' '/- pypsa/d' envs/environment.yaml # Remove pypsa from environment list
-        conda env update -n pypsa-eur -f envs/environment.yaml
-        pip install highspy
-        conda install -c conda-forge pypsa
 
     - name: Install inhouse packages from master
       if: matrix.inhouse == 'dev-inhouse-deps'

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -10,8 +10,10 @@ dependencies:
 - python>=3.8
 - pip
 
+- pypsa>=0.30.2
 - atlite>=0.2.9
 - linopy
+
 - dask
 
 # Dependencies of the workflow itself
@@ -62,4 +64,3 @@ dependencies:
   - snakemake-executor-plugin-slurm
   - snakemake-executor-plugin-cluster-generic
   - highspy
-  - pypsa>=0.30.2


### PR DESCRIPTION
- Failing pypsa installation on macos is fixed via feedstock
    - You might need to remove your env and clean the cache
    - The needed build is `pypsa-0.30.2-pyhd8ed1ab_1`
- This PR reverts all hot fixes 