### PR TITLE
Increase resources/mem_mb for default regional scope

### DIFF
--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -476,7 +476,7 @@ rule build_biomass_potentials:
         ),
     threads: 8
     resources:
-        mem_mb=1000,
+        mem_mb=2000,
     log:
         logs("build_biomass_potentials_s_{clusters}_{planning_horizons}.log"),
     benchmark:

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -40,7 +40,7 @@ rule add_existing_baseyear:
         planning_horizons=config["scenario"]["planning_horizons"][0],  #only applies to baseyear
     threads: 1
     resources:
-        mem_mb=2000,
+        mem_mb=3000,
     log:
         logs(
             "add_existing_baseyear_base_s_{clusters}_{opts}_{sector_opts}_{planning_horizons}.log"


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Fixing out of memory errors due to requested memory being to low for the default regional scope
- `build_biomass_potentials`: `mem_mb=1000` $\rightarrow$ `mem_mb=2000`
- `add_existing_baseyear`: `mem_mb=2000` $\rightarrow$ `mem_mb=3000`

## Checklist
- [X] I tested my contribution locally and it works as intended.
