### PR TITLE
Revert "docs: remove `-call` argument (#1386)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,11 @@ install-pinned-macos: _conda_check
 # Run default tests
 test:
 	set -e
-	snakemake solve_elec_networks --configfile config/test/config.electricity.yaml
-	snakemake --configfile config/test/config.overnight.yaml
-	snakemake --configfile config/test/config.myopic.yaml
-	snakemake make_summary_perfect --configfile config/test/config.perfect.yaml
-	snakemake --configfile config/test/config.scenarios.yaml -n
+	snakemake -call solve_elec_networks --configfile config/test/config.electricity.yaml
+	snakemake -call --configfile config/test/config.overnight.yaml
+	snakemake -call --configfile config/test/config.myopic.yaml
+	snakemake -call make_summary_perfect --configfile config/test/config.perfect.yaml
+	snakemake -call --configfile config/test/config.scenarios.yaml -n
 	echo "All tests completed successfully."
 
 unit-test:
@@ -66,11 +66,11 @@ unit-test:
 
 # Cleans all output files from tests
 clean-tests:
-	snakemake solve_elec_networks --configfile config/test/config.electricity.yaml --delete-all-output
-	snakemake --configfile config/test/config.overnight.yaml --delete-all-output
-	snakemake --configfile config/test/config.myopic.yaml --delete-all-output
-	snakemake make_summary_perfect --configfile config/test/config.perfect.yaml --delete-all-output
-	snakemake --configfile config/test/config.scenarios.yaml -n --delete-all-output
+	snakemake -call solve_elec_networks --configfile config/test/config.electricity.yaml --delete-all-output
+	snakemake -call --configfile config/test/config.overnight.yaml --delete-all-output
+	snakemake -call --configfile config/test/config.myopic.yaml --delete-all-output
+	snakemake -call make_summary_perfect --configfile config/test/config.perfect.yaml --delete-all-output
+	snakemake -call --configfile config/test/config.scenarios.yaml -n --delete-all-output
 
 # Removes all created files except for large cutout files (similar to fresh clone)
 reset:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -80,10 +80,10 @@ facilitate running multiple scenarios through a single command
 .. code:: console
 
    # for electricity-only studies
-   $ snakemake solve_elec_networks
+   $ snakemake -call solve_elec_networks
 
    # for sector-coupling studies
-   $ snakemake solve_sector_networks
+   $ snakemake -call solve_sector_networks
 
 For each wildcard, a **list of values** is provided. The rule
 ``solve_all_elec_networks`` will trigger the rules for creating

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -99,4 +99,4 @@ You can also use ``snakemake`` to specify another file, e.g.
 
 .. code:: console
 
-    $ snakemake --configfile config/config.mymodifications.yaml
+    $ snakemake -call --configfile config/config.mymodifications.yaml

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -35,7 +35,7 @@ For instance, an invocation to
 
 .. code:: console
 
-    $ snakemake results/networks/base_s_128_elec_.nc
+    $ snakemake -call results/networks/base_s_128_elec_.nc
 
 follows this dependency graph
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,8 @@ Release Notes
 .. Upcoming Release
 .. ================
 
