### PR TITLE
refactor: only add weighted price if load if non-zero

### DIFF
--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -542,24 +542,22 @@ def calculate_weighted_prices(n, label, weighted_prices):
     carriers = n.buses.carrier.unique()
 
     for carrier in carriers:
-        load = (
-            n.statistics.withdrawal(
-                groupby=pypsa.statistics.groupers["bus", "carrier"],
-                aggregate_time=False,
-                nice_names=False,
-                bus_carrier=carrier,
-            )
-            .groupby(level="bus")
-            .sum()
-            .T.fillna(0)
+        load = n.statistics.withdrawal(
+            groupby=pypsa.statistics.groupers["bus", "carrier"],
+            aggregate_time=False,
+            nice_names=False,
+            bus_carrier=carrier,
         )
 
-        price = n.buses_t.marginal_price.loc[:, n.buses.carrier == carrier]
-        price = price.reindex(columns=load.columns, fill_value=1)
+        if not load.empty and load.sum().sum() > 0:
+            load = load.groupby(level="bus").sum().T.fillna(0)
 
-        weighted_prices.loc[carrier, label] = (
-            load * price
-        ).sum().sum() / load.sum().sum()
+            price = n.buses_t.marginal_price.loc[:, n.buses.carrier == carrier]
+            price = price.reindex(columns=load.columns, fill_value=1)
+
+            weighted_prices.loc[carrier, label] = (
+                load * price
+            ).sum().sum() / load.sum().sum()
 
     return weighted_prices
 


### PR DESCRIPTION
I encountered some strange behavior when concatenating empty pandas series with non-empty pandas dataframes in the statistics module in pypsa, which can happen when aggregate_time is False. A fix is provided in https://github.com/PyPSA/PyPSA/pull/1118/files#diff-ce7e31f541948b44c5a77e2e6d35c8ba65265254f2d1e97174cd234b2a548cdaR224-R227, but it also leads to the behavior that the groupby columns that we insert in the statistics function don't always appear as index level (if all components are empty, no groupby is performed and thus the "target" groupby parameters don't appear in the index level). 
For this reason, this small case distinction is necessary.   