### PR TITLE
Bug fix: simplify_network.py (simplify_links) - By adding preceding converter removal

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -78,6 +78,8 @@ Upcoming Release
 
 * Bugfix: demand for ammonia was double-counted at current/near-term planning horizons when ``sector['ammonia']`` was set to ``True``.
 
+* Bugfix: Bug when multiple DC links are connected to the same DC bus and the DC bus is connected to an AC bus via converter. In this case, the DC links were wrongly simplified, completely dropping the shared DC bus. Bug fixed by adding preceding converter removal. Other functionalities are not impacted.
+
 PyPSA-Eur 0.13.0 (13th September 2024)
 ======================================
 

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -385,13 +385,10 @@ def remove_converters(n: pypsa.Network) -> pypsa.Network:
     Returns:
         n (pypsa.Network): The network object with all converters removed.
     """
-    network = n.copy()
-
-    network.links["bus0_carrier"] = network.links.bus0.map(network.buses.carrier)
-    network.links["bus1_carrier"] = network.links.bus1.map(network.buses.carrier)
-
-    # Only converters
-    converters = network.links.query("carrier == ''").copy()
+    # Extract converters
+    converters = n.links.query("carrier == ''")[["bus0", "bus1"]]
+    converters["bus0_carrier"] = converters["bus0"].map(n.buses.carrier)
+    converters["bus1_carrier"] = converters["bus1"].map(n.buses.carrier)
 
     converters["ac_bus"] = converters.apply(
         lambda x: x["bus1"] if x["bus1_carrier"] == "AC" else x["bus0"], axis=1
@@ -405,17 +402,14 @@ def remove_converters(n: pypsa.Network) -> pypsa.Network:
     dict_dc_to_ac = dict(zip(converters["dc_bus"], converters["ac_bus"]))
 
     # Remap all buses that were originally connected to the converter to the connected AC bus
-    network.links["bus0"] = network.links["bus0"].replace(dict_dc_to_ac)
-    network.links["bus1"] = network.links["bus1"].replace(dict_dc_to_ac)
+    n.links["bus0"] = n.links["bus0"].replace(dict_dc_to_ac)
+    n.links["bus1"] = n.links["bus1"].replace(dict_dc_to_ac)
 
     # Remove all converters from network.links and associated dc buses from network.buses
-    network.links = network.links.loc[~network.links.index.isin(converters.index)]
-    network.buses = network.buses.loc[~network.buses.index.isin(converters["dc_bus"])]
+    n.links = n.links.loc[~n.links.index.isin(converters.index)]
+    n.buses = n.buses.loc[~n.buses.index.isin(converters["dc_bus"])]
 
-    # Drop helper columns bus0_carrier and bus1_carrier
-    network.links.drop(["bus0_carrier", "bus1_carrier"], axis=1, inplace=True)
-
-    return network
+    return n
 
 
 if __name__ == "__main__":

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -422,9 +422,7 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
-        snakemake = mock_snakemake(
-            "simplify_network", configfiles=["config/config.osm-raw.yaml"]
-        )
+        snakemake = mock_snakemake("simplify_network")
     configure_logging(snakemake)
     set_scenario_config(snakemake)
 

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -372,13 +372,11 @@ def find_closest_bus(n, x, y, tol=2000):
         return n.buses.index[dist.argmin()]
     else:
         return None
-    
 
-def remove_converters(
-    n: pypsa.Network
-) -> pypsa.Network:
+
+def remove_converters(n: pypsa.Network) -> pypsa.Network:
     """
-    Remove all converters from the network and remap all buses that were originally connected to the 
+    Remove all converters from the network and remap all buses that were originally connected to the
     converter to the connected AC bus. Preparation step before simplifying links.
 
     Parameters:
@@ -396,15 +394,13 @@ def remove_converters(
     converters = network.links.query("carrier == ''").copy()
 
     converters["ac_bus"] = converters.apply(
-        lambda x: x["bus1"] if x["bus1_carrier"] == "AC" else x["bus0"], 
-        axis=1
+        lambda x: x["bus1"] if x["bus1_carrier"] == "AC" else x["bus0"], axis=1
     )
 
     converters["dc_bus"] = converters.apply(
-        lambda x: x["bus1"] if x["bus1_carrier"] == "DC" else x["bus0"], 
-        axis=1
+        lambda x: x["bus1"] if x["bus1_carrier"] == "DC" else x["bus0"], axis=1
     )
-    
+
     # Dictionary for remapping
     dict_dc_to_ac = dict(zip(converters["dc_bus"], converters["ac_bus"]))
 
@@ -426,7 +422,9 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
-        snakemake = mock_snakemake("simplify_network", configfiles=["config/config.osm-raw.yaml"])
+        snakemake = mock_snakemake(
+            "simplify_network", configfiles=["config/config.osm-raw.yaml"]
+        )
     configure_logging(snakemake)
     set_scenario_config(snakemake)
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
- @p-glaum and @bobbyxng 
- Bug fix occuring when multiple DC links are connected to the same DC bus and the DC bus is connected to an AC bus via converter.
- Links were simplified in a wrong manner, leading to the DC bus being dropped, e.g. in the case of a TYNDP project connecting Sicily to mainland Italy.
- This does not impact simplification of DC links that consist of DC buses along the way, which are not connected to an AC bus via converter.
- Tested with osm-grid, transmission projects on, 45 buses and weekly resolution. `solve_elec_networks` converges.

![Screenshot from 2024-10-22 14-09-09](https://github.com/user-attachments/assets/e6c0dc35-8103-4a5f-85f0-b8b7e51279da)

## Checklist

- [X] I tested my contribution locally and it works as intended.
- [X] Code and workflow changes are sufficiently documented.
- [X] Changed dependencies are added to `envs/environment.yaml`.
- [X] A release note `doc/release_notes.rst` is added.
