### PR TITLE
fix(benchmark): ignore keyboard interrupt in memory logging subprocess

### DIFF
--- a/scripts/_benchmark.py
+++ b/scripts/_benchmark.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+import signal
 import sys
 import time
 
@@ -42,6 +43,9 @@ class MemTimer(Process):
         super().__init__(*args, **kw)
 
     def run(self):
+        # ignore the interrupt signal in the child process
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+
         # get baseline memory usage
         cur_mem = _get_memory(
             self.monitor_pid,


### PR DESCRIPTION
## Changes proposed in this Pull Request

ensures a C-c is not consumed by the logging child process, but instead properly terminates the solver or main python process.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] A release note `doc/release_notes.rst` is added.
