### PR TITLE
fix MtK VOM

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -943,7 +943,7 @@ def add_methanol_to_kerosene(n, costs):
         suffix=f" {tech}",
         carrier=tech,
         capital_cost=capital_cost,
-        marginal_cost=costs.at[tech, "VOM"],
+        marginal_cost=costs.at[tech, "VOM"] / costs.at[tech, "methanol-input"],
         bus0=spatial.methanol.nodes,
         bus1=spatial.oil.kerosene,
         bus2=spatial.h2.nodes,


### PR DESCRIPTION
in the master the marginal_cost are currently in $€/MWh_{kerosene}$ but they should be in $€/MWh_{MeOH}$ because bus 0 is a methanol bus


## Changes proposed in this Pull Request


## Checklist

- [x] I tested my contribution locally and it works as intended.
