### PR TITLE
Complement era5 files for data bundle retrieval

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,8 @@ Release Notes
 .. Upcoming Release
 .. ================
 
+* Add era5 data sources that are meant to be retrieved as part of data bundle to datafiles list in ``retrieve.smk``
+
 PyPSA-Eur v2025.04.0 (6th April 2025)
 ========================================
 

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -28,6 +28,8 @@ if config["enable"]["retrieve"] and config["enable"].get("retrieve_databundle", 
         "gebco/GEBCO_2014_2D.nc",
         "GDP_per_capita_PPP_1990_2015_v2.nc",
         "ppp_2019_1km_Aggregated.tif",
+        "era5-HDD-per-country.csv",
+        "era5-runoff-per-country.csv",
     ]
 
     rule retrieve_databundle:


### PR DESCRIPTION
## Changes proposed in this Pull Request

Since #1613, the files era5-HDD-per-country.csv and era5-runoff-per-country.csv are intended to be part of the data bundle hosted on Zenodo. This PR adds them to the datafiles list in the retrieve.smk rule to ensure they are correctly downloaded and used as inputs of downstream rules such as `build_hydro_profile`.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
