### PR TITLE
Correct bioliquid emissions by BtL efficiency

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,9 @@ Release Notes
 
 Upcoming Release
 ================
+
+* Bugfix: Adjusted efficiency2 (to atmosphere) for bioliquids-to-oil Link in `prepare_sector_network` to exactly offset the corresponding oil emissions.
+
 * Bugfix: Duplicates in build_transmission_projects were caught, but not removed from the network. This is now fixed.
 
 * Replaced the Store representation of biogenic carriers (solid biomass, biogas, bioliquids, MSW) in ``prepare_sector_network`` with the extended Generator component that uses the ``e_sum_min`` and ``e_sum_max`` attributes to enforce minimum usage and limit maximum potential, respectively.

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2722,11 +2722,7 @@ def add_biomass(n, costs):
             bus2="co2 atmosphere",
             carrier="unsustainable bioliquids",
             efficiency=1,
-            efficiency2=(
-                -costs.at["solid biomass", "CO2 intensity"]
-                + costs.at["BtL", "CO2 stored"]
-            )
-            / costs.at["BtL", "efficiency"],
+            efficiency2=-costs.at["oil", "CO2 intensity"],
             p_nom=unsustainable_liquid_biofuel_potentials_spatial,
             marginal_cost=costs.at["BtL", "VOM"],
         )

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2722,8 +2722,11 @@ def add_biomass(n, costs):
             bus2="co2 atmosphere",
             carrier="unsustainable bioliquids",
             efficiency=1,
-            efficiency2=-costs.at["solid biomass", "CO2 intensity"]
-            + costs.at["BtL", "CO2 stored"],
+            efficiency2=(
+                -costs.at["solid biomass", "CO2 intensity"]
+                + costs.at["BtL", "CO2 stored"]
+            )
+            / costs.at["BtL", "efficiency"],
             p_nom=unsustainable_liquid_biofuel_potentials_spatial,
             marginal_cost=costs.at["BtL", "VOM"],
         )


### PR DESCRIPTION
## Changes proposed in this Pull Request
In `prepare_sector_network` the link between unsustainable bioliquids and oil previously did not correctly account for the amount of CO₂ emissions withdrawn from the atmosphere. The efficiency value was directly copied from the BtL (biomass to liquid) link without adjusting for the primary efficiency value, which represents the conversion between solid biomass and oil.

With this updated efficiency, 0.248 MtCO₂ are withdrawn from the atmosphere per MWh of unsustainable bioliquids introduced into the system. However, there remains a discrepancy when compared to the CO₂ intensity of oil used in the model, which stands at 0.2571. This difference is consistent with the BtL link’s implementation. An alternative approach would be to adjust the efficiency value to match the exact CO₂ intensity of oil, thereby eliminating the gap.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
