### PR TITLE
fix: make previous OSM versions compatible

### DIFF
--- a/matplotlibrc
+++ b/matplotlibrc
@@ -2,6 +2,5 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 font.family: sans-serif
-font.sans-serif: Ubuntu, DejaVu Sans
 image.cmap: viridis
 figure.autolayout : True

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -95,7 +95,7 @@ if config["enable"]["retrieve"]:
                     zip_ref.extract(filename, Path(output.shapes_level_3).parent)
                     extracted_file = Path(output.shapes_level_3).parent / filename
                     extracted_file.rename(
-                        getattr(output, f"shapes_level_{level[- 1]}")
+                        getattr(output, f"shapes_level_{level[-1]}")
                     )
             os.remove(params.zip_file)
 
@@ -473,7 +473,7 @@ if config["enable"]["retrieve"]:
                 layer_path = (
                     f"/vsizip/{params.folder}/WDPA_{bYYYY}_Public_shp_{i}.zip"
                 )
-                print(f"Adding layer {i + 1} of 3 to combined output file.")
+                print(f"Adding layer {i+1} of 3 to combined output file.")
                 shell("ogr2ogr -f gpkg -update -append {output.gpkg} {layer_path}")
 
     rule download_wdpa_marine:
@@ -496,7 +496,7 @@ if config["enable"]["retrieve"]:
             for i in range(3):
                 # vsizip is special driver for directly working with zipped shapefiles in ogr2ogr
                 layer_path = f"/vsizip/{params.folder}/WDPA_WDOECM_{bYYYY}_Public_marine_shp_{i}.zip"
-                print(f"Adding layer {i + 1} of 3 to combined output file.")
+                print(f"Adding layer {i+1} of 3 to combined output file.")
                 shell("ogr2ogr -f gpkg -update -append {output.gpkg} {layer_path}")
 
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Previous OSM prebuilts did not work because of the new data field `map` which is only available for OSM version >= 0.6. Fix this by making a case distinction.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
