### PR TITLE
Remove duplicate of add_methanol function

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2711,32 +2711,6 @@ def add_methanol(n, costs):
         add_methanol_reforming_cc(n, costs)
 
 
-def add_methanol(n, costs):
-
-    methanol_options = options["methanol"]
-    if not any(methanol_options.values()):
-        return
-
-    logger.info("Add methanol")
-    add_carrier_buses(n, "methanol")
-
-    if options["biomass"]:
-        if methanol_options["biomass_to_methanol"]:
-            add_biomass_to_methanol(n, costs)
-
-        if methanol_options["biomass_to_methanol"]:
-            add_biomass_to_methanol_cc(n, costs)
-
-    if methanol_options["methanol_to_power"]:
-        add_methanol_to_power(n, costs, types=methanol_options["methanol_to_power"])
-
-    if methanol_options["methanol_reforming"]:
-        add_methanol_reforming(n, costs)
-
-    if methanol_options["methanol_reforming_cc"]:
-        add_methanol_reforming_cc(n, costs)
-
-
 def add_biomass(n, costs):
     logger.info("Add biomass")
 


### PR DESCRIPTION
There is a duplicate in `prepare_sector_network` of the function `add_methanol` that probably comes from merging `master` into `ariadne2`.


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
_not applicable_
- [ ] Changed dependencies are added to `envs/environment.yaml`.
_not applicable_
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
_not applicable_
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
_not applicable_
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
_not applicable_
- [ ] A release note `doc/release_notes.rst` is added.
_not applicable_
