### PR TITLE
Missing geothermal data

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -482,6 +482,7 @@ sector:
     limited_heat_sources:
       geothermal:
         constant_temperature_celsius: 65
+        ignore_missing_regions: false
     direct_utilisation_heat_sources:
     - geothermal
   heat_pump_sources:

--- a/doc/configtables/sector.csv
+++ b/doc/configtables/sector.csv
@@ -28,6 +28,7 @@ district_heating,--,,`prepare_sector_network.py <https://github.com/PyPSA/pypsa-
 -- limited_heat_sources,--,Dictionary with names of limited heat sources (not air) for which data by Fraunhofer ISI (`Manz et al. 2024 <https://www.sciencedirect.com/science/article/pii/S0960148124001769>) is used,
 -- -- geothermal,-,Name of the heat source. Must be the same as in ``heat_pump_sources``,
 -- -- -- constant_temperature_celsius,°C,heat source temperature,
+-- -- -- ignore_missing_regions,--,Boolean,Ignore missing regions in the data and fill with zeros or raise an error,
 -- direct_utilisation_heat_sources,--,List of heat sources for direct heat utilisation in district heating. Must be in the keys of `heat_utilisation_potentials` (e.g. ``geothermal``),
 -- heat_pump_sources,--,,
 -- -- urban central,--,List of heat sources for heat pumps in urban central heating,

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,8 @@ Release Notes
 Upcoming Release
 ================
 
+* Bugfix: Handled missing geothermal potential data for GB if geothermal is included for direct utilisation or as heat pump source. The config parameter ``sector: district_heating: limited_heat_sources: geothermal: ignore_missing_regions`` can be used to either terminate the workflow throwing an error (default: ``true``) or assign 0 values to missing regions and continue the workflow (``false``).
+
 * In :mod:`prepare_sector_network`, split shipping and aviation sector from ``add_industry()`` into separate function and configuration setting.
   To mirror previous behaviour of setting ``sector: industry: true``, also set ``sector: shipping: true`` and ``sector: aviation: true``.
 

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -287,6 +287,13 @@ rule build_geothermal_heat_potential:
             "geothermal",
             "constant_temperature_celsius",
         ),
+        ignore_missing_regions=config_provider(
+            "sector",
+            "district_heating",
+            "limited_heat_sources",
+            "geothermal",
+            "ignore_missing_regions",
+        ),
     input:
         isi_heat_potentials="data/isi_heat_utilisation_potentials.xlsx",
         regions_onshore=resources("regions_onshore_base_s_{clusters}.geojson"),


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR implements two ways to deal with the missing geothermal potential data for Great Britain (GB) in the dataset of Manz et al. that was integrated into the workflow in #1516. The error was occurring when including geothermal as heat source for direct utilisation and heat pumps in district heating using the config parameter ``sector: heat_pump_sources: urban_central:``. The user can choose to ignore the missing data by assuming 0 potentials in GB by setting the parameter ``sector: district_heating: limited_heat_sources: geothermal: ignore_missing_regions`` to `true`. Otherwise, an error is thrown in the rule `build_geothermal_heat_potential`.

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
