### PR TITLE
fix: Update tutorial paths to match config directory structure

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -99,6 +99,26 @@ Note, that ``config/test/config.electricity.yaml`` only includes changes relativ
 the default configuration. There are many more configuration options, which are
 documented at :ref:`config`.
 
+Directory Structure and Configuration Settings
+----------------------------------------------
+
+It's important to understand how certain configuration settings affect the directory structure in PyPSA-Eur:
+
+- ``run.name`` determines the subdirectory within the ``results`` folder (e.g., ``results/test-elec/networks/...``)
+- ``run.shared_resources.policy`` determines the subdirectory within the ``resources`` folder (e.g., ``resources/test/networks/...``)
+
+These settings work together to organize model runs:
+
+- Final model outputs are always stored in ``results/[run.name]/...``
+- Intermediate files can be either:
+  - Specific to a run: ``resources/[run.shared_resources.policy]/...`` (if policy is a string)
+  - Shared between runs: ``resources/...`` (if policy is ``false``)
+  - Partially shared: If policy is ``"base"``, some common files are shared while others remain run-specific
+
+For this tutorial, with ``run.name: "test-elec"`` and ``run.shared_resources.policy: "test"``, 
+intermediate resources are stored in ``resources/test/...`` while results are in ``results/test-elec/...``.
+
+The implementation of this behavior can be found in ``scripts/_helpers.py``.
 
 How to use ``snakemake`` rules?
 ===================================
@@ -116,7 +136,7 @@ clustered down to 6 buses and every 24 hours aggregated to one snapshot. The com
 
     $ snakemake results/test-elec/networks/base_s_6_elec_.nc --configfile config/test/config.electricity.yaml
 
-orders ``snakemake`` to run the rule :mod:`solve_network` that produces the solved network and stores it in ``results/networks`` with the name ``base_s_6_elec_.nc``:
+orders ``snakemake`` to run the rule :mod:`solve_network` that produces the solved network and stores it in ``results/test-elec/networks`` with the name ``base_s_6_elec_.nc``:
 
 .. literalinclude:: ../rules/solve_electricity.smk
    :start-at: rule solve_network:
@@ -347,10 +367,10 @@ You can produce any output file occurring in the ``Snakefile`` by running
 
 For example, you can explore the evolution of the PyPSA networks by running
 
-#. ``snakemake resources/networks/base.nc --configfile config/test/config.electricity.yaml``
-#. ``snakemake resources/networks/base_s.nc --configfile config/test/config.electricity.yaml``
-#. ``snakemake resources/networks/base_s_6.nc --configfile config/test/config.electricity.yaml``
-#. ``snakemake resources/networks/base_s_6_elec_.nc --configfile config/test/config.electricity.yaml``
+#. ``snakemake resources/test/networks/base.nc --configfile config/test/config.electricity.yaml``
+#. ``snakemake resources/test/networks/base_s.nc --configfile config/test/config.electricity.yaml``
+#. ``snakemake resources/test/networks/base_s_6.nc --configfile config/test/config.electricity.yaml``
+#. ``snakemake resources/test/networks/base_s_6_elec_.nc --configfile config/test/config.electricity.yaml``
 
 To run all combinations of wildcard values provided in the ``config/config.yaml`` under ``scenario:``,
 you can use the collection rule ``solve_elec_networks``.
@@ -388,6 +408,6 @@ Jupyter Notebooks).
 
     import pypsa
 
-    n = pypsa.Network("results/networks/base_s_6_elec_.nc")
+    n = pypsa.Network("results/test-elec/networks/base_s_6_elec_.nc")
 
 For inspiration, read the `examples section in the PyPSA documentation <https://pypsa.readthedocs.io/en/latest/examples-basic.html>`__.


### PR DESCRIPTION
Fix directory path inconsistency between tutorial commands and actual file locations. The config sets `run.name: "test-elec"` and `run.shared_resources.policy: "test"`, which affects where files are stored.

- Update all example commands to include correct paths (resources/test/...)
- Fix analysis example to use correct results path (results/test-elec/...)
- Add explanatory section about how config settings affect directory structure

Fixes [#1614](https://github.com/PyPSA/pypsa-eur/issues/1614)

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [ x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
