### PR TITLE
fix for heat_dsm_profile for leap year

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2155,8 +2155,8 @@ def add_heat(n: pypsa.Network, costs: pd.DataFrame, cop: xr.DataArray):
             heat_dsm_profile = pd.read_csv(
                 snakemake.input.heat_dsm_profile, header=[1], index_col=[0]
             )[nodes]
-            heat_dsm_profile.index = n.snapshots
-
+            heat_dsm_profile.index = pd.DatetimeIndex(heat_dsm_profile.index)
+            heat_dsm_profile = heat_dsm_profile.reindex(n.snapshots)
             e_nom = (
                 heat_demand[["residential space"]]
                 .T.groupby(level=1)


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR adds some small changes to the heat DSM PR allowing the heat dsm profile to be compatible with different climate years or snapshots from a leap year and leap year is ignored.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
