### PR TITLE
fix: the planning_horizons params in CCL need to be string

### DIFF
--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -112,7 +112,7 @@ rule solve_sector_network_myopic:
     params:
         solving=config_provider("solving"),
         foresight=config_provider("foresight"),
-        planning_horizons=config_provider("scenario", "planning_horizons"),
+        planning_horizons=lambda wildcards: wildcards.planning_horizons,
         co2_sequestration_potential=config_provider(
             "sector", "co2_sequestration_potential", default=200
         ),

--- a/rules/solve_overnight.smk
+++ b/rules/solve_overnight.smk
@@ -7,7 +7,7 @@ rule solve_sector_network:
     params:
         solving=config_provider("solving"),
         foresight=config_provider("foresight"),
-        planning_horizons=config_provider("scenario", "planning_horizons"),
+        planning_horizons=lambda wildcards: wildcards.planning_horizons,
         co2_sequestration_potential=config_provider(
             "sector", "co2_sequestration_potential", default=200
         ),

--- a/rules/solve_perfect.smk
+++ b/rules/solve_perfect.smk
@@ -94,7 +94,7 @@ rule solve_sector_network_perfect:
         solving=config_provider("solving"),
         foresight=config_provider("foresight"),
         sector=config_provider("sector"),
-        planning_horizons=config_provider("scenario", "planning_horizons"),
+        planning_horizons=lambda wildcards: wildcards.planning_horizons,
         co2_sequestration_potential=config_provider(
             "sector", "co2_sequestration_potential", default=200
         ),

--- a/rules/solve_perfect.smk
+++ b/rules/solve_perfect.smk
@@ -94,7 +94,7 @@ rule solve_sector_network_perfect:
         solving=config_provider("solving"),
         foresight=config_provider("foresight"),
         sector=config_provider("sector"),
-        planning_horizons=lambda wildcards: wildcards.planning_horizons,
+        planning_horizons=config_provider("scenario", "planning_horizons", -1),
         co2_sequestration_potential=config_provider(
             "sector", "co2_sequestration_potential", default=200
         ),

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -244,6 +244,15 @@ def add_co2_sequestration_limit(
 ) -> None:
     """
     Add a global constraint on the amount of Mt CO2 that can be sequestered.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        The PyPSA network instance
+    limit_dict : dict[str, float]
+        CO2 sequestration potential limit constraints by year.
+    planning_horizons : str
+        The current planning horizon year
     """
 
     if not n.investment_periods.empty:
@@ -412,7 +421,7 @@ def prepare_network(
     foresight : str
         Planning foresight type ('myopic' or 'perfect')
     planning_horizons : str
-        List of planning horizon years
+        The current planning horizon year
     co2_sequestration_potential : Dict[str, float]
         CO2 sequestration potential constraints by year
 
@@ -513,8 +522,11 @@ def add_CCL_constraints(n: pypsa.Network, config: dict, planning_horizons: str) 
     Parameters
     ----------
     n : pypsa.Network
+        The PyPSA network instance
     config : dict
+        Configuration dictionary
     planning_horizons : str
+        The current planning horizon year
 
     Example
     -------


### PR DESCRIPTION
Closes # (if applicable).

## Issue:
When using CCL, an error occurs because the year key cannot be found in `agg_p_nom_minmax.csv`. The error is shown in the image below.<img width="1108" alt="image" src="https://github.com/user-attachments/assets/2c544ee9-64c0-4962-a84b-55a566095d26" />

config: 
```
 agg_p_nom_limits:
    agg_offwind: false
    include_existing: false
    file: data/agg_p_nom_minmax.csv
```

agg_p_nom_minmax.csv:
```
,,2030,2030,2045,2045,2050,2050
,,min,max,min,max,min,max
country,carrier,,,,,,
DE,onwind,0.1,,180000,181000,0.1,
DE,offwind-all,0.1,,71000,82000,0.1,
DE,solar,0.2,,336000,336500,0.2,
DE,solar rooftop,0.2,,164000,164500,0.2,
```

## Cause:


The issue arises in the function `add_CCL_constraints` https://github.com/PyPSA/pypsa-eur/blob/master/scripts/solve_network.py#L984. 

The parameter `planning_horizons` should be a string, but a list is passed instead. 

This problem was introduced by the changes in the PR for Consistent function scope 
1537 (https://github.com/PyPSA/pypsa-eur/pull/1537).


## Solution:
Modify the definition of the `planning_horizons` parameter in the rule to be a string.


## Changes proposed in this Pull Request


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
