### PR TITLE
fix(solve): Fix planning_horizons in solve_network

### DIFF
--- a/rules/solve_electricity.smk
+++ b/rules/solve_electricity.smk
@@ -7,7 +7,6 @@ rule solve_network:
     params:
         solving=config_provider("solving"),
         foresight=config_provider("foresight"),
-        planning_horizons=config_provider("scenario", "planning_horizons"),
         co2_sequestration_potential=config_provider(
             "sector", "co2_sequestration_potential", default=200
         ),
@@ -42,7 +41,6 @@ rule solve_operations_network:
         options=config_provider("solving", "options"),
         solving=config_provider("solving"),
         foresight=config_provider("foresight"),
-        planning_horizons=config_provider("scenario", "planning_horizons"),
         co2_sequestration_potential=config_provider(
             "sector", "co2_sequestration_potential", default=200
         ),

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -112,7 +112,6 @@ rule solve_sector_network_myopic:
     params:
         solving=config_provider("solving"),
         foresight=config_provider("foresight"),
-        planning_horizons=lambda wildcards: wildcards.planning_horizons,
         co2_sequestration_potential=config_provider(
             "sector", "co2_sequestration_potential", default=200
         ),

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -112,7 +112,7 @@ rule solve_sector_network_myopic:
     params:
         solving=config_provider("solving"),
         foresight=config_provider("foresight"),
-        planning_horizons=config_provider("scenario", "planning_horizons"),
+        planning_horizons=lambda wildcards: wildcards.planning_horizons,
         co2_sequestration_potential=config_provider(
             "sector", "co2_sequestration_potential", default=200
         ),

--- a/rules/solve_overnight.smk
+++ b/rules/solve_overnight.smk
@@ -7,7 +7,7 @@ rule solve_sector_network:
     params:
         solving=config_provider("solving"),
         foresight=config_provider("foresight"),
-        planning_horizons=config_provider("scenario", "planning_horizons"),
+        planning_horizons=lambda wildcards: wildcards.planning_horizons,
         co2_sequestration_potential=config_provider(
             "sector", "co2_sequestration_potential", default=200
         ),

--- a/rules/solve_overnight.smk
+++ b/rules/solve_overnight.smk
@@ -7,7 +7,6 @@ rule solve_sector_network:
     params:
         solving=config_provider("solving"),
         foresight=config_provider("foresight"),
-        planning_horizons=lambda wildcards: wildcards.planning_horizons,
         co2_sequestration_potential=config_provider(
             "sector", "co2_sequestration_potential", default=200
         ),

--- a/rules/solve_perfect.smk
+++ b/rules/solve_perfect.smk
@@ -94,7 +94,7 @@ rule solve_sector_network_perfect:
         solving=config_provider("solving"),
         foresight=config_provider("foresight"),
         sector=config_provider("sector"),
-        planning_horizons=config_provider("scenario", "planning_horizons"),
+        planning_horizons=lambda wildcards: wildcards.planning_horizons,
         co2_sequestration_potential=config_provider(
             "sector", "co2_sequestration_potential", default=200
         ),

--- a/rules/solve_perfect.smk
+++ b/rules/solve_perfect.smk
@@ -94,7 +94,7 @@ rule solve_sector_network_perfect:
         solving=config_provider("solving"),
         foresight=config_provider("foresight"),
         sector=config_provider("sector"),
-        planning_horizons=lambda wildcards: wildcards.planning_horizons,
+        planning_horizons=config_provider("scenario", "planning_horizons", -1),
         co2_sequestration_potential=config_provider(
             "sector", "co2_sequestration_potential", default=200
         ),

--- a/rules/solve_perfect.smk
+++ b/rules/solve_perfect.smk
@@ -94,7 +94,7 @@ rule solve_sector_network_perfect:
         solving=config_provider("solving"),
         foresight=config_provider("foresight"),
         sector=config_provider("sector"),
-        planning_horizons=config_provider("scenario", "planning_horizons", -1),
+        planning_horizons=config_provider("scenario", "planning_horizons"),
         co2_sequestration_potential=config_provider(
             "sector", "co2_sequestration_potential", default=200
         ),

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -128,7 +128,7 @@ def add_land_use_constraint_perfect(n: pypsa.Network) -> None:
         n.buses.loc[bus, name] = df_carrier.p_nom_max.values
 
 
-def add_land_use_constraint(n: pypsa.Network, planning_horizon: str) -> None:
+def add_land_use_constraint(n: pypsa.Network, planning_horizons: str) -> None:
     """
     Add land use constraints for renewable energy potential.
 
@@ -136,7 +136,7 @@ def add_land_use_constraint(n: pypsa.Network, planning_horizon: str) -> None:
     ----------
     n : pypsa.Network
         The PyPSA network instance
-    planning_horizon : str
+    planning_horizons : str
         The planning horizon year as string
 
     Returns
@@ -161,7 +161,7 @@ def add_land_use_constraint(n: pypsa.Network, planning_horizon: str) -> None:
             .groupby(n.generators.bus.map(n.buses.location))
             .sum()
         )
-        existing.index += f" {carrier}-{planning_horizon}"
+        existing.index += f" {carrier}-{planning_horizons}"
         n.generators.loc[existing.index, "p_nom_max"] -= existing
 
     # check if existing capacities are larger than technical potential
@@ -241,7 +241,7 @@ def add_solar_potential_constraints(n: pypsa.Network, config: dict) -> None:
 def add_co2_sequestration_limit(
     n: pypsa.Network,
     limit_dict: dict[str, float],
-    planning_horizons: str,
+    planning_horizons: str | None,
 ) -> None:
     """
     Add a global constraint on the amount of Mt CO2 that can be sequestered.