+* Fix: Revert default behaviour of `-cores` for `snakemake` (https://github.com/PyPSA/pypsa-eur/pull/1650).
+
 * Add era5 data sources that are meant to be retrieved as part of data bundle to datafiles list in ``retrieve.smk``
 
 PyPSA-Eur v2025.04.0 (6th April 2025)

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -32,7 +32,7 @@ configuration, execute
 .. code:: console
     :class: full-width
 
-    $ snakemake results/test-elec/networks/base_s_6_elec_.nc --configfile config/test/config.electricity.yaml
+    $ snakemake -call results/test-elec/networks/base_s_6_elec_.nc --configfile config/test/config.electricity.yaml
 
 This configuration is set to download a reduced cutout via the rule :mod:`retrieve_cutout`.
 For more information on the data dependencies of PyPSA-Eur, continue reading :ref:`data`.
@@ -135,7 +135,7 @@ clustered down to 6 buses and every 24 hours aggregated to one snapshot. The com
 
 .. code:: console
 
-    $ snakemake results/test-elec/networks/base_s_6_elec_.nc --configfile config/test/config.electricity.yaml
+    $ snakemake -call results/test-elec/networks/base_s_6_elec_.nc --configfile config/test/config.electricity.yaml
 
 orders ``snakemake`` to run the rule :mod:`solve_network` that produces the solved network and stores it in ``results/test-elec/networks`` with the name ``base_s_6_elec_.nc``:
 
@@ -364,21 +364,21 @@ You can produce any output file occurring in the ``Snakefile`` by running
 
 .. code:: console
 
-    $ snakemake <output file>
+    $ snakemake -call <output file>
 
 For example, you can explore the evolution of the PyPSA networks by running
 
-#. ``snakemake resources/test/networks/base.nc --configfile config/test/config.electricity.yaml``
-#. ``snakemake resources/test/networks/base_s.nc --configfile config/test/config.electricity.yaml``
-#. ``snakemake resources/test/networks/base_s_6.nc --configfile config/test/config.electricity.yaml``
-#. ``snakemake resources/test/networks/base_s_6_elec_.nc --configfile config/test/config.electricity.yaml``
+#. ``snakemake -call resources/test/networks/base.nc --configfile config/test/config.electricity.yaml``
+#. ``snakemake -call resources/test/networks/base_s.nc --configfile config/test/config.electricity.yaml``
+#. ``snakemake -call resources/test/networks/base_s_6.nc --configfile config/test/config.electricity.yaml``
+#. ``snakemake -call resources/test/networks/base_s_6_elec_.nc --configfile config/test/config.electricity.yaml``
 
 To run all combinations of wildcard values provided in the ``config/config.yaml`` under ``scenario:``,
 you can use the collection rule ``solve_elec_networks``.
 
 .. code:: console
 
-    $ snakemake solve_elec_networks --configfile config/test/config.electricity.yaml
+    $ snakemake -call solve_elec_networks --configfile config/test/config.electricity.yaml
 
 If you now feel confident and want to tackle runs with larger temporal and
 spatial scope, clean-up the repository and after modifying the ``config/config.yaml`` file
@@ -387,8 +387,8 @@ configuration file.
 
 .. code:: console
 
-    $ snakemake purge
-    $ snakemake solve_elec_networks
+    $ snakemake -call purge
+    snakemake -call solve_elec_networks
 
 .. note::
 
@@ -397,7 +397,7 @@ configuration file.
 
     .. code:: console
 
-        $ snakemake solve_elec_networks -n
+        $ snakemake -call solve_elec_networks -n
 
 How to analyse results?
 ===============================

--- a/doc/tutorial_sector.rst
+++ b/doc/tutorial_sector.rst
@@ -59,7 +59,7 @@ To run an overnight / greenfiled scenario with the specifications above, run
 
 .. code:: console
 
-    $ snakemake all --configfile config/test/config.overnight.yaml
+    $ snakemake -call all --configfile config/test/config.overnight.yaml
 
 which will result in the following jobs ``snakemake`` wants to run, some of
 which were already included in the electricity-only tutorial:
@@ -520,7 +520,7 @@ To run a myopic foresight scenario with the specifications above, run
 
 .. code:: console
 
-    $ snakemake all --configfile config/test/config.myopic.yaml
+    $ snakemake -call all --configfile config/test/config.myopic.yaml
 
 which will result in additional jobs ``snakemake`` wants to run, which
 translates to the following workflow diagram which nicely outlines how the
@@ -1059,8 +1059,8 @@ configuration file.
 
 .. code:: console
 
-    $ snakemake purge
-    $ snakemake all
+    $ snakemake -call purge
+    $ snakemake -call all
 
 .. note::
 
@@ -1069,4 +1069,4 @@ configuration file.
 
     .. code:: console
 
-        $ snakemake all -n
+        $ snakemake -call all -n

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -21,7 +21,7 @@ dependencies:
 - xlrd
 - openpyxl
 - seaborn
-- snakemake-minimal>=9.2
+- snakemake-minimal>=9
 - memory_profiler
 - yaml
 - pytables

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -21,7 +21,7 @@ dependencies:
 - xlrd
 - openpyxl
 - seaborn
-- snakemake-minimal>=9
+- snakemake-minimal>=9.2
 - memory_profiler
 - yaml
 - pytables


### PR DESCRIPTION
This reverts commit 225dae0e1ce781344d3e1b09745491241bbadaa5, PR https://github.com/PyPSA/pypsa-eur/pull/1386.

## Changes proposed in this Pull Request

As of `snakemake>=9.2.0` ([changelog](https://snakemake.readthedocs.io/en/stable/project_info/history.html#id4)), the default behaviour of `-cores` for `snakemake` is restored. This PR suggests reverting the changes and updates the environment.

From `snakemake` changelog:

> restore accidentally changed behavior of –cores. If not specified, Snakemake now complains again, asking for –cores to be specified (of –jobs in case of remote exec). As before, if a default is desired, it can be easily set via a profile ([#3531](https://github.com/snakemake/snakemake/issues/3531)) ([11b2b30](https://github.com/snakemake/snakemake/commit/11b2b307002c2cb16c2b0faf334c068b68e83a24))

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
