### PR TITLE
Bugfix: unsustainable bioliquids renaming

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2541,7 +2541,7 @@ def add_biomass(n, costs):
     if options["regional_oil_demand"]:
         unsustainable_liquid_biofuel_potentials_spatial = biomass_potentials[
             "unsustainable bioliquids"
-        ].rename(index=lambda x: x + " bioliquids")
+        ].rename(index=lambda x: x + " unsustainable bioliquids")
     else:
         unsustainable_liquid_biofuel_potentials_spatial = biomass_potentials[
             "unsustainable bioliquids"


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
- Bugfix in `prepare_sector_network.py`
- Renaming of `bioliquids` to `unsustainable bioliquids`, as a mismatch in indexing occurs otherwise

## Checklist

- [X] I tested my contribution locally and it works as intended.
- [X] Code and workflow changes are sufficiently documented.