### PR TITLE
use absolute imports

### DIFF
--- a/rules/common.smk
+++ b/rules/common.smk
@@ -10,7 +10,7 @@ import os, sys, glob
 path = workflow.source_path("../scripts/_helpers.py")
 sys.path.insert(0, os.path.dirname(path))
 
-from _helpers import validate_checksum, update_config_from_wildcards
+from scripts._helpers import validate_checksum, update_config_from_wildcards
 from snakemake.utils import update_config
 
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-# coding: utf-8
+

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -11,14 +11,15 @@ import numpy as np
 import pandas as pd
 import pypsa
 import xarray as xr
-from _helpers import (
+
+from scripts._helpers import (
     configure_logging,
     get_snapshots,
     set_scenario_config,
     update_config_from_wildcards,
 )
-from add_electricity import flatten
-from add_existing_baseyear import add_build_year_to_new_assets
+from scripts.add_electricity import flatten
+from scripts.add_existing_baseyear import add_build_year_to_new_assets
 
 logger = logging.getLogger(__name__)
 idx = pd.IndexSlice
@@ -326,7 +327,7 @@ def update_dynamic_ptes_capacity(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "add_brownfield",

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -58,14 +58,15 @@ import pandas as pd
 import powerplantmatching as pm
 import pypsa
 import xarray as xr
-from _helpers import (
+from pypsa.clustering.spatial import DEFAULT_ONE_PORT_STRATEGIES, normed_or_uniform
+
+from scripts._helpers import (
     configure_logging,
     get_snapshots,
     rename_techs,
     set_scenario_config,
     update_p_nom_max,
 )
-from pypsa.clustering.spatial import DEFAULT_ONE_PORT_STRATEGIES, normed_or_uniform
 
 idx = pd.IndexSlice
 
@@ -1130,7 +1131,7 @@ def attach_stores(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("add_electricity", clusters=100)
     configure_logging(snakemake)  # pylint: disable=E0606

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -16,16 +16,17 @@ import pandas as pd
 import powerplantmatching as pm
 import pypsa
 import xarray as xr
-from _helpers import (
+
+from scripts._helpers import (
     configure_logging,
     sanitize_custom_columns,
     set_scenario_config,
     update_config_from_wildcards,
 )
-from add_electricity import load_costs, sanitize_carriers
-from build_energy_totals import cartesian
-from definitions.heat_system import HeatSystem
-from prepare_sector_network import cluster_heat_buses, define_spatial
+from scripts.add_electricity import load_costs, sanitize_carriers
+from scripts.build_energy_totals import cartesian
+from scripts.definitions.heat_system import HeatSystem
+from scripts.prepare_sector_network import cluster_heat_buses, define_spatial
 
 logger = logging.getLogger(__name__)
 cc = coco.CountryConverter()
@@ -700,7 +701,7 @@ def add_heating_capacities_installed_before_baseyear(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "add_existing_baseyear",

--- a/scripts/add_transmission_projects_and_dlr.py
+++ b/scripts/add_transmission_projects_and_dlr.py
@@ -12,7 +12,8 @@ import numpy as np
 import pandas as pd
 import pypsa
 import xarray as xr
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +71,7 @@ def attach_line_rating(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("add_transmission_projects_and_dlr")
     configure_logging(snakemake)  # pylint: disable=E0606

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-# coding: utf-8
+
 """
 Creates the network topology from a `ENTSO-E map extract.
 <https://github.com/PyPSA/GridKit/tree/master/entsoe>`_ (March 2022)
@@ -30,12 +30,18 @@ import shapely
 import shapely.prepared
 import shapely.wkt
 import yaml
-from _helpers import REGION_COLS, configure_logging, get_snapshots, set_scenario_config
 from packaging.version import Version, parse
 from scipy.sparse import csgraph
 from scipy.spatial import KDTree
 from shapely.geometry import Point
 from tqdm import tqdm
+
+from scripts._helpers import (
+    REGION_COLS,
+    configure_logging,
+    get_snapshots,
+    set_scenario_config,
+)
 
 PD_GE_2_2 = parse(pd.__version__) >= Version("2.2")
 
@@ -1569,7 +1575,7 @@ def build_admin_shapes(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("base_network")
     configure_logging(snakemake)

--- a/scripts/build_ammonia_production.py
+++ b/scripts/build_ammonia_production.py
@@ -15,7 +15,8 @@ import logging
 
 import country_converter as coco
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +25,7 @@ cc = coco.CountryConverter()
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_ammonia_production")
 

--- a/scripts/build_biomass_potentials.py
+++ b/scripts/build_biomass_potentials.py
@@ -11,8 +11,9 @@ import logging
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
-from build_energy_totals import build_eurostat
+
+from scripts._helpers import configure_logging, set_scenario_config
+from scripts.build_energy_totals import build_eurostat
 
 logger = logging.getLogger(__name__)
 AVAILABLE_BIOMASS_YEARS = [2010, 2020, 2030, 2040, 2050]
@@ -338,7 +339,7 @@ def add_unsustainable_potentials(df):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_biomass_potentials",

--- a/scripts/build_biomass_transport_costs.py
+++ b/scripts/build_biomass_transport_costs.py
@@ -17,7 +17,8 @@ assuming as an approximation energy content of wood pellets
 import logging
 
 import pandas as pd
-from _helpers import configure_logging
+
+from scripts._helpers import configure_logging
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +118,7 @@ def build_biomass_transport_costs():
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_biomass_transport_costs")
     configure_logging(snakemake)

--- a/scripts/build_central_heating_temperature_profiles/run.py
+++ b/scripts/build_central_heating_temperature_profiles/run.py
@@ -38,8 +38,9 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import xarray as xr
-from _helpers import get_snapshots, set_scenario_config
-from central_heating_temperature_approximator import (
+
+from scripts._helpers import get_snapshots, set_scenario_config
+from scripts.build_central_heating_temperature_profiles.central_heating_temperature_approximator import (
     CentralHeatingTemperatureApproximator,
 )
 
@@ -188,7 +189,7 @@ def scale_temperature_to_investment_year(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_cop_profiles",

--- a/scripts/build_clustered_co2_sequestration_potentials.py
+++ b/scripts/build_clustered_co2_sequestration_potentials.py
@@ -11,7 +11,8 @@ import logging
 
 import geopandas as gpd
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ def allocate_sequestration_potential(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_sequestration_potentials", clusters="128")
 

--- a/scripts/build_clustered_population_layouts.py
+++ b/scripts/build_clustered_population_layouts.py
@@ -11,13 +11,14 @@ import logging
 import geopandas as gpd
 import pandas as pd
 import xarray as xr
-from _helpers import configure_logging, load_cutout, set_scenario_config
+
+from scripts._helpers import configure_logging, load_cutout, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_clustered_population_layouts", clusters=48)
 

--- a/scripts/build_clustered_solar_rooftop_potentials.py
+++ b/scripts/build_clustered_solar_rooftop_potentials.py
@@ -8,11 +8,12 @@ Build solar rooftop potentials for all clustered model regions per resource clas
 import geopandas as gpd
 import pandas as pd
 import xarray as xr
-from _helpers import load_cutout, set_scenario_config
+
+from scripts._helpers import load_cutout, set_scenario_config
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_clustered_solar_rooftop_potentials",

--- a/scripts/build_co2_sequestration_potentials.py
+++ b/scripts/build_co2_sequestration_potentials.py
@@ -296,7 +296,7 @@ def merge_maps(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_co2_storage")
 

--- a/scripts/build_cop_profiles/CentralHeatingCopApproximator.py
+++ b/scripts/build_cop_profiles/CentralHeatingCopApproximator.py
@@ -7,7 +7,8 @@ from typing import Union
 
 import numpy as np
 import xarray as xr
-from BaseCopApproximator import BaseCopApproximator
+
+from scripts.build_cop_profiles.BaseCopApproximator import BaseCopApproximator
 
 
 class CentralHeatingCopApproximator(BaseCopApproximator):

--- a/scripts/build_cop_profiles/DecentralHeatingCopApproximator.py
+++ b/scripts/build_cop_profiles/DecentralHeatingCopApproximator.py
@@ -7,7 +7,8 @@ from typing import Union
 
 import numpy as np
 import xarray as xr
-from BaseCopApproximator import BaseCopApproximator
+
+from scripts.build_cop_profiles.BaseCopApproximator import BaseCopApproximator
 
 
 class DecentralHeatingCopApproximator(BaseCopApproximator):

--- a/scripts/build_cop_profiles/run.py
+++ b/scripts/build_cop_profiles/run.py
@@ -38,10 +38,14 @@ Outputs
 
 import pandas as pd
 import xarray as xr
-from _helpers import set_scenario_config
-from CentralHeatingCopApproximator import CentralHeatingCopApproximator
-from DecentralHeatingCopApproximator import DecentralHeatingCopApproximator
 
+from scripts._helpers import set_scenario_config
+from scripts.build_cop_profiles.CentralHeatingCopApproximator import (
+    CentralHeatingCopApproximator,
+)
+from scripts.build_cop_profiles.DecentralHeatingCopApproximator import (
+    DecentralHeatingCopApproximator,
+)
 from scripts.definitions.heat_system_type import HeatSystemType
 
 
@@ -88,7 +92,7 @@ def get_cop(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_cop_profiles",

--- a/scripts/build_cutout.py
+++ b/scripts/build_cutout.py
@@ -73,13 +73,14 @@ import logging
 import atlite
 import geopandas as gpd
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_cutout", cutout="europe-2013-sarah3-era5")
     configure_logging(snakemake)

--- a/scripts/build_daily_heat_demand.py
+++ b/scripts/build_daily_heat_demand.py
@@ -19,14 +19,20 @@ import logging
 import geopandas as gpd
 import numpy as np
 import xarray as xr
-from _helpers import configure_logging, get_snapshots, load_cutout, set_scenario_config
 from dask.distributed import Client, LocalCluster
+
+from scripts._helpers import (
+    configure_logging,
+    get_snapshots,
+    load_cutout,
+    set_scenario_config,
+)
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_daily_heat_demands",

--- a/scripts/build_direct_heat_source_utilisation_profiles.py
+++ b/scripts/build_direct_heat_source_utilisation_profiles.py
@@ -17,7 +17,8 @@ Outputs
 import logging
 
 import xarray as xr
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +78,7 @@ def get_profile(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_cop_profiles",

--- a/scripts/build_district_heat_share.py
+++ b/scripts/build_district_heat_share.py
@@ -23,15 +23,16 @@ Notes
 import logging
 
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
-from prepare_sector_network import get
+
+from scripts._helpers import configure_logging, set_scenario_config
+from scripts.prepare_sector_network import get
 
 logger = logging.getLogger(__name__)
 
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_district_heat_share",

--- a/scripts/build_egs_potentials.py
+++ b/scripts/build_egs_potentials.py
@@ -22,8 +22,9 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import xarray as xr
-from _helpers import configure_logging, get_snapshots, set_scenario_config
 from shapely.geometry import Polygon
+
+from scripts._helpers import configure_logging, get_snapshots, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -194,7 +195,7 @@ def get_capacity_factors(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_egs_potentials",

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -13,8 +13,9 @@ import logging
 
 import numpy as np
 import pandas as pd
-from _helpers import configure_logging, get_snapshots, set_scenario_config
 from pandas import Timedelta as Delta
+
+from scripts._helpers import configure_logging, get_snapshots, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -229,7 +230,7 @@ def manual_adjustment(load, fn_load, countries):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_electricity_demand")
 

--- a/scripts/build_electricity_demand_base.py
+++ b/scripts/build_electricity_demand_base.py
@@ -14,8 +14,9 @@ import pandas as pd
 import pypsa
 import scipy.sparse as sparse
 import xarray as xr
-from _helpers import configure_logging, set_scenario_config
 from shapely.prepared import prep
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +89,7 @@ def upsample_load(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_electricity_demand_base")
     configure_logging(snakemake)

--- a/scripts/build_energy_totals.py
+++ b/scripts/build_energy_totals.py
@@ -26,8 +26,9 @@ import country_converter as coco
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-from _helpers import configure_logging, mute_print, set_scenario_config
 from tqdm import tqdm
+
+from scripts._helpers import configure_logging, mute_print, set_scenario_config
 
 cc = coco.CountryConverter()
 logger = logging.getLogger(__name__)
@@ -1572,7 +1573,7 @@ def build_heating_efficiencies(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_energy_totals")
 

--- a/scripts/build_existing_heating_distribution.py
+++ b/scripts/build_existing_heating_distribution.py
@@ -29,7 +29,8 @@ import logging
 import country_converter as coco
 import numpy as np
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -154,7 +155,7 @@ def build_existing_heating():
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_existing_heating_distribution",

--- a/scripts/build_gas_input_locations.py
+++ b/scripts/build_gas_input_locations.py
@@ -11,8 +11,9 @@ import logging
 
 import geopandas as gpd
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
-from cluster_gas_network import load_bus_regions
+
+from scripts._helpers import configure_logging, set_scenario_config
+from scripts.cluster_gas_network import load_bus_regions
 
 logger = logging.getLogger(__name__)
 
@@ -143,7 +144,7 @@ def build_gas_input_locations(gem_fn, entry_fn, sto_fn, countries):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_gas_input_locations",

--- a/scripts/build_gas_network.py
+++ b/scripts/build_gas_network.py
@@ -11,9 +11,10 @@ import logging
 
 import geopandas as gpd
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
 from pypsa.geo import haversine_pts
 from shapely.geometry import Point
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -141,7 +142,7 @@ def prepare_dataset(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_gas_network")
 

--- a/scripts/build_geothermal_heat_potential.py
+++ b/scripts/build_geothermal_heat_potential.py
@@ -40,7 +40,8 @@ import logging
 
 import geopandas as gpd
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -204,7 +205,7 @@ def get_heat_source_power(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_geothermal_heat_potential",

--- a/scripts/build_hac_features.py
+++ b/scripts/build_hac_features.py
@@ -8,15 +8,21 @@ Aggregate all rastered cutout data to base regions Voronoi cells.
 import logging
 
 import geopandas as gpd
-from _helpers import configure_logging, get_snapshots, load_cutout, set_scenario_config
 from atlite.aggregate import aggregate_matrix
 from dask.distributed import Client
+
+from scripts._helpers import (
+    configure_logging,
+    get_snapshots,
+    load_cutout,
+    set_scenario_config,
+)
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_hac_features")
     configure_logging(snakemake)

--- a/scripts/build_heat_totals.py
+++ b/scripts/build_heat_totals.py
@@ -15,8 +15,9 @@ import logging
 from itertools import product
 
 import pandas as pd
-from _helpers import configure_logging
 from numpy.polynomial import Polynomial
+
+from scripts._helpers import configure_logging
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +102,7 @@ def approximate_heat_demand(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_heat_totals")
 

--- a/scripts/build_hourly_heat_demand.py
+++ b/scripts/build_hourly_heat_demand.py
@@ -14,7 +14,8 @@ from itertools import product
 
 import pandas as pd
 import xarray as xr
-from _helpers import (
+
+from scripts._helpers import (
     configure_logging,
     generate_periodic_profiles,
     get_snapshots,
@@ -25,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_hourly_heat_demand",

--- a/scripts/build_hydro_profile.py
+++ b/scripts/build_hydro_profile.py
@@ -28,8 +28,14 @@ import logging
 import country_converter as coco
 import geopandas as gpd
 import pandas as pd
-from _helpers import configure_logging, get_snapshots, load_cutout, set_scenario_config
 from numpy.polynomial import Polynomial
+
+from scripts._helpers import (
+    configure_logging,
+    get_snapshots,
+    load_cutout,
+    set_scenario_config,
+)
 
 cc = coco.CountryConverter()
 
@@ -139,7 +145,7 @@ logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_hydro_profile")
     configure_logging(snakemake)

--- a/scripts/build_industrial_distribution_key.py
+++ b/scripts/build_industrial_distribution_key.py
@@ -31,7 +31,8 @@ from itertools import product
 import country_converter as coco
 import geopandas as gpd
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 cc = coco.CountryConverter()
@@ -372,7 +373,7 @@ def build_nodal_distribution_key(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_industrial_distribution_key",

--- a/scripts/build_industrial_energy_demand_per_country_today.py
+++ b/scripts/build_industrial_energy_demand_per_country_today.py
@@ -54,8 +54,9 @@ from functools import partial
 
 import country_converter as coco
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
 from tqdm import tqdm
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -276,7 +277,7 @@ def add_coke_ovens(demand, fn, year, factor=0.75):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_industrial_energy_demand_per_country_today")
     configure_logging(snakemake)

--- a/scripts/build_industrial_energy_demand_per_node.py
+++ b/scripts/build_industrial_energy_demand_per_node.py
@@ -26,13 +26,14 @@ which can later be used as values for the industry load.
 import logging
 
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_industrial_energy_demand_per_node",

--- a/scripts/build_industrial_energy_demand_per_node_today.py
+++ b/scripts/build_industrial_energy_demand_per_node_today.py
@@ -18,7 +18,8 @@ from itertools import product
 
 import numpy as np
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +80,7 @@ def build_nodal_industrial_energy_demand():
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_industrial_energy_demand_per_node_today",

--- a/scripts/build_industrial_production_per_country.py
+++ b/scripts/build_industrial_production_per_country.py
@@ -48,8 +48,9 @@ from functools import partial
 import country_converter as coco
 import numpy as np
 import pandas as pd
-from _helpers import configure_logging, mute_print, set_scenario_config
 from tqdm import tqdm
+
+from scripts._helpers import configure_logging, mute_print, set_scenario_config
 
 logger = logging.getLogger(__name__)
 cc = coco.CountryConverter()
@@ -313,7 +314,7 @@ def separate_basic_chemicals(demand, year):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_industrial_production_per_country")
     configure_logging(snakemake)

--- a/scripts/build_industrial_production_per_country_tomorrow.py
+++ b/scripts/build_industrial_production_per_country_tomorrow.py
@@ -35,14 +35,15 @@ The unit of the production is kt/a.
 import logging
 
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
-from prepare_sector_network import get
+
+from scripts._helpers import configure_logging, set_scenario_config
+from scripts.prepare_sector_network import get
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_industrial_production_per_country_tomorrow")
     configure_logging(snakemake)

--- a/scripts/build_industrial_production_per_node.py
+++ b/scripts/build_industrial_production_per_node.py
@@ -17,7 +17,8 @@ import logging
 from itertools import product
 
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +77,7 @@ def build_nodal_industrial_production():
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_industrial_production_per_node", clusters=48)
     configure_logging(snakemake)

--- a/scripts/build_industry_sector_ratios.py
+++ b/scripts/build_industry_sector_ratios.py
@@ -32,7 +32,8 @@ import logging
 
 import country_converter as coco
 import pandas as pd
-from _helpers import configure_logging, mute_print, set_scenario_config
+
+from scripts._helpers import configure_logging, mute_print, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -1512,7 +1513,7 @@ def other_industrial_sectors():
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_industry_sector_ratios")
     configure_logging(snakemake)

--- a/scripts/build_industry_sector_ratios_intermediate.py
+++ b/scripts/build_industry_sector_ratios_intermediate.py
@@ -61,8 +61,9 @@ import logging
 
 import numpy as np
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
-from prepare_sector_network import get
+
+from scripts._helpers import configure_logging, set_scenario_config
+from scripts.prepare_sector_network import get
 
 logger = logging.getLogger(__name__)
 
@@ -125,7 +126,7 @@ def build_industry_sector_ratios_intermediate():
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_industry_sector_ratios_intermediate",

--- a/scripts/build_line_rating.py
+++ b/scripts/build_line_rating.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-# coding: utf-8
+
 """
 Calculates dynamic line rating time series from base network.
 
@@ -33,10 +33,16 @@ import geopandas as gpd
 import numpy as np
 import pypsa
 import xarray as xr
-from _helpers import configure_logging, get_snapshots, load_cutout, set_scenario_config
 from dask.distributed import Client
 from shapely.geometry import LineString as Line
 from shapely.geometry import Point
+
+from scripts._helpers import (
+    configure_logging,
+    get_snapshots,
+    load_cutout,
+    set_scenario_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +135,7 @@ def calculate_line_rating(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_line_rating")
     configure_logging(snakemake)

--- a/scripts/build_monthly_prices.py
+++ b/scripts/build_monthly_prices.py
@@ -29,7 +29,8 @@ Data was accessed at 16.5.2023
 import logging
 
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +93,7 @@ def get_co2_price():
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_monthly_prices")
 

--- a/scripts/build_osm_boundaries.py
+++ b/scripts/build_osm_boundaries.py
@@ -8,10 +8,11 @@ import logging
 import country_converter as coco
 import geopandas as gpd
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
-from build_shapes import eez
 from shapely import line_merge
 from shapely.geometry import LineString, MultiLineString, MultiPolygon, Polygon
+
+from scripts._helpers import configure_logging, set_scenario_config
+from scripts.build_shapes import eez
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +168,7 @@ def build_osm_boundaries(country, adm1_path, offshore_shapes):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_osm_boundaries", country="MD")
 

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -11,13 +11,14 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 import pypsa
-from _helpers import configure_logging, set_scenario_config
 from pyproj import Transformer
 from shapely import prepare
 from shapely.algorithms.polylabel import polylabel
 from shapely.geometry import LineString, MultiLineString, Point
 from shapely.ops import linemerge, split
 from tqdm import tqdm
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -1649,7 +1650,7 @@ def build_network(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_osm_network")
 

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -13,7 +13,8 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import xarray as xr
-from _helpers import configure_logging, load_cutout, set_scenario_config
+
+from scripts._helpers import configure_logging, load_cutout, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,7 @@ cc = coco.CountryConverter()
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_population_layouts",

--- a/scripts/build_population_weighted_energy_totals.py
+++ b/scripts/build_population_weighted_energy_totals.py
@@ -8,7 +8,8 @@ Distribute country-level energy demands by population.
 import logging
 
 import pandas as pd
-from _helpers import configure_logging, get_snapshots, set_scenario_config
+
+from scripts._helpers import configure_logging, get_snapshots, set_scenario_config
 
 idx = pd.IndexSlice
 
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_population_weighted_energy_totals",

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-# coding: utf-8
+
 """
 Retrieves conventional powerplant capacities and locations from
 `powerplantmatching <https://github.com/PyPSA/powerplantmatching>`_, assigns
@@ -70,8 +70,9 @@ import numpy as np
 import pandas as pd
 import powerplantmatching as pm
 import pypsa
-from _helpers import configure_logging, set_scenario_config
 from powerplantmatching.export import map_country_bus
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +145,7 @@ def replace_natural_gas_fueltype(df):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_powerplants")
     configure_logging(snakemake)

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -96,17 +96,23 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import xarray as xr
-from _helpers import configure_logging, get_snapshots, load_cutout, set_scenario_config
 from atlite.gis import ExclusionContainer
-from build_shapes import _simplify_polys
 from dask.distributed import Client
+
+from scripts._helpers import (
+    configure_logging,
+    get_snapshots,
+    load_cutout,
+    set_scenario_config,
+)
+from scripts.build_shapes import _simplify_polys
 
 logger = logging.getLogger(__name__)
 
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_renewable_profiles", clusters=38, technology="offwind-ac"

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -69,7 +69,8 @@ import logging
 
 import pandas as pd
 import xarray as xr
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -1049,7 +1050,7 @@ def sample_dE_costs_area(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_retro_cost",

--- a/scripts/build_salt_cavern_potentials.py
+++ b/scripts/build_salt_cavern_potentials.py
@@ -24,7 +24,8 @@ import logging
 
 import geopandas as gpd
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +75,7 @@ def salt_cavern_potential_by_region(caverns, regions):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_salt_cavern_potentials", clusters="37")
 

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -18,9 +18,10 @@ import numpy as np
 import pandas as pd
 import rasterio
 import xarray as xr
-from _helpers import configure_logging, set_scenario_config
 from rasterio.mask import mask
 from shapely.geometry import MultiPolygon, Polygon, box
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 cc = coco.CountryConverter()
@@ -490,7 +491,7 @@ def calc_gdp_pop(country, regions, gdp_non_nuts3, pop_non_nuts3):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_shapes")
     configure_logging(snakemake)

--- a/scripts/build_ship_raster.py
+++ b/scripts/build_ship_raster.py
@@ -25,7 +25,8 @@ import zipfile
 from pathlib import Path
 
 import rioxarray
-from _helpers import configure_logging, load_cutout, set_scenario_config
+
+from scripts._helpers import configure_logging, load_cutout, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +58,7 @@ def determine_cutout_xXyY(cutout_name):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_ship_raster")
     configure_logging(snakemake)

--- a/scripts/build_shipping_demand.py
+++ b/scripts/build_shipping_demand.py
@@ -11,13 +11,14 @@ import logging
 
 import geopandas as gpd
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_shipping_demand", clusters=48)
     configure_logging(snakemake)

--- a/scripts/build_solar_thermal_profiles.py
+++ b/scripts/build_solar_thermal_profiles.py
@@ -16,14 +16,20 @@ import logging
 import geopandas as gpd
 import numpy as np
 import xarray as xr
-from _helpers import configure_logging, get_snapshots, load_cutout, set_scenario_config
 from dask.distributed import Client, LocalCluster
+
+from scripts._helpers import (
+    configure_logging,
+    get_snapshots,
+    load_cutout,
+    set_scenario_config,
+)
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_solar_thermal_profiles", clusters=48)
     configure_logging(snakemake)

--- a/scripts/build_temperature_profiles.py
+++ b/scripts/build_temperature_profiles.py
@@ -18,14 +18,20 @@ import logging
 import geopandas as gpd
 import numpy as np
 import xarray as xr
-from _helpers import configure_logging, get_snapshots, load_cutout, set_scenario_config
 from dask.distributed import Client, LocalCluster
+
+from scripts._helpers import (
+    configure_logging,
+    get_snapshots,
+    load_cutout,
+    set_scenario_config,
+)
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_temperature_profiles",

--- a/scripts/build_tes_capacity/run.py
+++ b/scripts/build_tes_capacity/run.py
@@ -36,14 +36,15 @@ Outputs
 import logging
 
 import xarray as xr
-from _helpers import set_scenario_config
-from tes_capacity_approximator import TesCapacityApproximator
+
+from scripts._helpers import set_scenario_config
+from scripts.build_tes_capacity.tes_capacity_approximator import TesCapacityApproximator
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_tes_parameters",

--- a/scripts/build_transmission_projects.py
+++ b/scripts/build_transmission_projects.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-# coding: utf-8
+
 """
 Gets the transmission projects defined in the config file, concatenates and
 deduplicates them. Projects are later included in :mod:`add_electricity.py`.
@@ -33,10 +33,11 @@ import numpy as np
 import pandas as pd
 import pypsa
 import shapely
-from _helpers import configure_logging, set_scenario_config
 from pypsa.descriptors import nominal_attrs
 from scipy import spatial
 from shapely.geometry import LineString, Point
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -461,7 +462,7 @@ def fill_length_from_geometry(line, line_factor=1.2):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_transmission_projects")
     configure_logging(snakemake)

--- a/scripts/build_transport_demand.py
+++ b/scripts/build_transport_demand.py
@@ -12,7 +12,8 @@ import logging
 import numpy as np
 import pandas as pd
 import xarray as xr
-from _helpers import (
+
+from scripts._helpers import (
     configure_logging,
     generate_periodic_profiles,
     get_snapshots,
@@ -163,7 +164,7 @@ def bev_dsm_profile(snapshots, nodes, options):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("build_transport_demand", clusters=128)
     configure_logging(snakemake)

--- a/scripts/clean_osm_data.py
+++ b/scripts/clean_osm_data.py
@@ -21,10 +21,11 @@ import re
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
 from shapely.algorithms.polylabel import polylabel
 from shapely.geometry import LineString, MultiLineString, Point, Polygon
 from shapely.ops import linemerge, unary_union
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -1570,7 +1571,7 @@ def _check_if_ways_in_multi(list, longer_list):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("clean_osm_data")
 

--- a/scripts/cluster_gas_network.py
+++ b/scripts/cluster_gas_network.py
@@ -9,9 +9,10 @@ import logging
 
 import geopandas as gpd
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
 from pypsa.geo import haversine_pts
 from shapely import wkt
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +106,7 @@ def aggregate_parallel_pipes(df):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("cluster_gas_network", clusters="37")
     configure_logging(snakemake)

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-# coding: utf-8
+
 """
 Creates networks clustered to ``{cluster}`` number of zones with aggregated
 buses and transmission corridors.
@@ -74,7 +74,6 @@ import pandas as pd
 import pypsa
 import tqdm
 import xarray as xr
-from _helpers import configure_logging, set_scenario_config
 from packaging.version import Version, parse
 from pypsa.clustering.spatial import (
     busmap_by_greedy_modularity,
@@ -85,6 +84,8 @@ from pypsa.clustering.spatial import (
 from scipy.sparse.csgraph import connected_components
 from shapely.algorithms.polylabel import polylabel
 from shapely.geometry import MultiPolygon, Polygon
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 PD_GE_2_2 = parse(pd.__version__) >= Version("2.2")
 
@@ -457,7 +458,7 @@ def update_bus_coordinates(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("cluster_network", clusters=60)
     configure_logging(snakemake)

--- a/scripts/definitions/heat_system.py
+++ b/scripts/definitions/heat_system.py
@@ -4,8 +4,8 @@
 
 from enum import Enum
 
-from definitions.heat_sector import HeatSector
-from definitions.heat_system_type import HeatSystemType
+from scripts.definitions.heat_sector import HeatSector
+from scripts.definitions.heat_system_type import HeatSystemType
 
 
 class HeatSystem(Enum):

--- a/scripts/determine_availability_matrix.py
+++ b/scripts/determine_availability_matrix.py
@@ -62,14 +62,15 @@ import atlite
 import geopandas as gpd
 import numpy as np
 import xarray as xr
-from _helpers import configure_logging, load_cutout, set_scenario_config
+
+from scripts._helpers import configure_logging, load_cutout, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "build_renewable_profiles", clusters=100, technology="onwind"

--- a/scripts/determine_availability_matrix_MD_UA.py
+++ b/scripts/determine_availability_matrix_MD_UA.py
@@ -15,7 +15,8 @@ import atlite
 import fiona
 import geopandas as gpd
 import numpy as np
-from _helpers import configure_logging, load_cutout, set_scenario_config
+
+from scripts._helpers import configure_logging, load_cutout, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ def get_wdpa_layer_name(wdpa_fn, layer_substring):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "determine_availability_matrix_MD_UA", clusters=100, technology="solar"

--- a/scripts/make_cumulative_costs.py
+++ b/scripts/make_cumulative_costs.py
@@ -9,7 +9,8 @@ import logging
 
 import numpy as np
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 idx = pd.IndexSlice
 logger = logging.getLogger(__name__)
@@ -46,7 +47,7 @@ def calculate_cumulative_cost(costs, planning_horizons):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "make_cumulative_costs",

--- a/scripts/make_global_summary.py
+++ b/scripts/make_global_summary.py
@@ -9,7 +9,8 @@ capacity factors, curtailment, energy balances, prices and other metrics.
 import logging
 
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ INDEX_COLS = {
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("make_global_summary")
 

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -10,7 +10,8 @@ import logging
 
 import pandas as pd
 import pypsa
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 idx = pd.IndexSlice
 logger = logging.getLogger(__name__)
@@ -296,7 +297,7 @@ def calculate_market_values(n: pypsa.Network) -> pd.Series:
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "make_summary",

--- a/scripts/make_summary_perfect.py
+++ b/scripts/make_summary_perfect.py
@@ -10,14 +10,15 @@ other metrics.
 import numpy as np
 import pandas as pd
 import pypsa
-from _helpers import set_scenario_config
-from add_electricity import load_costs
-from make_summary import (
+from pypsa.descriptors import get_active_assets
+from six import iteritems
+
+from scripts._helpers import set_scenario_config
+from scripts.add_electricity import load_costs
+from scripts.make_summary import (
     assign_carriers,
     assign_locations,
 )
-from pypsa.descriptors import get_active_assets
-from six import iteritems
 
 idx = pd.IndexSlice
 
@@ -706,7 +707,7 @@ def to_csv(df):
 if __name__ == "__main__":
     # Detect running outside of snakemake and mock snakemake for testing
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("make_summary_perfect")
     set_scenario_config(snakemake)

--- a/scripts/plot_balance_map.py
+++ b/scripts/plot_balance_map.py
@@ -9,22 +9,23 @@ import geopandas as gpd
 import matplotlib.pyplot as plt
 import pandas as pd
 import pypsa
-from _helpers import (
+from packaging.version import Version, parse
+from pypsa.plot import add_legend_lines, add_legend_patches, add_legend_semicircles
+from pypsa.statistics import get_transmission_carriers
+
+from scripts._helpers import (
     configure_logging,
     set_scenario_config,
     update_config_from_wildcards,
 )
-from add_electricity import sanitize_carriers
-from packaging.version import Version, parse
-from plot_power_network import load_projection
-from pypsa.plot import add_legend_lines, add_legend_patches, add_legend_semicircles
-from pypsa.statistics import get_transmission_carriers
+from scripts.add_electricity import sanitize_carriers
+from scripts.plot_power_network import load_projection
 
 SEMICIRCLE_CORRECTION_FACTOR = 2 if parse(pypsa.__version__) <= Version("0.33.2") else 1
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "plot_balance_map",

--- a/scripts/plot_balance_timeseries.py
+++ b/scripts/plot_balance_timeseries.py
@@ -15,8 +15,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pypsa
-from _helpers import configure_logging, get_snapshots, set_scenario_config
 from tqdm import tqdm
+
+from scripts._helpers import configure_logging, get_snapshots, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -181,7 +182,7 @@ def process_carrier(group_item, balance, months, colors, config, output_dir):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "plot_balance_timeseries",

--- a/scripts/plot_gas_network.py
+++ b/scripts/plot_gas_network.py
@@ -12,10 +12,11 @@ import geopandas as gpd
 import matplotlib.pyplot as plt
 import pandas as pd
 import pypsa
-from _helpers import configure_logging, retry, set_scenario_config
-from make_summary import assign_locations
-from plot_power_network import load_projection
 from pypsa.plot import add_legend_circles, add_legend_lines, add_legend_patches
+
+from scripts._helpers import configure_logging, retry, set_scenario_config
+from scripts.make_summary import assign_locations
+from scripts.plot_power_network import load_projection
 
 logger = logging.getLogger(__name__)
 
@@ -231,7 +232,7 @@ def plot_ch4_map(n):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "plot_gas_network",

--- a/scripts/plot_heatmap_timeseries.py
+++ b/scripts/plot_heatmap_timeseries.py
@@ -13,7 +13,8 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import pypsa
 import seaborn as sns
-from _helpers import configure_logging, get_snapshots, set_scenario_config
+
+from scripts._helpers import configure_logging, get_snapshots, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +87,7 @@ def plot_heatmap(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "plot_heatmap_timeseries",

--- a/scripts/plot_hydrogen_network.py
+++ b/scripts/plot_hydrogen_network.py
@@ -12,10 +12,11 @@ import geopandas as gpd
 import matplotlib.pyplot as plt
 import pandas as pd
 import pypsa
-from _helpers import configure_logging, retry, set_scenario_config
-from make_summary import assign_locations
-from plot_power_network import load_projection
 from pypsa.plot import add_legend_circles, add_legend_lines, add_legend_patches
+
+from scripts._helpers import configure_logging, retry, set_scenario_config
+from scripts.make_summary import assign_locations
+from scripts.plot_power_network import load_projection
 
 logger = logging.getLogger(__name__)
 
@@ -254,7 +255,7 @@ def plot_h2_map(n, regions):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "plot_hydrogen_network",

--- a/scripts/plot_power_network.py
+++ b/scripts/plot_power_network.py
@@ -13,10 +13,11 @@ import geopandas as gpd
 import matplotlib.pyplot as plt
 import pandas as pd
 import pypsa
-from _helpers import configure_logging, rename_techs, retry, set_scenario_config
-from make_summary import assign_locations
-from plot_summary import preferred_order
 from pypsa.plot import add_legend_circles, add_legend_lines, add_legend_patches
+
+from scripts._helpers import configure_logging, rename_techs, retry, set_scenario_config
+from scripts.make_summary import assign_locations
+from scripts.plot_summary import preferred_order
 
 logger = logging.getLogger(__name__)
 
@@ -236,7 +237,7 @@ def plot_map(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "plot_power_network",

--- a/scripts/plot_power_network_clustered.py
+++ b/scripts/plot_power_network_clustered.py
@@ -8,14 +8,15 @@ Plot clustered electricity transmission network.
 import geopandas as gpd
 import matplotlib.pyplot as plt
 import pypsa
-from _helpers import set_scenario_config
 from matplotlib.lines import Line2D
-from plot_power_network import load_projection
 from pypsa.plot import add_legend_lines
+
+from scripts._helpers import set_scenario_config
+from scripts.plot_power_network import load_projection
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "plot_power_network_clustered",

--- a/scripts/plot_power_network_perfect.py
+++ b/scripts/plot_power_network_perfect.py
@@ -12,11 +12,12 @@ import geopandas as gpd
 import matplotlib.pyplot as plt
 import pandas as pd
 import pypsa
-from _helpers import configure_logging, retry, set_scenario_config
-from make_summary import assign_locations
-from plot_power_network import load_projection, rename_techs_tyndp
-from plot_summary import preferred_order
 from pypsa.plot import add_legend_circles, add_legend_lines
+
+from scripts._helpers import configure_logging, retry, set_scenario_config
+from scripts.make_summary import assign_locations
+from scripts.plot_power_network import load_projection, rename_techs_tyndp
+from scripts.plot_summary import preferred_order
 
 logger = logging.getLogger(__name__)
 
@@ -174,7 +175,7 @@ def plot_map_perfect(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "plot_power_network_perfect",

--- a/scripts/plot_statistics.py
+++ b/scripts/plot_statistics.py
@@ -5,14 +5,15 @@
 import matplotlib.pyplot as plt
 import pypsa
 import seaborn as sns
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 sns.set_theme("paper", style="whitegrid")
 
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "plot_elec_statistics",

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -10,8 +10,9 @@ import logging
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import pandas as pd
-from _helpers import configure_logging, rename_techs, set_scenario_config
-from prepare_sector_network import co2_emissions_year
+
+from scripts._helpers import configure_logging, rename_techs, set_scenario_config
+from scripts.prepare_sector_network import co2_emissions_year
 
 logger = logging.getLogger(__name__)
 plt.style.use("bmh")
@@ -488,7 +489,7 @@ def plot_carbon_budget_distribution(input_eurostat, options):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("plot_summary")
 

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-# coding: utf-8
+
 """
 Prepare PyPSA network for solving according to :ref:`opts` and :ref:`ll`, such
 as.
@@ -29,14 +29,15 @@ import logging
 import numpy as np
 import pandas as pd
 import pypsa
-from _helpers import (
+from pypsa.descriptors import expand_series
+
+from scripts._helpers import (
     configure_logging,
     get,
     set_scenario_config,
     update_config_from_wildcards,
 )
-from add_electricity import load_costs, set_transmission_costs
-from pypsa.descriptors import expand_series
+from scripts.add_electricity import load_costs, set_transmission_costs
 
 idx = pd.IndexSlice
 
@@ -287,7 +288,7 @@ def set_line_nom_max(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "prepare_network",

--- a/scripts/prepare_osm_network_release.py
+++ b/scripts/prepare_osm_network_release.py
@@ -8,9 +8,10 @@ import folium
 import geopandas as gpd
 import numpy as np
 import pypsa
-from _helpers import configure_logging, set_scenario_config
-from base_network import _get_linetype_by_voltage
 from shapely.wkt import loads
+
+from scripts._helpers import configure_logging, set_scenario_config
+from scripts.base_network import _get_linetype_by_voltage
 
 logger = logging.getLogger(__name__)
 
@@ -222,7 +223,7 @@ def create_geometries(network, is_converter, crs=GEO_CRS):
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("prepare_osm_network_release")
 

--- a/scripts/prepare_perfect_foresight.py
+++ b/scripts/prepare_perfect_foresight.py
@@ -10,16 +10,17 @@ import logging
 import numpy as np
 import pandas as pd
 import pypsa
-from _helpers import (
+from pypsa.descriptors import expand_series
+from six import iterkeys
+
+from scripts._helpers import (
     configure_logging,
     sanitize_custom_columns,
     set_scenario_config,
     update_config_from_wildcards,
 )
-from add_electricity import sanitize_carriers
-from add_existing_baseyear import add_build_year_to_new_assets
-from pypsa.descriptors import expand_series
-from six import iterkeys
+from scripts.add_electricity import sanitize_carriers
+from scripts.add_existing_baseyear import add_build_year_to_new_assets
 
 logger = logging.getLogger(__name__)
 
@@ -598,7 +599,7 @@ def update_heat_pump_efficiency(n: pypsa.Network, years: list[int]) -> None:
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "prepare_perfect_foresight",

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -16,33 +16,34 @@ import numpy as np
 import pandas as pd
 import pypsa
 import xarray as xr
-from _helpers import (
+from networkx.algorithms import complement
+from networkx.algorithms.connectivity.edge_augmentation import k_edge_augmentation
+from pypsa.geo import haversine_pts
+from scipy.stats import beta
+
+from scripts._helpers import (
     configure_logging,
     get,
     set_scenario_config,
     update_config_from_wildcards,
 )
-from add_electricity import (
+from scripts.add_electricity import (
     calculate_annuity,
     flatten,
     load_costs,
     sanitize_carriers,
     sanitize_locations,
 )
-from build_energy_totals import (
+from scripts.build_energy_totals import (
     build_co2_totals,
     build_eea_co2,
     build_eurostat,
     build_eurostat_co2,
 )
-from build_transport_demand import transport_degree_factor
-from definitions.heat_sector import HeatSector
-from definitions.heat_system import HeatSystem
-from networkx.algorithms import complement
-from networkx.algorithms.connectivity.edge_augmentation import k_edge_augmentation
-from prepare_network import maybe_adjust_costs_and_potentials
-from pypsa.geo import haversine_pts
-from scipy.stats import beta
+from scripts.build_transport_demand import transport_degree_factor
+from scripts.definitions.heat_sector import HeatSector
+from scripts.definitions.heat_system import HeatSystem
+from scripts.prepare_network import maybe_adjust_costs_and_potentials
 
 spatial = SimpleNamespace()
 logger = logging.getLogger(__name__)
@@ -5990,7 +5991,7 @@ def add_import_options(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "prepare_sector_network",

--- a/scripts/retrieve_cost_data.py
+++ b/scripts/retrieve_cost_data.py
@@ -8,13 +8,13 @@ Retrieve cost data from ``technology-data``.
 import logging
 from pathlib import Path
 
-from _helpers import configure_logging, progress_retrieve, set_scenario_config
+from scripts._helpers import configure_logging, progress_retrieve, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("retrieve_cost_data", year=2030)
         rootpath = ".."

--- a/scripts/retrieve_databundle.py
+++ b/scripts/retrieve_databundle.py
@@ -20,7 +20,7 @@ import logging
 import tarfile
 from pathlib import Path
 
-from _helpers import (
+from scripts._helpers import (
     configure_logging,
     progress_retrieve,
     set_scenario_config,
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("retrieve_databundle")
         rootpath = ".."

--- a/scripts/retrieve_electricity_demand.py
+++ b/scripts/retrieve_electricity_demand.py
@@ -8,13 +8,14 @@ Retrieve electricity prices from OPSD.
 import logging
 
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+
+from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("retrieve_electricity_demand")
         rootpath = ".."

--- a/scripts/retrieve_eurostat_data.py
+++ b/scripts/retrieve_eurostat_data.py
@@ -9,13 +9,13 @@ import logging
 import zipfile
 from pathlib import Path
 
-from _helpers import configure_logging, progress_retrieve, set_scenario_config
+from scripts._helpers import configure_logging, progress_retrieve, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("retrieve_eurostat_data")
         rootpath = ".."

--- a/scripts/retrieve_eurostat_household_data.py
+++ b/scripts/retrieve_eurostat_household_data.py
@@ -10,13 +10,13 @@ import logging
 import shutil
 from pathlib import Path
 
-from _helpers import configure_logging, progress_retrieve, set_scenario_config
+from scripts._helpers import configure_logging, progress_retrieve, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("retrieve_eurostat_data")
         rootpath = ".."

--- a/scripts/retrieve_gas_infrastructure_data.py
+++ b/scripts/retrieve_gas_infrastructure_data.py
@@ -10,7 +10,7 @@ import logging
 import zipfile
 from pathlib import Path
 
-from _helpers import (
+from scripts._helpers import (
     configure_logging,
     progress_retrieve,
     set_scenario_config,
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("retrieve_gas_network_data")
         rootpath = ".."

--- a/scripts/retrieve_jrc_idees.py
+++ b/scripts/retrieve_jrc_idees.py
@@ -8,7 +8,7 @@ Retrieve and extract JRC IDEES 2021 data.
 import logging
 import zipfile
 
-from _helpers import configure_logging, progress_retrieve, set_scenario_config
+from scripts._helpers import configure_logging, progress_retrieve, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +17,7 @@ url_jrc = "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/JRC-IDEES/JRC-IDEES-
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("retrieve_jrc_idees")
         rootpath = ".."

--- a/scripts/retrieve_monthly_fuel_prices.py
+++ b/scripts/retrieve_monthly_fuel_prices.py
@@ -8,13 +8,13 @@ Retrieve monthly fuel prices from Destatis.
 import logging
 from pathlib import Path
 
-from _helpers import configure_logging, progress_retrieve, set_scenario_config
+from scripts._helpers import configure_logging, progress_retrieve, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("retrieve_monthly_fuel_prices")
         rootpath = ".."

--- a/scripts/retrieve_osm_boundaries.py
+++ b/scripts/retrieve_osm_boundaries.py
@@ -15,7 +15,8 @@ import logging
 import time
 
 import requests
-from _helpers import (  # set_scenario_config,; update_config_from_wildcards,; update_config_from_wildcards,
+
+from scripts._helpers import (  # set_scenario_config,; update_config_from_wildcards,; update_config_from_wildcards,
     configure_logging,
     set_scenario_config,
 )
@@ -111,7 +112,7 @@ def retrieve_osm_boundaries(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("retrieve_osm_boundaries", country="XK")
     configure_logging(snakemake)

--- a/scripts/retrieve_osm_data.py
+++ b/scripts/retrieve_osm_data.py
@@ -16,7 +16,8 @@ import os
 import time
 
 import requests
-from _helpers import (  # set_scenario_config,; update_config_from_wildcards,; update_config_from_wildcards,
+
+from scripts._helpers import (  # set_scenario_config,; update_config_from_wildcards,; update_config_from_wildcards,
     configure_logging,
     set_scenario_config,
 )
@@ -138,7 +139,7 @@ def retrieve_osm_data(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("retrieve_osm_data", country="BE")
     configure_logging(snakemake)

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-# coding: utf-8
+
 """
 Lifts electrical transmission network to a single 380 kV voltage layer, removes
 dead-ends of the network, and reduces multi-hop HVDC connections to a single
@@ -47,10 +47,11 @@ import numpy as np
 import pandas as pd
 import pypsa
 import scipy as sp
-from _helpers import configure_logging, set_scenario_config
-from cluster_network import busmap_for_admin_regions, cluster_regions
 from pypsa.clustering.spatial import busmap_by_stubs, get_clustering_from_busmap
 from scipy.sparse.csgraph import connected_components, dijkstra
+
+from scripts._helpers import configure_logging, set_scenario_config
+from scripts.cluster_network import busmap_for_admin_regions, cluster_regions
 
 logger = logging.getLogger(__name__)
 
@@ -416,7 +417,7 @@ def remove_converters(n: pypsa.Network) -> pypsa.Network:
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake("simplify_network")
     configure_logging(snakemake)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -40,15 +40,16 @@ import pandas as pd
 import pypsa
 import xarray as xr
 import yaml
-from _benchmark import memory_logger
-from _helpers import (
+from pypsa.descriptors import get_activity_mask
+from pypsa.descriptors import get_switchable_as_dense as get_as_dense
+
+from scripts._benchmark import memory_logger
+from scripts._helpers import (
     configure_logging,
     get,
     set_scenario_config,
     update_config_from_wildcards,
 )
-from pypsa.descriptors import get_activity_mask
-from pypsa.descriptors import get_switchable_as_dense as get_as_dense
 
 logger = logging.getLogger(__name__)
 pypsa.pf.logger.setLevel(logging.WARNING)
@@ -1354,7 +1355,7 @@ def solve_network(
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "solve_sector_network",

--- a/scripts/solve_operations_network.py
+++ b/scripts/solve_operations_network.py
@@ -10,19 +10,20 @@ import logging
 
 import numpy as np
 import pypsa
-from _helpers import (
+
+from scripts._helpers import (
     configure_logging,
     set_scenario_config,
     update_config_from_wildcards,
 )
-from solve_network import prepare_network, solve_network
+from scripts.solve_network import prepare_network, solve_network
 
 logger = logging.getLogger(__name__)
 
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "solve_operations_network",

--- a/scripts/time_aggregation.py
+++ b/scripts/time_aggregation.py
@@ -19,7 +19,8 @@ import pandas as pd
 import pypsa
 import tsam.timeseriesaggregation as tsam
 import xarray as xr
-from _helpers import (
+
+from scripts._helpers import (
     configure_logging,
     set_scenario_config,
     update_config_from_wildcards,
@@ -29,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+        from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
             "time_aggregation",

--- a/test/test_base_network.py
+++ b/test/test_base_network.py
@@ -15,7 +15,7 @@ import pytest
 
 sys.path.append("./scripts")
 
-from base_network import (
+from scripts.base_network import (
     _get_country,
     _get_linetype_by_voltage,
     _get_linetypes_config,


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
- Change all imports of internal modules to absolute. Right now it is mostly a mix of sometimes absolute and sometimes not
- This might make problems with people's `mock_snakemake` setup. You will need to add the working dir to your Python path to resolve it. I'll add a release note for that.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] A release note `doc/release_notes.rst` is added.
