### PR TITLE
bugfix: Fix typo unit commitment

### DIFF
--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -623,7 +623,7 @@ def attach_conventional_generators(
     if unit_commitment is not None:
         committable_attrs = ppl.carrier.isin(unit_commitment).to_frame("committable")
         for attr in unit_commitment.index:
-            default = pypsa.components.component_attrs["Generator"].default[attr]
+            default = n.component_attrs["Generator"].loc[attr, "default"]
             committable_attrs[attr] = ppl.carrier.map(unit_commitment.loc[attr]).fillna(
                 default
             )


### PR DESCRIPTION
Closes #1623

## Changes proposed in this Pull Request
Fixes a typo in the unit commitment with latest version of PyPSA.
Tested with @davidep3

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
