### PR TITLE
fix: emission-spot-primary-market-auction-report-2019-data.xls 404

### DIFF
--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -506,7 +506,7 @@ if config["enable"]["retrieve"]:
     rule retrieve_monthly_co2_prices:
         input:
             storage(
-                "https://www.eex.com/fileadmin/EEX/Downloads/EUA_Emission_Spot_Primary_Market_Auction_Report/Archive_Reports/emission-spot-primary-market-auction-report-2019-data.xls",
+                "https://public.eex-group.com/eex/eua-auction-report/emission-spot-primary-market-auction-report-2019-data.xls",
                 keep_local=True,
             ),
         output:


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

This address https://www.eex.com/fileadmin/EEX/Downloads/EUA_Emission_Spot_Primary_Market_Auction_Report/Archive_Reports/emission-spot-primary-market-auction-report-2019-data.xls currently returns a 404 error.

<img width="970" alt="image" src="https://github.com/user-attachments/assets/bb1d78e0-c457-4795-ba49-033a6105283f" />

Replace it with an accessible address.


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
