### PR TITLE
Change heat_vent config.default setting

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -618,7 +618,7 @@ sector:
   coal_cc: false
   dac: true
   co2_vent: false
-  central_heat_vent: false
+  central_heat_vent: true
   allam_cycle_gas: false
   hydrogen_fuel_cell: true
   hydrogen_turbine: false

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,9 +11,9 @@ Release Notes
 Upcoming Release
 ================
 
-* Bugfix: Geothermal heat potentials are now restricted to those in close proximity to future district heating areas as projected by Manz et al. 2024. Includes a refactoring change: Building of generic technical potentials from heat utilisation potentials was changed to specific computation of geothermal heat potentials.
+- Bugfix: Changed setting ``central_heat_vent`` (default: ``true``) because the urban central water tanks charger and discharger were previously used as heat vents with an efficiency of 0.9. Charger sizing is now directly linked to hot water store sizing via the ``TES_energy_to_power_ratio_constraints``, and the efficiency has been updated to 1.0 according to DEA technology catalogues. Consequently, they no longer function as heat vents.
 
-- ...
+* Bugfix: Geothermal heat potentials are now restricted to those in close proximity to future district heating areas as projected by Manz et al. 2024. Includes a refactoring change: Building of generic technical potentials from heat utilisation potentials was changed to specific computation of geothermal heat potentials.
 
 - Bug fix: Added setting ``run: use_shadow_directory:`` (default: ``true``) which sets the ``shadow`` parameter of the snakemake workflow. Configuring to ``true`` sets snakemake ``shadow`` parameter to ``shalloow``, ``false`` to `Ǹone``. Should be set to ``false`` for those cases, where snakemake has an issue with finding missing input/output files in solving rules.
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,7 +11,7 @@ Release Notes
 Upcoming Release
 ================
 
-- Bugfix: Changed setting ``central_heat_vent`` (default: ``true``) because the urban central water tanks charger and discharger were previously used as heat vents with an efficiency of 0.9. Charger sizing is now directly linked to hot water store sizing via the ``TES_energy_to_power_ratio_constraints``, and the efficiency has been updated to 1.0 according to DEA technology catalogues. Consequently, they no longer function as heat vents.
+- Bugfix: Changed setting ``central_heat_vent`` (default: ``true``), because the  water tanks charger and discharger were used as heat vents with an efficiency of 0.9.
 
 * Bugfix: Geothermal heat potentials are now restricted to those in close proximity to future district heating areas as projected by Manz et al. 2024. Includes a refactoring change: Building of generic technical potentials from heat utilisation potentials was changed to specific computation of geothermal heat potentials.
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

By default, the ```central_heat_vent``` setting in is disabled in ```config.default.yaml```.
```yaml
sector:
   central_heat_vent: False
```
 As a result, the urban central water tanks charger and discharger have been utilized as heat vents, both operating with an efficiency of 0.9.

However, with the introduction of PR #1546, which aims to implement a more realistic approach for modeling thermal energy storage, the sizing of the charger is now directly linked to that of the hot water storage via the ```TES_energy_to_power_ratio_constraints```. Consequently, the charger can no longer be used as a heat vent.

The figure below illustrates the behavior of the "BE0 3 urban central water tanks charger" and "BE0 3 urban central water tanks discharger" as defined in ```config/test/config.overnight.yaml```, demonstrating how energy is "released" as heat.

![timeseries_charger_discharger](https://github.com/user-attachments/assets/73e5501a-a4a1-4cb9-941c-ef1622b362c4)



## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
