### PR TITLE
Keep existing conventional generation in sector network

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -360,7 +360,6 @@ pypsa_eur:
   - solar-hsat
   - solar
   - ror
-  - nuclear
   StorageUnit:
   - PHS
   - hydro
@@ -693,6 +692,10 @@ sector:
   biogas_upgrading_cc: false
   conventional_generation:
     OCGT: gas
+    nuclear: uranium
+    coal: coal
+    lignite: lignite
+  keep_existing_capacities: false
   biomass_to_liquid: false
   biomass_to_liquid_cc: false
   electrobiofuels: false

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1023,6 +1023,7 @@ rule prepare_sector_network:
         countries=config_provider("countries"),
         adjustments=config_provider("adjustments", "sector"),
         emissions_scope=config_provider("energy", "emissions"),
+        electricity=config_provider("electricity"),
         biomass=config_provider("biomass"),
         RDIR=RDIR,
         heat_pump_sources=config_provider("sector", "heat_pump_sources"),


### PR DESCRIPTION
Closes # (if applicable).


## Changes proposed in this Pull Request
The sector coupled network currently removes existing conventional generators. This PR adds them back (in the traditional sectoral setup with EU Generators + Links)

## Checklist
- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
