### PR TITLE
Move shipping & aviation sector into separate function and config

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -440,6 +440,7 @@ sector:
   heating: true
   biomass: true
   industry: true
+  shipping: true
   agriculture: true
   fossil_fuels: true
   district_heating:

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -441,6 +441,7 @@ sector:
   biomass: true
   industry: true
   shipping: true
+  aviation: true
   agriculture: true
   fossil_fuels: true
   district_heating:

--- a/doc/configtables/sector.csv
+++ b/doc/configtables/sector.csv
@@ -4,6 +4,7 @@ heating,--,"{true, false}",Flag to include heating sector.
 biomass,--,"{true, false}",Flag to include biomass sector.
 industry,--,"{true, false}",Flag to include industry sector.
 shipping,--,"{true, false}",Flag to include shipping sector.
+aviation,--,"{true, false}",Flag to include aviation sector.
 agriculture,--,"{true, false}",Flag to include agriculture sector.
 fossil_fuels,--,"{true, false}","Flag to include imports of fossil fuels."
 district_heating,--,,`prepare_sector_network.py <https://github.com/PyPSA/pypsa-eur-sec/blob/master/scripts/prepare_sector_network.py>`_

--- a/doc/configtables/sector.csv
+++ b/doc/configtables/sector.csv
@@ -3,6 +3,7 @@ transport,--,"{true, false}",Flag to include transport sector.
 heating,--,"{true, false}",Flag to include heating sector.
 biomass,--,"{true, false}",Flag to include biomass sector.
 industry,--,"{true, false}",Flag to include industry sector.
+shipping,--,"{true, false}",Flag to include shipping sector.
 agriculture,--,"{true, false}",Flag to include agriculture sector.
 fossil_fuels,--,"{true, false}","Flag to include imports of fossil fuels."
 district_heating,--,,`prepare_sector_network.py <https://github.com/PyPSA/pypsa-eur-sec/blob/master/scripts/prepare_sector_network.py>`_

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,8 +11,8 @@ Release Notes
 Upcoming Release
 ================
 
-* In :mod:`prepare_sector_network`, split shipping sector from ``add_industry()`` into separate function and configuration setting.
-  To mirror previous behaviour of setting ``sector: industry: true``, also set ``sector: shipping: true``.
+* In :mod:`prepare_sector_network`, split shipping and aviation sector from ``add_industry()`` into separate function and configuration setting.
+  To mirror previous behaviour of setting ``sector: industry: true``, also set ``sector: shipping: true`` and ``sector: aviation: true``.
 
 * Added rule :mod:`build_co2_sequestration_potentials`, which processes the raw data from `CO2Stop <https://setis.ec.europa.eu/european-co2-storage-
 database_en>`_. Integrated from separate repository (https://github.com/ericzhou571/Co2Storage).

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,9 @@ Release Notes
 Upcoming Release
 ================
 
+* In :mod:`prepare_sector_network`, split shipping sector from ``add_industry()`` into separate function and configuration setting.
+  To mirror previous behaviour of setting ``sector: industry: true``, also set ``sector: shipping: true``.
+
 * Added rule :mod:`build_co2_sequestration_potentials`, which processes the raw data from `CO2Stop <https://setis.ec.europa.eu/european-co2-storage-
 database_en>`_. Integrated from separate repository (https://github.com/ericzhou571/Co2Storage).
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -6140,7 +6140,6 @@ if __name__ == "__main__":
             n=n,
             costs=costs,
             industrial_demand_file=snakemake.input.industrial_demand,
-            shipping_demand_file=snakemake.input.shipping_demand,
             pop_layout=pop_layout,
             pop_weighted_energy_totals=pop_weighted_energy_totals,
             options=options,


### PR DESCRIPTION
# Changes proposed in this Pull Request

Separates functions `add_aviation()` and `add_shipping()` from `add_industry()`.

This restructuring will simplify endogenizing the shipping and aviation sectors.

No other changes.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
