### PR TITLE
build: pin `highspy` and use conda version

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -10,13 +10,14 @@ dependencies:
 - python>=3.8
 - pip
 
+# Inhouse packages
 - pypsa>=0.31
 - atlite>=0.2.9
 - linopy
-
-- dask
+- powerplantmatching>=0.5.15,<0.6
 
 # Dependencies of the workflow itself
+- dask
 - xlrd
 - openpyxl!=3.1.1
 - seaborn
@@ -25,7 +26,6 @@ dependencies:
 - yaml
 - pytables
 - lxml
-- powerplantmatching>=0.5.15,<0.6
 - numpy
 - pandas>=2.1
 - geopandas>=1
@@ -49,6 +49,7 @@ dependencies:
 - graphviz
 - pre-commit
 - geojson
+- highspy!=1.8.0
 
 # Keep in conda environment when calling ipython
 - ipython
@@ -63,4 +64,3 @@ dependencies:
   - snakemake-storage-plugin-http
   - snakemake-executor-plugin-slurm
   - snakemake-executor-plugin-cluster-generic
-  - highspy


### PR DESCRIPTION
- Highspy `1.8.0` is breaking things
- Resolves failing tests
- Merge #1379 first