### PR TITLE
Reincluded fuel type in chp carrier attribute

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,7 @@ Release Notes
 Upcoming Release
 ================
 
+* Re-included the fuel name as part of the carrier attribute for CHP plants added in :mod:`prepare_sector_network`
 
 * Added option to use dynamic capacity for pit storage using the ``e_max_pu`` attribute of the store component, which is calculated in the new rule :mod:`build_tes_capacity_profiles` and added to the network in :mod:`prepare_sector_network`.
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3246,7 +3246,7 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + " urban central heat",
                     bus3="co2 atmosphere",
-                    carrier="urban central CHP",
+                    carrier=f"urban central {fuel} CHP",
                     p_nom_extendable=True,
                     capital_cost=costs.at["central gas CHP", "capital_cost"]
                     * costs.at["central gas CHP", "efficiency"],
@@ -3266,7 +3266,7 @@ def add_heat(
                     bus2=nodes + " urban central heat",
                     bus3="co2 atmosphere",
                     bus4=spatial.co2.df.loc[nodes, "nodes"].values,
-                    carrier="urban central CHP CC",
+                    carrier=f"urban central {fuel} CHP CC",
                     p_nom_extendable=True,
                     capital_cost=costs.at["central gas CHP", "capital_cost"]
                     * costs.at["central gas CHP", "efficiency"]


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR re-includes the fuel type into the carrier string attribute of the CHP plants in `prepare_sector_network`. This is done for reasons of consistency with the biomass CHP plants and traceability in `n.statistics`.

https://github.com/PyPSA/pypsa-eur/blob/88853a730e360f99aab41f356a8ca1fa911aead8/scripts/prepare_sector_network.py#L3996


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
