### PR TITLE
fix(add_electricity): Fix nuclear p_max_pu time-series for greenfield nuclear

### DIFF
--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -492,16 +492,6 @@ def input_profile_tech(w):
     }
 
 
-def input_conventional(w):
-    return {
-        f"conventional_{carrier}_{attr}": fn
-        for carrier, d in config_provider("conventional", default={None: {}})(w).items()
-        if carrier in config_provider("electricity", "conventional_carriers")(w)
-        for attr, fn in d.items()
-        if str(fn).startswith("data/")
-    }
-
-
 rule build_electricity_demand_base:
     params:
         distribution_key=config_provider("load", "distribution_key"),
@@ -647,10 +637,14 @@ def input_profile_tech(w):
 
 
 def input_conventional(w):
+    carriers = [
+        *config_provider("electricity", "conventional_carriers")(w),
+        *config_provider("electricity", "extendable_carriers", "Generator")(w),
+    ]
     return {
         f"conventional_{carrier}_{attr}": fn
-        for carrier, d in config_provider("conventional", default={None: {}})(w).items()
-        if carrier in config_provider("electricity", "conventional_carriers")(w)
+        for carrier, d in config_provider("conventional", default={})(w).items()
+        if carrier in carriers
         for attr, fn in d.items()
         if str(fn).startswith("data/")
     }


### PR DESCRIPTION
## Changes proposed in this Pull Request

If nuclear is only part of extendable carriers, but not of convential carriers, then the typical "conventional: nuclear: p_max_pu" setting writes the file name all over the p_max_pu time-series, breaking the add_electricity rule.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
