### PR TITLE
clustering with NUTS3 in Spain breaks

### DIFF
--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -1232,26 +1232,34 @@ def clean_dict(
 
     # Sub dictionary where values are only of length 1
     single_occurrences = {k: v for k, v in diction.items() if len(v) == 1}
-    # Create list of key, value pairs and store in list
-    single_values = list(chain.from_iterable(single_occurrences.values()))
-    single_keys = list(single_occurrences.keys())
+    
+    
+    # Enters only if single_occurrences is not empty
+    if single_occurrences:
+        # Create list of key, value pairs and store in list
+        single_values = list(chain.from_iterable(single_occurrences.values()))
+        single_keys = list(single_occurrences.keys())
 
-    # Create dict with single_keys() as keys and sets of single_keys and single_values as values using
-    single_df = pd.DataFrame(
-        zip(
-            single_keys,
-            [set([key, value]) for key, value in zip(single_keys, single_values)],
+        # Create dict with single_keys() as keys and sets of single_keys and single_values as values using
+        single_df = pd.DataFrame(
+            zip(
+                single_keys,
+                [set([key, value]) for key, value in zip(single_keys, single_values)],
+            )
         )
-    )
-    # Only keep first occurrence of duplicates
-    single_df = single_df.drop_duplicates(subset=1, keep="first")
+        # Only keep first occurrence of duplicates
+        single_df = single_df.drop_duplicates(subset=1, keep="first")
 
-    # Difference between single_df[0].values and single_keys
-    drop_keys = set(single_keys) - set(single_df[0].values)
+        # Difference between single_df[0].values and single_keys
+        drop_keys = set(single_keys) - set(single_df[0].values)
 
-    # Drop keys in double_values
-    diction = {k: v for k, v in diction.items() if k not in drop_keys}
-
+        # Drop keys in double_values
+        diction = {k: v for k, v in diction.items() if k not in drop_keys}
+    else:
+        # If there are no unique value occurrences, continue without changing the dictionary
+        drop_keys = set()
+        
+        
     # Create list of values, that also exist as key
     double_values = list(chain.from_iterable(diction.values()))
     double_values = [x for x in double_values if x in diction.keys()]

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -1147,7 +1147,9 @@ def create_merged_admin_region(
     )
 
     merge_regions = sorted([row.name] + first_neighbours)
-    contains_cumulative = sorted(row.contains + first_neighbours + neighbours_contain)
+    contains_cumulative = sorted(
+        set(row.contains + first_neighbours + neighbours_contain)
+    )
     gdf = admin_shapes.loc[merge_regions]
 
     geometry = gdf.union_all()

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -1256,9 +1256,6 @@ def clean_dict(
 
         # Drop keys in double_values
         diction = {k: v for k, v in diction.items() if k not in drop_keys}
-    else:
-        # If there are no unique value occurrences, continue without changing the dictionary
-        drop_keys = set()
 
     # Create list of values, that also exist as key
     double_values = list(chain.from_iterable(diction.values()))

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -1232,8 +1232,7 @@ def clean_dict(
 
     # Sub dictionary where values are only of length 1
     single_occurrences = {k: v for k, v in diction.items() if len(v) == 1}
-    
-    
+
     # Enters only if single_occurrences is not empty
     if single_occurrences:
         # Create list of key, value pairs and store in list
@@ -1258,8 +1257,7 @@ def clean_dict(
     else:
         # If there are no unique value occurrences, continue without changing the dictionary
         drop_keys = set()
-        
-        
+
     # Create list of values, that also exist as key
     double_values = list(chain.from_iterable(diction.values()))
     double_values = [x for x in double_values if x in diction.keys()]


### PR DESCRIPTION
## Changes proposed in this Pull Request

I've been testing the new NUTS clustering feature (congratulations, it's a great update!). It works pretty well, but I get an error when running it only for Spain and for clustering at NUTS3 level.

The error occurs during the 'base_network' rule. 

In short, the problem seems to be that the "clean_dict" function is not robust if the provided dic has no values with len=1.

In detail: At some point, "build_admin_shapes" calls to "merge_regions_recursive" at:

https://github.com/PyPSA/pypsa-eur/blob/a3938febf80d6b93dea32afdb1586984b1093e3d/scripts/base_network.py#L1551 

In this function there is a call to the function "clean_dict" on line:

https://github.com/PyPSA/pypsa-eur/blob/a3938febf80d6b93dea32afdb1586984b1093e3d/scripts/base_network.py#L1387

where the input dictionary at this point is just: {'ES532': ['ES531', 'ES533']}

(just for info: ES531 and ES533 are two small islands without electrical buses, and here the code aims to add them to the larger island of Mallorca, ES532, which is connected with peninsular Spain with a DC-link). 

The problem is that "clean_dict" seems to break at line:

https://github.com/PyPSA/pypsa-eur/blob/a3938febf80d6b93dea32afdb1586984b1093e3d/scripts/base_network.py#L1250

because the variable "single_occurrences" is empty, due to the fact that there are no values in the input dictionary with length=1). This probably does not happen when running a case for Europe, but for the case of a single country like Spain, it leads to the mentioned break.

So, this PR is just to add a check step on "single_occurrences", to proceed only if it is not empty.




## Checklist

- [ x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
