### PR TITLE
fix: remove broken pre-commit rule (`docformatter`)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,12 +37,14 @@ repos:
     types_or: [python, rst, markdown]
     files: ^(scripts|doc)/
 
-  # Make docstrings PEP 257 compliant
-- repo: https://github.com/PyCQA/docformatter
-  rev: v1.7.5
-  hooks:
-  - id: docformatter
-    args: ["--in-place", "--make-summary-multi-line", "--pre-summary-newline"]
+# Make docstrings PEP 257 compliant
+# Broken for pre-commit<=4.0.0
+# See https://github.com/PyCQA/docformatter/issues/293
+# - repo: https://github.com/PyCQA/docformatter
+#   rev: v1.7.5
+#   hooks:
+#   - id: docformatter
+#     args: ["--in-place", "--make-summary-multi-line", "--pre-summary-newline"]
 
 - repo: https://github.com/keewis/blackdoc
   rev: v0.3.9


### PR DESCRIPTION
- `docformatter` is broken for `pre-commit>=4.0`
- See https://github.com/PyCQA/docformatter/issues/293