### PR TITLE
Bidding zones representation + custom busmap

### DIFF
--- a/config/test/config.clusters.yaml
+++ b/config/test/config.clusters.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+
+
+clustering:
+  mode: administrative
+  administrative:
+    level: bz

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -121,38 +121,6 @@ rule build_osm_boundaries:
         "../scripts/build_osm_boundaries.py"
 
 
-rule build_shapes:
-    params:
-        countries=config_provider("countries"),
-    input:
-        eez=ancient("data/eez/World_EEZ_v12_20231025_LR/eez_v12_lowres.gpkg"),
-        nuts3_2021="data/nuts/NUTS_RG_01M_2021_4326_LEVL_3.geojson",
-        ba_adm1="data/osm-boundaries/build/BA_adm1.geojson",
-        md_adm1="data/osm-boundaries/build/MD_adm1.geojson",
-        ua_adm1="data/osm-boundaries/build/UA_adm1.geojson",
-        xk_adm1="data/osm-boundaries/build/XK_adm1.geojson",
-        nuts3_gdp="data/jrc-ardeco/ARDECO-SUVGDP.2021.table.csv",
-        nuts3_pop="data/jrc-ardeco/ARDECO-SNPTD.2021.table.csv",
-        other_gdp="data/bundle/GDP_per_capita_PPP_1990_2015_v2.nc",
-        other_pop="data/bundle/ppp_2019_1km_Aggregated.tif",
-    output:
-        country_shapes=resources("country_shapes.geojson"),
-        offshore_shapes=resources("offshore_shapes.geojson"),
-        europe_shape=resources("europe_shape.geojson"),
-        nuts3_shapes=resources("nuts3_shapes.geojson"),
-    log:
-        logs("build_shapes.log"),
-    benchmark:
-        benchmarks("build_shapes")
-    threads: 1
-    resources:
-        mem_mb=1500,
-    conda:
-        "../envs/environment.yaml"
-    script:
-        "../scripts/build_shapes.py"
-
-
 rule build_bidding_zones:
     params:
         countries=config_provider("countries"),
@@ -171,6 +139,39 @@ rule build_bidding_zones:
         "../envs/environment.yaml"
     script:
         "../scripts/build_bidding_zones.py"
+
+
+rule build_shapes:
+    params:
+        countries=config_provider("countries"),
+    input:
+        eez=ancient("data/eez/World_EEZ_v12_20231025_LR/eez_v12_lowres.gpkg"),
+        nuts3_2021="data/nuts/NUTS_RG_01M_2021_4326_LEVL_3.geojson",
+        ba_adm1="data/osm-boundaries/build/BA_adm1.geojson",
+        md_adm1="data/osm-boundaries/build/MD_adm1.geojson",
+        ua_adm1="data/osm-boundaries/build/UA_adm1.geojson",
+        xk_adm1="data/osm-boundaries/build/XK_adm1.geojson",
+        nuts3_gdp="data/jrc-ardeco/ARDECO-SUVGDP.2021.table.csv",
+        nuts3_pop="data/jrc-ardeco/ARDECO-SNPTD.2021.table.csv",
+        bidding_zones=resources("bidding_zones.geojson"),
+        other_gdp="data/bundle/GDP_per_capita_PPP_1990_2015_v2.nc",
+        other_pop="data/bundle/ppp_2019_1km_Aggregated.tif",
+    output:
+        country_shapes=resources("country_shapes.geojson"),
+        offshore_shapes=resources("offshore_shapes.geojson"),
+        europe_shape=resources("europe_shape.geojson"),
+        nuts3_shapes=resources("nuts3_shapes.geojson"),
+    log:
+        logs("build_shapes.log"),
+    benchmark:
+        benchmarks("build_shapes")
+    threads: 1
+    resources:
+        mem_mb=1500,
+    conda:
+        "../envs/environment.yaml"
+    script:
+        "../scripts/build_shapes.py"
 
 
 if config["enable"].get("build_cutout", False):

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -130,6 +130,18 @@ if config["enable"]["retrieve"]:
 
 
 