@@ -252,8 +252,8 @@ def add_co2_sequestration_limit(
         The PyPSA network instance
     limit_dict : dict[str, float]
         CO2 sequestration potential limit constraints by year.
-    planning_horizons : str
-        The current planning horizon year
+    planning_horizons : str, optional
+        The current planning horizon year or None in perfect foresight
     """
 
     if not n.investment_periods.empty:
@@ -512,7 +512,7 @@ def prepare_network(
         )
 
 
-def add_CCL_constraints(n: pypsa.Network, config: dict, planning_horizons: str) -> None:
+def add_CCL_constraints(n: pypsa.Network, config: dict, planning_horizons: str|None) -> None:
     """
     Add CCL (country & carrier limit) constraint to the network.
 
@@ -526,8 +526,8 @@ def add_CCL_constraints(n: pypsa.Network, config: dict, planning_horizons: str) 
         The PyPSA network instance
     config : dict
         Configuration dictionary
-    planning_horizons : str
-        The current planning horizon year
+    planning_horizons : str, optional
+        The current planning horizon year or None in perfect foresight
 
     Example
     -------
@@ -536,6 +536,10 @@ def add_CCL_constraints(n: pypsa.Network, config: dict, planning_horizons: str) 
     electricity:
         agg_p_nom_limits: data/agg_p_nom_minmax.csv
     """
+
+    assert planning_horizons is not None, \
+        "add_CCL_constraints are not implemented for perfect foresight, yet"
+
     agg_p_nom_minmax = pd.read_csv(
         config["solving"]["agg_p_nom_limits"]["file"], index_col=[0, 1], header=[0, 1]
     )[planning_horizons]
@@ -978,7 +982,7 @@ def extra_functionality(
     snapshots : pd.DatetimeIndex
         Simulation timesteps
     planning_horizons : str, optional
-        The current planning horizon year
+        The current planning horizon year or None in perfect foresight
 
     Collects supplementary constraints which will be passed to
     ``pypsa.optimization.optimize``.
@@ -994,7 +998,7 @@ def extra_functionality(
     if constraints["SAFE"] and n.generators.p_nom_extendable.any():
         add_SAFE_constraints(n, config)
     if constraints["CCL"] and n.generators.p_nom_extendable.any():
-        add_CCL_constraints(n, config, n.planning_horizons)
+        add_CCL_constraints(n, config, planning_horizons)
 
     reserve = config["electricity"].get("operational_reserve", {})
     if reserve.get("activate"):
@@ -1085,6 +1089,8 @@ def solve_network(
         Dictionary of solving options and configuration
     rule_name : str, optional
         Name of the snakemake rule being executed
+    planning_horizons : str, optional
+            The current planning horizon year or None in perfect foresight
     **kwargs
         Additional keyword arguments passed to the solver
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -512,7 +512,9 @@ def prepare_network(
         )
 
 
-def add_CCL_constraints(n: pypsa.Network, config: dict, planning_horizons: str|None) -> None:
+def add_CCL_constraints(
+    n: pypsa.Network, config: dict, planning_horizons: str | None
+) -> None:
     """
     Add CCL (country & carrier limit) constraint to the network.
 
@@ -537,8 +539,9 @@ def add_CCL_constraints(n: pypsa.Network, config: dict, planning_horizons: str|N
         agg_p_nom_limits: data/agg_p_nom_minmax.csv
     """
 
-    assert planning_horizons is not None, \
+    assert planning_horizons is not None, (
         "add_CCL_constraints are not implemented for perfect foresight, yet"
+    )
 
     agg_p_nom_minmax = pd.read_csv(
         config["solving"]["agg_p_nom_limits"]["file"], index_col=[0, 1], header=[0, 1]

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -244,6 +244,15 @@ def add_co2_sequestration_limit(
 ) -> None:
     """
     Add a global constraint on the amount of Mt CO2 that can be sequestered.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        The PyPSA network instance
+    limit_dict : dict[str, float]
+        CO2 sequestration potential limit constraints by year.
+    planning_horizons : str
+        The current planning horizon year
     """
 
     if not n.investment_periods.empty:
@@ -412,7 +421,7 @@ def prepare_network(
     foresight : str
         Planning foresight type ('myopic' or 'perfect')
     planning_horizons : str
-        List of planning horizon years
+        The current planning horizon year
     co2_sequestration_potential : Dict[str, float]
         CO2 sequestration potential constraints by year
 
@@ -513,8 +522,11 @@ def add_CCL_constraints(n: pypsa.Network, config: dict, planning_horizons: str) 
     Parameters
     ----------
     n : pypsa.Network
+        The PyPSA network instance
     config : dict
+        Configuration dictionary
     planning_horizons : str
+        The current planning horizon year
 
     Example
     -------

--- a/scripts/solve_operations_network.py
+++ b/scripts/solve_operations_network.py
@@ -52,6 +52,7 @@ if __name__ == "__main__":
         params=snakemake.params,
         solving=snakemake.params.solving,
         log_fn=snakemake.log.solver,
+        rule_name=snakemake.rule,
     )
 
     n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))


### PR DESCRIPTION
Follow-up to #1537 .

Closes #1551 .

## Changes proposed in this Pull Request

In perfect foresight, the planning_horizons param remains the list
of all planning horizons (to trigger re-runs).

The current planning horizons is always taken from the planning_horizons
wildcard and passed into extra_functionality as a partial kwarg.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
