### PR TITLE
enh: enable running mock_snakemake from a separate workdir

### DIFF
--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -533,6 +533,7 @@ def mock_snakemake(
     else:
         root_dir = Path(root_dir).resolve()
 
+    workdir = None
     user_in_script_dir = Path.cwd().resolve() == script_dir
     if str(submodule_dir) in __file__:
         # the submodule_dir path is only need to locate the project dir
@@ -540,12 +541,12 @@ def mock_snakemake(
     elif user_in_script_dir:
         os.chdir(root_dir)
     elif Path.cwd().resolve() != root_dir:
-        raise RuntimeError(
-            "mock_snakemake has to be run from the repository root"
-            f" {root_dir} or scripts directory {script_dir}"
-        )
+        logger.info("Not in scripts or root directory, will assume this is a separate workdir")
+        workdir = Path.cwd()
+
     try:
         for p in SNAKEFILE_CHOICES:
+            p = root_dir / p
             if os.path.exists(p):
                 snakefile = p
                 break
@@ -566,6 +567,7 @@ def mock_snakemake(
             storage_settings,
             dag_settings,
             storage_provider_settings=dict(),
+            overwrite_workdir=workdir,
         )
         workflow.include(snakefile)
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Working directories are a simple mechanism of snakemake to have multiple not competing runs of the same workflow.

Data, config and logfiles are expected relative to the directory specified with `--directory`, while all the source files (mainly script snakemake and environment definitions are resolved relative from the current snakefile).

A new working directory can be quickly set up:
```shell
mkdir workdir
cp -lr -t workdir --parents cutouts $(git ls-files data)
cp -r config workdir
```

Running it then works in the repo root like
```shell
snakemake --directory workdir ...
```


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