+if config["enable"]["retrieve"]:
+
+    rule retrieve_bidding_zones:
+        input:
+            naturalearth=ancient("data/naturalearth/ne_10m_admin_0_countries_deu.shp"),
+        output:
+            file_entsoepy="data/busshapes/bidding_zones_entsoepy.geojson",
+            file_electricitymaps="data/busshapes/bidding_zones_electricitymaps.geojson",
+        script:
+            "../scripts/retrieve_bidding_zones.py"
+
+
 if config["enable"]["retrieve"] and config["enable"].get("retrieve_cutout", True):
 
     rule retrieve_cutout:

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -1438,6 +1438,7 @@ def build_admin_shapes(
         1: "level1",
         2: "level2",
         3: "level3",
+        "bz": "bidding_zone",
     }
 
     adm1_countries = ["BA", "MD", "UA", "XK"]
@@ -1450,6 +1451,7 @@ def build_admin_shapes(
 
     if clustering == "administrative":
         logger.info(f"Building bus regions at administrative level {level}")
+
         nuts3_regions["column"] = level_map[level]
 
         # Only keep the values whose keys are in countries
@@ -1485,14 +1487,8 @@ def build_admin_shapes(
         nuts3_regions["admin"] = nuts3_regions["country"]
 
     # Group by busmap
-    admin_shapes = nuts3_regions[["admin", "geometry"]]
-    admin_shapes = admin_shapes.groupby("admin")["geometry"].apply(
-        lambda x: x.union_all()
-    )
-    admin_shapes = gpd.GeoDataFrame(
-        admin_shapes, geometry="geometry", crs=nuts3_regions.crs
-    )
-    admin_shapes["country"] = admin_shapes.index.str[:2]
+    admin_shapes = nuts3_regions[["admin", "geometry", "country"]]
+    admin_shapes = admin_shapes.dissolve("admin")
 
     # Identify regions that do not contain buses and merge them with smallest
     # neighbouring area of the same parent region (NUTS3 -> NUTS2 -> NUTS1 -> country)

--- a/scripts/build_bidding_zones.py
+++ b/scripts/build_bidding_zones.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+#
+# SPDX-License-Identifier: MIT
+from functools import reduce
+from itertools import takewhile
+from operator import attrgetter
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+from shapely.geometry import MultiPolygon
+
+
+def _simplify_polys(polys, minarea=0.1, tolerance=None, filterremote=True):
+    if isinstance(polys, MultiPolygon):
+        polys = sorted(polys.geoms, key=attrgetter("area"), reverse=True)
+        mainpoly = polys[0]
+        mainlength = np.sqrt(mainpoly.area / (2.0 * np.pi))
+        if mainpoly.area > minarea:
+            polys = MultiPolygon(
+                [
+                    p
+                    for p in takewhile(lambda p: p.area > minarea, polys)
+                    if not filterremote or (mainpoly.distance(p) < mainlength)
+                ]
+            )
+        else:
+            polys = mainpoly
+    if tolerance is not None:
+        polys = polys.simplify(tolerance=tolerance)
+    return polys
+
+
+def get_countries(naturalearth: str, country_list: set[str]) -> gpd.GeoDataFrame:
+    """
+    Load geometries for missing countries from Natural Earth dataset.
+
+    Args:
+        naturalearth: Path to Natural Earth dataset
+        missing_countries: Set of country codes that are missing in the bidding zones
+
+    Returns:
+        GeoDataFrame: Contains geometries for all missing countries
+    """
+    df = gpd.read_file(naturalearth)
+
+    # Names are a hassle in naturalearth, try several fields
+    fieldnames = (
+        df[x].where(lambda s: s != "-99") for x in ("ISO_A2", "WB_A2", "ADM0_A3")
+    )
+    df["name"] = reduce(lambda x, y: x.fillna(y), fieldnames, next(fieldnames)).str[:2]
+    df.replace({"name": {"KV": "XK"}}, inplace=True)
+
+    df = df.loc[
+        df.name.isin(country_list) & ((df["scalerank"] == 0) | (df["scalerank"] == 5))
+    ]
+    return gpd.GeoDataFrame(
+        df.set_index("name")[["geometry"]].geometry.map(_simplify_polys).set_crs(df.crs)
+    )
+
+
+def parse_zone_names(zone_names: pd.Series) -> tuple[set[str], pd.Series]:
+    """
+    Parse bidding zone names to extract country codes and handle combined zones.
+
+    Args:
+        zone_names: Series of zone names (e.g., 'DE', 'DE_LU', etc.)
+
+    Returns:
+        tuple containing:
+            - set of country codes covered by the zones
+            - Series of combined country strings (e.g., 'DE,LU')
+    """
+    # Extract primary country codes (first two characters)
+    primary_countries = set(zone_names.str[:2])
+
+    # Parse combined zones (e.g., 'DE_LU' -> 'LU')
+    secondary_countries = (
+        zone_names.str.split("_", expand=True)[1]
+        .dropna()
+        .loc[lambda x: x.str.len() == 2]
+    )
+
+    # Create combined country strings (e.g., 'DE,LU')
+    country_strings = zone_names.str[:2] + (
+        "," + secondary_countries.reindex(zone_names.index)
+    ).fillna("")
+
+    # Remove secondary countries from primary set
+    covered_countries = primary_countries | set(secondary_countries)
+
+    return covered_countries, country_strings
+
+
+def split_combined_zones(gdf, country_shapes):
+    """Split multi-country zones into individual country entries."""
+    crs = gdf.crs
+    new_rows = []
+
+    for _, row in gdf.iterrows():
+        countries = row.country.split(",")
+        if len(countries) == 1:
+            new_rows.append(row)
+            continue
+
+        # Split geometry for combined countries
+        for country in countries:
+            country_geom = country_shapes.loc[country].geometry
+            intersection = row.geometry.intersection(country_geom)
+
+            if not intersection.is_empty:
+                new_row = row.copy()
+                new_row.country = country
+                new_row.geometry = intersection
+                new_rows.append(new_row)
+
+    return gpd.GeoDataFrame(new_rows, crs=crs)
+
+
+def extract_shape_by_bbox(
+    gdf: gpd.GeoDataFrame,
+    country: str,
+    min_lon: float,
+    max_lon: float,
+    min_lat: float,
+    max_lat: float,
+    region_id: str,
+):
+    """
+    Extracts a shape from a country's GeoDataFrame based on latitude and longitude bounds.
+
+    Parameters
+    ----------
+        - gdf (GeoDataFrame): GeoDataFrame containing country geometries.
+        - country (str): The country code or name to filter.
+        - min_lon, max_lon (float): Longitude bounds for extraction.
+        - min_lat, max_lat (float): Latitude bounds for extraction.
+        - region_id (str): String to assign an ID to the extracted region.
+
+    Returns
+    -------
+        - gdf_new: Updated GeoDataFrame with the extracted shape separated.
+    """
+    country_gdf = gdf.explode().query(f"country == '{country}'").reset_index(drop=True)
+
+    extracted_region = country_gdf.cx[min_lon:max_lon, min_lat:max_lat].assign(
+        zone_name=region_id
+    )
+
+    remaining_country = (
+        country_gdf.drop(extracted_region.index).dissolve(by="country").reset_index()
+    )
+
+    return pd.concat(
+        [
+            gdf.query(f"country != '{country}'"),
+            remaining_country,
+            extracted_region.dissolve(by="country").reset_index(),
+        ]
+    ).reset_index(drop=True)
+
+
+def format_names(s: str):
+    s = (
+        s.replace("DK-DK1", "DKW1")
+        .replace("DK-DK2", "DKE1")
+        .replace("GB", "UK")
+        .replace("IT_NORD", "ITN1")
+        .replace("IT_SUD", "ITS1")
+        .replace("LU", "LUG1")
+        .replace("NO-NO3", "NOM1")
+        .replace("NO-NO4", "NON1")
+        .replace("SE-SE", "SE0")
+        .replace("_", "")
+        .ljust(4, "0")
+    )[:4]
+    return s
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from _helpers import mock_snakemake
+
+        snakemake = mock_snakemake("build_bidding_zones")
+
+    # Load core bidding zones and country shapes
+    countries = snakemake.params.countries
+
+    rename_columns = {"zoneName": "zone_name", "countryKey": "country"}
+    bidding_zones_elecmaps = gpd.read_file(
+        snakemake.input.bidding_zones_electricitymaps
+    )
+    bidding_zones_elecmaps = bidding_zones_elecmaps.rename(columns=rename_columns)
+    bidding_zones = bidding_zones_elecmaps[
+        bidding_zones_elecmaps.country.isin(countries)
+    ].drop(columns="countryName")
+
+    if not set(countries).issubset(bidding_zones.country):
+        raise ValueError("Missing countries in electricitymaps bidding zones")
+
+    # Manual corrections: replace Italy by entsoepy version
+    bidding_zones = bidding_zones[bidding_zones.country != "IT"]
+
+    bidding_zones_entsoe = gpd.read_file(snakemake.input.bidding_zones_entsoepy)
+    bidding_zones_entsoe = bidding_zones_entsoe.rename(
+        columns={"zoneName": "zone_name"}
+    )
+    core_countries, country_strings = parse_zone_names(
+        bidding_zones_entsoe["zone_name"]
+    )
+    bidding_zones_entsoe["country"] = country_strings
+    italian_zones = bidding_zones_entsoe[bidding_zones_entsoe.country == "IT"]
+    bidding_zones = pd.concat([bidding_zones, italian_zones], ignore_index=True)
+    bidding_zones = bidding_zones.sort_values("zone_name").reset_index(drop=True)
+
+    # manual corrections: remove islands
+    islands = [
+        "DK-BHM",
+        "ES-CE",
+        "ES-CN-HI",
+        "ES-CN-IG",
+        "ES-CN-LP",
+        "ES-CN-LZ",
+        "ES-IB-FO",
+        "ES-IB-IZ",
+        "ES-IB-ME",
+        "ES-IB-MA",
+        "ES-CN-FV",
+        "ES-CN-GC",
+        "ES-CN-TE",
+        "ES-ML",
+        "GB-ORK",
+        "GB-ZET",
+        "PT-MA",
+        "PT-AC",
+    ]
+    bidding_zones = bidding_zones[~bidding_zones.zone_name.isin(islands)]
+
+    # manually merge southern norwegian zones
+    nos0_idx = bidding_zones.query("zone_name in ['NO-NO1', 'NO-NO2', 'NO-NO5']").index
+    bidding_zones = pd.concat(
+        [
+            bidding_zones.drop(nos0_idx),
+            bidding_zones.loc[nos0_idx]
+            .dissolve(by="country")
+            .reset_index()
+            .assign(zone_name="NOS0"),
+        ]
+    )
+
+    # Extract Crete
+    bidding_zones = extract_shape_by_bbox(
+        bidding_zones,
+        country="GR",
+        min_lon=24.0,
+        max_lon=26.5,
+        min_lat=35.0,
+        max_lat=35.7,
+        region_id="GR03",
+    )
+
+    # manually add zone group for DE_LU
+    bidding_zones.loc[
+        bidding_zones.zone_name.isin(["DE", "LU"]), "cross_country_zone"
+    ] = "DE_LU"
+
+    # if turkey is not in the list of countries, drop northern cyprus
+    if "TR" not in countries:
+        bidding_zones = bidding_zones[~bidding_zones.zone_name.eq("XX")]
+
+    # rename zones
+    bidding_zones["zone_name"] = bidding_zones["zone_name"].apply(format_names)
+
+    bidding_zones.to_file(snakemake.output.file)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -341,10 +341,6 @@ def create_regions(
         offshore_shapes.geometry.union_all()
     )
 
-    # Add bidding zone information
-    bidding_zones = gpd.read_file(bidding_zones_path)
-    regions = map_bidding_zones_to_regions(regions, bidding_zones)
-
     # GDP and POP for NUTS3 regions
     # GDP
     logger.info(f"Importing JRC ARDECO GDP data for year {GDP_YEAR}.")
@@ -388,6 +384,10 @@ def create_regions(
 
     # Only include countries in the config
     regions = regions.query("country in @country_list")
+
+    # Add bidding zone information
+    bidding_zones = gpd.read_file(bidding_zones_path)
+    regions = regions.assign(bidding_zone=bidding_zone_map(regions, bidding_zones))
 
     return regions
 
@@ -492,11 +492,13 @@ def calc_gdp_pop(country, regions, gdp_non_nuts3, pop_non_nuts3):
     return gdp_pop
 
 
-def map_bidding_zones_to_regions(
+def bidding_zone_map(
     regions: gpd.GeoDataFrame, bidding_zones: gpd.GeoDataFrame
-) -> gpd.GeoDataFrame:
+) -> pd.Series:
     """
-    Map bidding zones to regions on a country-by-country basis.
+    Map bidding zones to regions on a country-by-country basis, assigning each region
+    to the bidding zone with which it has the largest overlap. If a region doesn't
+    overlap with any bidding zone, it's assigned to the nearest one as a fallback.
 
     Parameters
     ----------
@@ -507,12 +509,13 @@ def map_bidding_zones_to_regions(
 
     Returns
     -------
-    regions : geopandas.GeoDataFrame
-        The regions GeoDataFrame with an added 'bidding_zone' columnk
+    bidding_zone_map : pandas.Series
+        A Series with the same index as regions, containing the assigned bidding zone names.
     """
-
     # Initialize the bidding_zone column with NaN values
-    regions["bidding_zone"] = pd.NA
+    bidding_zone_map = pd.Series(pd.NA, regions.index, dtype="object")
+
+    logger.info("Mapping bidding zones to regions based on maximum overlap area")
 
     # Get unique countries in regions
     countries = regions["country"].unique()
@@ -520,23 +523,87 @@ def map_bidding_zones_to_regions(
     # Process each country separately
     for country in countries:
         # Get regions for this country
-
         country_sel = regions["country"] == country
-        country_regions = regions[country_sel].copy()
-        # Get bidding zones that might correspond to this country
+        country_regions = regions.loc[country_sel].copy()
+
+        # Get bidding zones for this country
         country_bidding_zones = bidding_zones[bidding_zones.country == country]
 
-        # Perform spatial join for this country
         if country_regions.empty or country_bidding_zones.empty:
+            logger.debug(
+                f"Skipping country {country}: no regions or bidding zones found"
+            )
             continue
-        joined = gpd.sjoin(
-            country_regions, country_bidding_zones, how="left", predicate="within"
-        )
 
-        # Update the bidding_zone column for this country
-        regions.loc[country_sel, "bidding_zone"] = joined["zone_name"]
+        logger.debug(f"Processing {len(country_regions)} regions in country: {country}")
 
-    return regions
+        # Calculate overlap for each region with each bidding zone
+        assignments = []
+        no_overlap_regions = []
+
+        # Ensure same CRS for accurate area calculations
+        if country_regions.crs != country_bidding_zones.crs:
+            country_bidding_zones = country_bidding_zones.to_crs(country_regions.crs)
+
+        for idx, region in country_regions.iterrows():
+            region_geom = region.geometry
+            max_overlap = 0
+            best_zone = None
+
+            for _, zone in country_bidding_zones.iterrows():
+                intersection = region_geom.intersection(zone.geometry)
+                if not intersection.is_empty:
+                    overlap_area = intersection.area
+                    if overlap_area > max_overlap:
+                        max_overlap = overlap_area
+                        best_zone = zone.zone_name
+
+            if best_zone is not None:
+                assignments.append((idx, best_zone))
+            else:
+                # Keep track of regions with no overlap for nearest assignment
+                no_overlap_regions.append(idx)
+                logger.debug(
+                    f"Region {idx} in {country} has no overlap with any bidding zone, will use nearest"
+                )
+
+        # Update the bidding_zone column for regions with overlap
+        for idx, zone in assignments:
+            bidding_zone_map[idx] = zone
+
+        # Handle regions with no overlap by finding nearest bidding zone
+        if no_overlap_regions:
+            logger.info(
+                f"Assigning {len(no_overlap_regions)} regions in {country} to nearest bidding zone"
+            )
+
+            for idx in no_overlap_regions:
+                region_geom = regions.loc[idx, "geometry"]
+                min_distance = float("inf")
+                nearest_zone = None
+
+                for _, zone in country_bidding_zones.iterrows():
+                    distance = region_geom.distance(zone.geometry)
+                    if distance < min_distance:
+                        min_distance = distance
+                        nearest_zone = zone.zone_name
+
+                if nearest_zone is not None:
+                    bidding_zone_map[idx] = nearest_zone
+                    logger.debug(
+                        f"Region {idx} assigned to nearest zone {nearest_zone}"
+                    )
+                else:
+                    logger.warning(
+                        f"Could not find any bidding zone for region {idx} in {country}"
+                    )
+
+    # Check if any regions couldn't be assigned
+    unassigned = bidding_zone_map.isnull().sum()
+    if unassigned > 0:
+        logger.warning(f"{unassigned} regions couldn't be assigned to any bidding zone")
+
+    return bidding_zone_map
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The following changes add an additional layer for bidding zones on the administrative shapes introduced in #1502. 

On top, a cluster mode `custom_busshapes` was added to support passing user-defined busshapes (instead of custom busmap) which is used to perform the clustering. 

Note that this is two distinct features. 

### TODO
- [ ] Crete does not have a substation according to OSM prebuilt. however there should be one, as well as the interconnection between the main land and the island (https://www.admie.gr/en/erga/erga-diasyndeseis/diasyndesi-tis-kritis-me-tin-peloponniso). This missing piece is crashing the party a bit, as create has its own bidding zone. 


@bobbyxng @tgilon if you already want to take a look feel free. 


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
