### PR TITLE
fix index of unsustainable bioliquids

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2554,7 +2554,7 @@ def add_biomass(n, costs):
     if options["regional_oil_demand"]:
         unsustainable_liquid_biofuel_potentials_spatial = biomass_potentials[
             "unsustainable bioliquids"
-        ].rename(index=lambda x: x + " bioliquids")
+        ].rename(index=lambda x: x + " unsustainable bioliquids")
     else:
         unsustainable_liquid_biofuel_potentials_spatial = biomass_potentials[
             "unsustainable bioliquids"


### PR DESCRIPTION
The unsustainable bioliquids had the wrong index, s.t. there e_nom was 0. This is now fixed.


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
