### PR TITLE
Update outdated GLPK reference to HiGHS

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -88,7 +88,7 @@ want to use the ERA-5 dataset for solar and not the default SARAH-3 dataset.
    :end-at: cutout:
 
 Finally, it is possible to pick a solver. For instance, this tutorial uses the
-open-source solver GLPK.
+open-source solver HiGHS.
 
 .. literalinclude:: ../config/test/config.electricity.yaml
    :language: yaml


### PR DESCRIPTION
## Changes proposed in this Pull Request
The [tutorial](https://pypsa-eur.readthedocs.io/en/latest/tutorial.html#how-to-configure-runs) still had an old reference to GLPK, while the config file currently refers to using HiGHS as solver.

## Checklist
None of these checks seem relevant for this fix.
- [ ] ~I tested my contribution locally and it works as intended.~
- [ ] ~Code and workflow changes are sufficiently documented.~
- [ ] ~Changed dependencies are added to `envs/environment.yaml`.~
- [ ] ~Changes in configuration options are added in `config/config.default.yaml`.~
- [ ] ~Changes in configuration options are documented in `doc/configtables/*.csv`.~
- [ ] ~Sources of newly added data are documented in `doc/data_sources.rst`.~
- [ ] ~A release note `doc/release_notes.rst` is added.~
