### PR TITLE
Fixes for new CHP fuel config; list biomass among fuels

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -599,8 +599,10 @@ sector:
     central: 1.0
   chp:
     enable: true
-    fuel: gas # for all fuels the same techno economic data from gas CHP is taken
-  micro_chp: false
+    fuel:
+    - solid biomass # For solid biomass, CHP with and without CC are added
+    - gas # For all other fuels the same techno economic data from gas CHP is taken
+    micro_chp: false # Only gas is used for micro_chp
   solar_thermal: true
   solar_cf_correction: 0.788457  # =  >>> 1/1.2683
   marginal_cost_storage: 0. #1e-4

--- a/doc/configtables/sector.csv
+++ b/doc/configtables/sector.csv
@@ -95,8 +95,8 @@ overdimension_heat_generators,,,Add option for overdimensioning heating systems 
 -- central,--,float,The factor for overdimensioning (increasing CAPEX) central heating systems
 chp,--,,
 -- enable,--,"{true, false}",Add option for using Combined Heat and Power (CHP)
--- fuel,--,string or list of fuels,"Possible options are all fuels which have an exisitng bus and their CO2 intensity is given in the technology data. Currently possible are ""gas"", ""oil"", ""methanol"", ""lignite"", ""coal"". For all fuels, the techno-economic data from gas CHP is used."
-micro_chp,--,"{true, false}",Add option for using Combined Heat and Power (CHP) for decentral areas.
+-- fuel,--,list of fuels,"Possible options are all fuels which have an existing bus and their CO2 intensity is given in the technology data. Currently possible are ""gas"", ""oil"", ""methanol"", ""lignite"", ""coal"" as well as ""solid biomass"". For all fuels except solid biomass, the techno-economic data from gas CHP is used. For the special case of solid biomass fuel, both CHP plants with and without carbon capture are added."
+-- micro_chp,--,"{true, false}",Add option for using gas-fired Combined Heat and Power (CHP) for decentral areas.
 solar_thermal,--,"{true, false}",Add option for using solar thermal to generate heat.
 solar_cf_correction,--,float,The correction factor for the value provided by the solar thermal profile calculations
 marginal_cost_storage,"currency/MWh ",float,The marginal cost of discharging batteries in distributed grids

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,7 +11,7 @@ Release Notes
 Upcoming Release
 ================
 
-* Feature: Allow CHPs to use different fuel sources such as gas, oil, coal, and methanol. Note that the cost assumptions are based on a gas CHP.
+* Feature: Allow CHPs to use different fuel sources such as gas, oil, coal, and methanol. Note that the cost assumptions are based on a gas CHP (except for solid biomass-fired CHP).
 
 * Improve `sanitize_carrier`` function by filling in colors of missing carriers with colors mapped after using the function `rename_techs`.
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

It looks there was a mistake in the last CHP-fuel-related PR: there were still references to the "old" `chp: true/false` option in `prepare_sector_network.py`. And now that CHP-configuration is being improved, I thought it would be more user-friendly to also:
- List solid biomass as one of the fuels explicitly, and document how biomass-CHP is treated separately (w.r.t. parameters and CC)
- Put the micro_chp option under the new chp config section

What do you think, @p-glaum?

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
