### PR TITLE
Remove duplicated def of input_profile_tech (w/o clusters wildcard)

### DIFF
--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -486,13 +486,6 @@ rule add_transmission_projects_and_dlr:
         "../scripts/add_transmission_projects_and_dlr.py"
 
 
-def input_profile_tech(w):
-    return {
-        f"profile_{tech}": resources(f"profile_{tech}.nc")
-        for tech in config_provider("electricity", "renewable_carriers")(w)
-    }
-
-
 def input_class_regions(w):
     return {
         f"class_regions_{tech}": resources(


### PR DESCRIPTION
## Changes proposed in this Pull Request
`input_profile_tech` was defined twice in `build_electricity.smk`. This removes the definition that doesn't contain the clusters wildcard (for non-hydro techs), which points to non-existing files (given I understand this correctly).

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
