### PR TITLE
fix for multiprocessing snakemake object unknown in build_industrial_production_per_country

### DIFF
--- a/scripts/build_industrial_production_per_country.py
+++ b/scripts/build_industrial_production_per_country.py
@@ -189,7 +189,7 @@ def find_physical_output(df):
     return slice(start, end)
 
 
-def get_energy_ratio(country, eurostat_dir, jrc_dir, year):
+def get_energy_ratio(country, eurostat_dir, jrc_dir, year, snakemake):
     if country == "CH":
         # data ranges between 2014-2023
         e_country = pd.read_csv(
@@ -228,7 +228,7 @@ def get_energy_ratio(country, eurostat_dir, jrc_dir, year):
     return pd.Series({k: e_ratio[v] for k, v in sub2sect.items()})
 
 
-def industry_production_per_country(country, year, eurostat_dir, jrc_dir):
+def industry_production_per_country(country, year, eurostat_dir, jrc_dir, snakemake):
     def get_sector_data(sector, country):
         jrc_country = jrc_names.get(country, country)
         fn = f"{jrc_dir}/{jrc_country}/JRC-IDEES-2021_Industry_{jrc_country}.xlsx"
@@ -250,7 +250,13 @@ def industry_production_per_country(country, year, eurostat_dir, jrc_dir):
     demand = pd.concat([get_sector_data(s, ct) for s in sect2sub])
 
     if country not in eu27:
-        demand *= get_energy_ratio(country, eurostat_dir, jrc_dir, year)
+        demand *= get_energy_ratio(
+            country,
+            eurostat_dir,
+            jrc_dir,
+            year,
+            snakemake,
+        )
 
     demand.name = country
 
@@ -266,6 +272,7 @@ def industry_production(countries, year, eurostat_dir, jrc_dir):
         year=year,
         eurostat_dir=eurostat_dir,
         jrc_dir=jrc_dir,
+        snakemake=snakemake,
     )
     tqdm_kwargs = dict(
         ascii=False,


### PR DESCRIPTION
## Changes proposed in this Pull Request
Minor fix that avoids a bug occuring with multiprocessing functions and references to the snakemake object within these functions on some package versions on MacOS and Windows OS.
Closes #1339.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
