### PR TITLE
Windows snakefile

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -32,7 +32,7 @@ Upcoming Release
 
 * New feature: Allowing network clustering based on administrative boundaries (i.e., NUTS0/country-level to NUTS3).  To make use of this setting, set ``clustering["mode"]: administrative`` and additionally the ``clusters`` wildcard in ``scenario`` to ‘adm’. Optionally include dictionary of individual country codes and their individual NUTS levels (0 to 3, see documentation). Note that non-NUTS countries 'BA', 'MD', 'UA', and 'XK' can only be clustered to level 0 and 1. Please be aware that not every region will solve/converge at every NUTS level (especially at high NUTS resolution) due to rigid regional boundaries.
 
-* Bugfix: Change wdpa download rules in ``retrieve.smk`` to use powershell on Windows. (https://github.com/PyPSA/pypsa-eur/pull/1575)
+* Bugfix: Change wdpa download rules in ``retrieve.smk`` to use shutil instead of shell commands to properly function on Windows. (https://github.com/PyPSA/pypsa-eur/pull/1575)
 
 PyPSA-Eur v2025.01.0 (24th January 2025)
 ========================================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -32,6 +32,8 @@ Upcoming Release
 
 * New feature: Allowing network clustering based on administrative boundaries (i.e., NUTS0/country-level to NUTS3).  To make use of this setting, set ``clustering["mode"]: administrative`` and additionally the ``clusters`` wildcard in ``scenario`` to ‘adm’. Optionally include dictionary of individual country codes and their individual NUTS levels (0 to 3, see documentation). Note that non-NUTS countries 'BA', 'MD', 'UA', and 'XK' can only be clustered to level 0 and 1. Please be aware that not every region will solve/converge at every NUTS level (especially at high NUTS resolution) due to rigid regional boundaries.
 
+* Bugfix: Change wdpa download rules in ``retrieve.smk`` to use powershell on Windows. (https://github.com/PyPSA/pypsa-eur/pull/1575)
+
 PyPSA-Eur v2025.01.0 (24th January 2025)
 ========================================
 

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -474,8 +474,14 @@ if config["enable"]["retrieve"]:
         output:
             gpkg="data/WDPA.gpkg",
         run:
-            shell("cp {input} {params.zip}")
-            shell("unzip -o {params.zip} -d {params.folder}")
+            if os.name == "nt": # Special handling for Windows (PR #1575)
+                shell("powershell -Command \"Copy-Item -Path {input} -Destination {params.zip}\"")
+                shell("powershell -Command \"Expand-Archive -Path {params.zip} -DestinationPath {params.folder} -Force\"")
+                #shell('xcopy "{input}" "{params.zip}"')
+            else:
+                shell("cp {input} {params.zip}")
+                shell("unzip -o {params.zip} -d {params.folder}")
+            
             for i in range(3):
                 # vsizip is special driver for directly working with zipped shapefiles in ogr2ogr
                 layer_path = (
@@ -499,8 +505,14 @@ if config["enable"]["retrieve"]:
         output:
             gpkg="data/WDPA_WDOECM_marine.gpkg",
         run:
-            shell("cp {input} {params.zip}")
-            shell("unzip -o {params.zip} -d {params.folder}")
+            if os.name == "nt": # Special handling for Windows (PR #1575)
+                shell("powershell -Command \"Copy-Item -Path {input} -Destination {params.zip}\"")
+                shell("powershell -Command \"Expand-Archive -Path {params.zip} -DestinationPath {params.folder} -Force\"")
+                #shell('xcopy "{input}" "{params.zip}"')
+            else:
+                shell("cp {input} {params.zip}")
+                shell("unzip -o {params.zip} -d {params.folder}")
+            
             for i in range(3):
                 # vsizip is special driver for directly working with zipped shapefiles in ogr2ogr
                 layer_path = f"/vsizip/{params.folder}/WDPA_WDOECM_{bYYYY}_Public_marine_shp_{i}.zip"

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -468,7 +468,7 @@ if config["enable"]["retrieve"]:
     # Website: https://www.protectedplanet.net/en/thematic-areas/wdpa
     rule download_wdpa:
         input:
-            zip = storage(url, keep_local=True),
+            zip=storage(url, keep_local=True),
         params:
             zip="data/WDPA_shp.zip",
             folder=directory("data/WDPA"),
@@ -477,7 +477,7 @@ if config["enable"]["retrieve"]:
         run:
             shcopy(input.zip, params.zip)
             unpack_archive(params.zip, params.folder)
-            
+
             for i in range(3):
                 # vsizip is special driver for directly working with zipped shapefiles in ogr2ogr
                 layer_path = (
@@ -491,7 +491,7 @@ if config["enable"]["retrieve"]:
         # extract the main zip and then merge the contained 3 zipped shapefiles
         # Website: https://www.protectedplanet.net/en/thematic-areas/marine-protected-areas
         input:
-            zip = storage(
+            zip=storage(
                 f"https://d1gam3xoknrgr2.cloudfront.net/current/WDPA_WDOECM_{bYYYY}_Public_marine_shp.zip",
                 keep_local=True,
             ),

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -477,7 +477,6 @@ if config["enable"]["retrieve"]:
             if os.name == "nt": # Special handling for Windows (PR #1575)
                 shell("powershell -Command \"Copy-Item -Path {input} -Destination {params.zip}\"")
                 shell("powershell -Command \"Expand-Archive -Path {params.zip} -DestinationPath {params.folder} -Force\"")
-                #shell('xcopy "{input}" "{params.zip}"')
             else:
                 shell("cp {input} {params.zip}")
                 shell("unzip -o {params.zip} -d {params.folder}")
@@ -508,7 +507,6 @@ if config["enable"]["retrieve"]:
             if os.name == "nt": # Special handling for Windows (PR #1575)
                 shell("powershell -Command \"Copy-Item -Path {input} -Destination {params.zip}\"")
                 shell("powershell -Command \"Expand-Archive -Path {params.zip} -DestinationPath {params.folder} -Force\"")
-                #shell('xcopy "{input}" "{params.zip}"')
             else:
                 shell("cp {input} {params.zip}")
                 shell("unzip -o {params.zip} -d {params.folder}")


### PR DESCRIPTION
## Changes proposed in this Pull Request

### Summary
Modify `download_wdpa` and `download_wdpa_marine` in `rules/retrieve.smk` to properly work on Windows.

### Reason
Previously, both rules would not work on Windows, since the shell commands `cp` and `unzip` don't exist on Windows.
Since the corresponding commands (`copy`/`xcopy`) did not work for me when testing, and the `tar` command (roughly `unzip`) is not available on older Windows versions, I switched to Powershell.

I am not fully proficient regarding shell or powershell, so please comment any improvements you would suggest!


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
