### PR TITLE
add jupyter & entsoe-py to env

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -58,12 +58,14 @@ dependencies:
 - ipython
 - pre-commit
 - ruff
+- jupyter
 
 - pip:
   - gurobipy
   - highspy<1.8
   - pyscipopt # See https://github.com/scipopt/PySCIPOpt/issues/944
   - tsam>=2.3.1
+  - entsoe-py
   - snakemake-storage-plugin-http
   - snakemake-executor-plugin-slurm
   - snakemake-executor-plugin-cluster-generic


### PR DESCRIPTION
Closes #1530 

I took the freedom to add `entsoe-py` to the pip installation. It is quite minimal and will be used in upcoming projects with pypsa-eur (provides bidding zones, demand time series and even flow based domains i think) 


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
