### PR TITLE
Ensure Constraint of Solar and Solar-hsat with Post Discretization

### DIFF
--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -259,7 +259,7 @@ def add_solar_potential_constraints(n, config):
             n.generators.loc[solar_today, "p_nom_max"]
             .groupby(n.generators.loc[solar_today].index.rename("bus").map(location))
             .sum()
-            - n.generators.loc[solar_hsat, "p_nom_opt"]
+            - n.generators.loc[solar_hsat, "p_nom"]
             .groupby(n.generators.loc[solar_hsat].index.rename("bus").map(location))
             .sum()
             * land_use_factors["solar-hsat"]
@@ -272,7 +272,7 @@ def add_solar_potential_constraints(n, config):
             n.generators.loc[solar_today, "p_nom_max"]
             .groupby(n.generators.loc[solar_today].bus.map(location))
             .sum()
-            - n.generators.loc[solar_hsat, "p_nom_opt"]
+            - n.generators.loc[solar_hsat, "p_nom"]
             .groupby(n.generators.loc[solar_hsat].bus.map(location))
             .sum()
             * land_use_factors["solar-hsat"]


### PR DESCRIPTION
## Bugfix

## Changes proposed in this Pull Request
When the post discretization is enabled, the function `add_solar_potential_constraints` is called multiple times.
The first time, the optimal capacity of generators with carrier `solar-hsat` is zero. However, the second time, the optimal capacity can be greater than zero which would then overly reduce the potential.
Since the `p_nom` is set in the next planning horizon in the rule `add_brownfield` switching from `p_nom_opt` to `p_nom` is the correct way to formulate the boundary condition.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
_not applicable_
- [ ] Changed dependencies are added to `envs/environment.yaml`.
_not applicable_
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
_not applicable_
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
_not applicable_
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
_not applicable_
- [ ] A release note `doc/release_notes.rst` is added.
_not applicable_
