### PR TITLE
Fixing snakemake shadow directory bug that occures with Windows/SMB drives

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -10,7 +10,7 @@ from snakemake.utils import min_version
 
 min_version("8.11")
 
-from scripts._helpers import path_provider, copy_default_files, get_scenarios, get_rdir
+from scripts._helpers import path_provider, copy_default_files, get_scenarios, get_rdir, get_shadow
 
 
 copy_default_files(workflow)
@@ -23,6 +23,7 @@ configfile: "config/config.yaml"
 run = config["run"]
 scenarios = get_scenarios(run)
 RDIR = get_rdir(run)
+shadow_config = get_shadow(run)
 
 shared_resources = run["shared_resources"]["policy"]
 exclude_from_shared = run["shared_resources"]["exclude"]

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -30,6 +30,7 @@ run:
     policy: false
     exclude: []
   shared_cutouts: true
+  use_shadow_directory: true # Set to false if problems regarding missing directories occur
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#foresight
 foresight: overnight

--- a/doc/configtables/run.csv
+++ b/doc/configtables/run.csv
@@ -9,3 +9,4 @@ shared_resources,,,
 -- policy,bool/str,,"Boolean switch to select whether resources should be shared across runs. If a string is passed, this is used as a subdirectory name for shared resources. If set to 'base', only resources before creating the elec.nc file are shared."
 -- exclude,str,"For the case shared_resources=base, specify additional files that should not be shared across runs."
 shared_cutouts,bool,"{true, false}","Switch to select whether cutouts should be shared across runs."
+use_shadow_directory,bool,"{true, false}","Set to ``true`` (default) if snakemake shadow directories (``shallow``) should be used. Set to ``false`` if problems occcur."

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,6 +13,7 @@ Upcoming Release
 
 - Added option to specify the cutout directory in the configuration file. This allows to the user to specify the directory where the cutouts are stored. Use it by setting ``atlite: cutout_directory:`` in the configuration file. (https://github.com/PyPSA/pypsa-eur/pull/1515)
 
+- Bug fix: Added setting ``run: use_shadow_directory:`` (default: ``true``) which sets the ``shadow`` parameter of the snakemake workflow. Configuring to ``true`` sets snakemake ``shadow`` parameter to ``shalloow``, ``false`` to `Ǹone``. Should be set to ``false`` for those cases, where snakemake has an issue with finding missing input/output files in solving rules.
 
 PyPSA-Eur v2025.01.0 (24th January 2025)
 ========================================

--- a/rules/solve_electricity.smk
+++ b/rules/solve_electricity.smk
@@ -29,8 +29,8 @@ rule solve_network:
     resources:
         mem_mb=memory,
         runtime=config_provider("solving", "runtime", default="6h"),
-    shadow:
-        "shallow"
+    shadow: 
+        shadow_config
     conda:
         "../envs/environment.yaml"
     script:
@@ -65,7 +65,7 @@ rule solve_operations_network:
         mem_mb=(lambda w: 10000 + 372 * int(w.clusters)),
         runtime=config_provider("solving", "runtime", default="6h"),
     shadow:
-        "shallow"
+        shadow_config
     conda:
         "../envs/environment.yaml"
     script:

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -128,7 +128,7 @@ rule solve_sector_network_myopic:
         config=RESULTS
         + "configs/config.base_s_{clusters}_{opts}_{sector_opts}_{planning_horizons}.yaml",
     shadow:
-        "shallow"
+       shadow_config
     log:
         solver=RESULTS
         + "logs/base_s_{clusters}_{opts}_{sector_opts}_{planning_horizons}_solver.log",

--- a/rules/solve_overnight.smk
+++ b/rules/solve_overnight.smk
@@ -22,7 +22,7 @@ rule solve_sector_network:
         config=RESULTS
         + "configs/config.base_s_{clusters}_{opts}_{sector_opts}_{planning_horizons}.yaml",
     shadow:
-        "shallow"
+        shadow_config
     log:
         solver=RESULTS
         + "logs/base_s_{clusters}_{opts}_{sector_opts}_{planning_horizons}_solver.log",

--- a/rules/solve_perfect.smk
+++ b/rules/solve_perfect.smk
@@ -113,7 +113,7 @@ rule solve_sector_network_perfect:
     resources:
         mem_mb=config_provider("solving", "mem"),
     shadow:
-        "shallow"
+        shadow_config
     log:
         solver=RESULTS
         + "logs/base_s_{clusters}_{opts}_{sector_opts}_brownfield_all_years_solver.log",

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -162,6 +162,16 @@ def path_provider(dir, rdir, shared_resources, exclude_from_shared):
     )
 
 
+def get_shadow(run):
+    """
+    Returns 'shallow' or None depending on the user setting.
+    """
+    shadow_config = run.get("use_shadow_directory", True)
+    if shadow_config:
+        return "shallow"
+    return None
+
+
 def get_opt(opts, expr, flags=None):
     """
     Return the first option matching the regular expression.


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Fixes issue (occuring mostly on Windows/WSL systems or when project is located on a network drive (e.g. connected through SMB protocol), that input/output files could not be found when snakemake's `shadow` parameter is used.
- Error `FileNotFoundError: [Errno 2] No such file or directory: '.../pypsa-eur/.snakemake/shadow/tmp.../results/...'`
- Implemented as a function in `_helpers` as direct access through `config_provider` or `config["run"]["use_shadow_directory"]` does not work.
- Seems to be a general issue in Snakemake, this is a pragmatic, functioning workaround for now.

## Checklist

- [X] I tested my contribution locally and it works as intended.
- [X] Code and workflow changes are sufficiently documented.
- [X] Changes in configuration options are added in `config/config.default.yaml`.
- [X] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [X] Sources of newly added data are documented in `doc/data_sources.rst`.
- [X] A release note `doc/release_notes.rst` is added.