### PR TITLE
Updated the rule retrieve_osm_prebuild

### DIFF
--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -556,18 +556,24 @@ if config["enable"]["retrieve"] and (
     rule retrieve_osm_prebuilt:
         input:
             [
-                storage(
-                    f"https://zenodo.org/records/{OSM_ZENODO_IDS[OSM_VERSION]}/files/{component}.csv"
-                ) if component != "map" else
-                storage(
-                    f"https://zenodo.org/records/{OSM_ZENODO_IDS[OSM_VERSION]}/files/{component}.html"
+                (
+                    storage(
+                        f"https://zenodo.org/records/{OSM_ZENODO_IDS[OSM_VERSION]}/files/{component}.csv"
+                    )
+                    if component != "map"
+                    else storage(
+                        f"https://zenodo.org/records/{OSM_ZENODO_IDS[OSM_VERSION]}/files/{component}.html"
+                    )
                 )
                 for component in OSM_COMPONENTS
             ],
         output:
             [
-                f"data/osm-prebuilt/{OSM_VERSION}/{component}.csv" if component != "map" else
-                f"data/osm-prebuilt/{OSM_VERSION}/{component}.html"
+                (
+                    f"data/osm-prebuilt/{OSM_VERSION}/{component}.csv"
+                    if component != "map"
+                    else f"data/osm-prebuilt/{OSM_VERSION}/{component}.html"
+                )
                 for component in OSM_COMPONENTS
             ],
         log:

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -558,12 +558,16 @@ if config["enable"]["retrieve"] and (
             [
                 storage(
                     f"https://zenodo.org/records/{OSM_ZENODO_IDS[OSM_VERSION]}/files/{component}.csv"
+                ) if component != "map" else
+                storage(
+                    f"https://zenodo.org/records/{OSM_ZENODO_IDS[OSM_VERSION]}/files/{component}.html"
                 )
                 for component in OSM_COMPONENTS
             ],
         output:
             [
-                f"data/osm-prebuilt/{OSM_VERSION}/{component}.csv"
+                f"data/osm-prebuilt/{OSM_VERSION}/{component}.csv" if component != "map" else
+                f"data/osm-prebuilt/{OSM_VERSION}/{component}.html"
                 for component in OSM_COMPONENTS
             ],
         log:


### PR DESCRIPTION
Closes #1497 .

## Changes proposed in this Pull Request

    # update rule to use the correct version
    rule retrieve_osm_prebuilt:
        input:
            [
                storage(
                    f"https://zenodo.org/records/{OSM_ZENODO_IDS[OSM_VERSION]}/files/{component}.csv"
                ) if component != "map" else
                storage(
                    f"https://zenodo.org/records/{OSM_ZENODO_IDS[OSM_VERSION]}/files/{component}.html"
                )
                for component in OSM_COMPONENTS
            ],
        output:
            [
                f"data/osm-prebuilt/{OSM_VERSION}/{component}.csv" if component != "map" else
                f"data/osm-prebuilt/{OSM_VERSION}/{component}.html"
                for component in OSM_COMPONENTS
            ],


## Checklist

- [x ] I tested my contribution locally and it works as intended.

simple bug fix for data path, no more documentation needed

