### PR TITLE
Log memory usage also for electricity-only solve_network

### DIFF
--- a/rules/solve_electricity.smk
+++ b/rules/solve_electricity.smk
@@ -22,6 +22,8 @@ rule solve_network:
             RESULTS
             + "logs/solve_network/base_s_{clusters}_elec_l{ll}_{opts}_solver.log"
         ),
+        memory=RESULTS
+        + "logs/solve_network/base_s_{clusters}_elec_l{ll}_{opts}_memory.log",
         python=RESULTS
         + "logs/solve_network/base_s_{clusters}_elec_l{ll}_{opts}_python.log",
     benchmark:


### PR DESCRIPTION
For some reason memory usage was not being logged when solving electricity-only networks. I would say this doesn't need a release note :)

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
