### PR TITLE
drop non buses

### DIFF
--- a/scripts/plot_gas_network.py
+++ b/scripts/plot_gas_network.py
@@ -86,6 +86,10 @@ def plot_ch4_map(n):
     biogas.index = pd.MultiIndex.from_product([biogas.index, ["biogas"]])
 
     bus_sizes = pd.concat([fossil_gas, methanation, biogas])
+    non_buses = bus_sizes.index.unique(level=0).difference(n.buses.index)
+    if any(non_buses):
+        logger.info(f"Dropping non-buses {non_buses.tolist()} for CH4 network plot.")
+        bus_sizes = bus_sizes.drop(non_buses)
     bus_sizes.sort_index(inplace=True)
 
     to_remove = n.links.index[~n.links.carrier.str.contains("gas pipeline")]


### PR DESCRIPTION
Closes #1599.

## Changes proposed in this Pull Request

Drop link indices not in n.buses to prevent the script from failing with a KeyError. In principle, this applies the same logic as `plot_power_network.py:126`
```
# drop non-bus
to_drop = costs.index.levels[0].symmetric_difference(n.buses.index)
if len(to_drop) != 0:
    logger.info(f"Dropping non-buses {to_drop.tolist()}")
    costs.drop(to_drop, level=0, inplace=True, axis=0, errors="ignore")
```
where non-buses are being dropped already. 

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
