### PR TITLE
Add support for aquifer thermal energy storage (ATES)

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -483,6 +483,15 @@ sector:
       dynamic_capacity: true
       max_top_temperature: 90
       min_bottom_temperature: 35
+    ates:
+      allow: false
+      suitable_aquifer_types: ['Highly productive porous aquifers']
+      aquifer_volumetric_heat_capacity: 2600
+      fraction_of_aquifer_area_available: 0.2
+      effective_screen_length: 20
+      dh_area_buffer: 1000
+      capex_as_fraction_of_geothermal_heat_source: 0.75
+      recovery_factor: 0.6
     heat_source_cooling: 6 #K
     heat_pump_cop_approximation:
       refrigerant: ammonia

--- a/config/plotting.default.yaml
+++ b/config/plotting.default.yaml
@@ -423,6 +423,9 @@ plotting:
     urban central water pits: "#d96f4c"
     urban central water pits charger: "#a85d47"
     urban central water pits discharger: "#b36452"
+    aquifer storage: "#6d00fc"
+    aquifer storage charger: "#6d00fc"
+    aquifer storage discharger: "#6d00fc"
     # heat demand
     Heat load: '#cc1f1f'
     heat: '#cc1f1f'

--- a/doc/configtables/sector.csv
+++ b/doc/configtables/sector.csv
@@ -23,6 +23,21 @@ district_heating,--,,
 -- -- dynamic_capacity,--,"{true, false}",Add option for dynamic temperature-dependent energy capacity of pit storage in district heating
 -- -- max_top_temperature,C,float,The maximum top temperature of the pit storage according to DEA technology catalogue (2018)
 -- -- min_bottom_temperature,C,float,The minimum bottom temperature of the pit storage according to DEA technology catalogue (2018)
+-- ates,,,
+-- -- allow,--,"{true, false}",Allow investments in aquifer thermal energy pit storage in district heating
+-- -- suitable_aquifer_types,--,List of aquifer types assumed suitable for ATES. Must be subset of [Highly productive porous aquifers';
+       'Low and moderately productive porous aquifers';
+       'Highly productive fissured aquifers (including karstified rocks)';
+       'Low and moderately productive fissured aquifers (including karstified rocks)';
+       'Locally aquiferous rocks, porous or fissured';
+       'Practically non-aquiferous rocks, porous or fissured';
+       'Inland water'; 'Snow field / ice field'],
+-- -- aquifer_volumetric_heat_capacity, kJ/m³/K,float,The volumetric heat capacity of the aquifer water
+-- -- fraction_of_aquifer_area_available,,float,The fraction of the aquifer area available for ATES
+-- -- effective_screen_length,m,float,The effective screen length of the aquifer well. Used to estimate its thermal radius.
+-- -- dh_area_buffer,m,float,Suitable aquifers must be within this distance to district heating areas. 
+-- -- capex_as_fraction_of_geothermal_heat_source,,float,The capital expenditure of ATES chargers/dischargers as a fraction of the geothermal heat source per-MWh CAPEX.
+-- -- recovery_factor,,float,The recovery factor of the aquifer (1- yearly_losses).
 -- heat_source_cooling,K,float,Cooling of heat source for heat pumps
 -- heat_pump_cop_approximation,,,
 -- -- refrigerant,--,"{ammonia, isobutane}",Heat pump refrigerant assumed for COP approximation

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -329,6 +329,81 @@ rule build_geothermal_heat_potential:
     script:
         "../scripts/build_geothermal_heat_potential.py"
 
+rule build_ates_potentials:
+    params:
+        max_top_temperature=config_provider(
+            "sector",
+            "district_heating",
+            "ates",
+            "max_top_temperature",
+        ),
+        min_bottom_temperature=config_provider(
+            "sector",
+            "district_heating",
+            "ates",
+            "min_bottom_temperature",
+        ),
+        suitable_aquifer_types=config_provider(
+            "sector",
+            "district_heating",
+            "ates",
+            "suitable_aquifer_types",
+        ),
+        aquifer_volumetric_heat_capacity=config_provider(
+            "sector",
+            "district_heating",
+            "ates",
+            "aquifer_volumetric_heat_capacity",
+        ),
+        fraction_of_aquifer_area_available=config_provider(
+            "sector",
+            "district_heating",
+            "ates",
+            "fraction_of_aquifer_area_available",
+        ),
+        effective_screen_length=config_provider(
+            "sector",
+            "district_heating",
+            "ates",
+            "effective_screen_length",
+        ),
+        dh_area_buffer=config_provider(
+            "sector",
+            "district_heating",
+            "ates",
+            "dh_area_buffer",
+        ),
+    input:
+        aquifer_shapes_shp="data/bgr/ihme1500_aquif_ec4060_v12_poly.shp",
+        aquifer_shapes_shx="data/bgr/ihme1500_aquif_ec4060_v12_poly.shx",
+        aquifer_shapes_dbf="data/bgr/ihme1500_aquif_ec4060_v12_poly.dbf",
+        aquifer_shapes_cpg="data/bgr/ihme1500_aquif_ec4060_v12_poly.cpg",
+        aquifer_shapes_prj="data/bgr/ihme1500_aquif_ec4060_v12_poly.prj",
+        aquifer_shapes_sbn="data/bgr/ihme1500_aquif_ec4060_v12_poly.sbn",
+        aquifer_shapes_sbx="data/bgr/ihme1500_aquif_ec4060_v12_poly.sbx",
+        dh_areas="data/dh_areas.gpkg",
+        regions_onshore=resources("regions_onshore_base_s_{clusters}.geojson"),
+        central_heating_forward_temperature_profiles=resources(
+            "central_heating_forward_temperature_profiles_base_s_{clusters}_{planning_horizons}.nc"
+        ),
+        central_heating_return_temperature_profiles=resources(
+            "central_heating_return_temperature_profiles_base_s_{clusters}_{planning_horizons}.nc"
+        ),
+    output:
+        ates_potentials=resources(
+            "ates_potentials_base_s_{clusters}_{planning_horizons}.csv"
+        ),
+    resources:
+        mem_mb=2000,
+    log:
+        logs("build_ates_potentials_s_{clusters}_{planning_horizons}.log"),
+    benchmark:
+        benchmarks("build_ates_potentials_geothermal_s_{clusters}_{planning_horizons}")
+    conda:
+        "../envs/environment.yaml"
+    script:
+        "../scripts/build_ates_potentials.py"
+
 
 rule build_cop_profiles:
     params:
@@ -1309,6 +1384,9 @@ rule prepare_sector_network:
         ),
         direct_heat_source_utilisation_profiles=resources(
             "direct_heat_source_utilisation_profiles_base_s_{clusters}_{planning_horizons}.nc"
+        ),
+        ates_potentials=resources(
+            "ates_potentials_base_s_{clusters}_{planning_horizons}.csv"
         ),
     output:
         resources(

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -668,7 +668,7 @@ if config["enable"]["retrieve"]:
     rule retrieve_geothermal_heat_utilisation_potentials:
         input:
             isi_heat_potentials=storage(
-                "https://fordatis.fraunhofer.de/bitstream/fordatis/341.3/12/Results_DH_Matching_Cluster.xlsx",
+                "https://fordatis.fraunhofer.de/bitstream/fordatis/341.5/11/Results_DH_Matching_Cluster.xlsx",
                 keep_local=True,
             ),
         output:
@@ -720,3 +720,50 @@ if config["enable"]["retrieve"]:
                     with open(output_path, "wb") as f:
                         f.write(response.content)
 
+if config["enable"]["retrieve"]:
+
+    rule retrieve_aquifer_data_bgr:
+        input:
+            zip=storage("https://download.bgr.de/bgr/grundwasser/IHME1500/v12/shp/IHME1500_v12.zip"),
+        output:
+            aquifer_shapes_shp="data/bgr/ihme1500_aquif_ec4060_v12_poly.shp",
+            aquifer_shapes_shx="data/bgr/ihme1500_aquif_ec4060_v12_poly.shx",
+            aquifer_shapes_dbf="data/bgr/ihme1500_aquif_ec4060_v12_poly.dbf",
+            aquifer_shapes_cpg="data/bgr/ihme1500_aquif_ec4060_v12_poly.cpg",
+            aquifer_shapes_prj="data/bgr/ihme1500_aquif_ec4060_v12_poly.prj",
+            aquifer_shapes_sbn="data/bgr/ihme1500_aquif_ec4060_v12_poly.sbn",
+            aquifer_shapes_sbx="data/bgr/ihme1500_aquif_ec4060_v12_poly.sbx",
+        params:
+            filename_shp="IHME1500_v12/shp/ihme1500_aquif_ec4060_v12_poly.shp",
+            filename_shx="IHME1500_v12/shp/ihme1500_aquif_ec4060_v12_poly.shx",
+            filename_dbf="IHME1500_v12/shp/ihme1500_aquif_ec4060_v12_poly.dbf",
+            filename_cpg="IHME1500_v12/shp/ihme1500_aquif_ec4060_v12_poly.cpg",
+            filename_prj="IHME1500_v12/shp/ihme1500_aquif_ec4060_v12_poly.prj",
+            filename_sbn="IHME1500_v12/shp/ihme1500_aquif_ec4060_v12_poly.sbn",
+            filename_sbx="IHME1500_v12/shp/ihme1500_aquif_ec4060_v12_poly.sbx",
+        run:
+            with ZipFile(input.zip, "r") as zip_ref:
+                for fn, outpt in zip(
+                    params,
+                    output,
+                ):
+                    zip_ref.extract(fn, Path(outpt).parent)
+                    extracted_file = Path(outpt).parent / fn
+                    extracted_file.rename(outpt)
+
+    rule retrieve_dh_areas:
+        input:
+            dh_areas=storage(
+                "https://fordatis.fraunhofer.de/bitstream/fordatis/341.5/2/dh_areas.gpkg",
+                keep_local=True,
+            ),
+        output:
+            dh_areas="data/dh_areas.gpkg",
+        log:
+            "logs/retrieve_dh_areas.log",
+        threads: 1
+        retries: 2
+        run:
+            move(input[0], output[0])
+
+ 

--- a/scripts/build_ates_potentials.py
+++ b/scripts/build_ates_potentials.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+#
+# SPDX-License-Identifier: MIT
+
+import logging
+
+import geopandas as gpd
+import pandas as pd
+import xarray as xr
+from _helpers import configure_logging, set_scenario_config
+
+logger = logging.getLogger(__name__)
+
+
+def mwh_ates_per_m2(
+    aquifer_volumetric_heat_capacity: float,
+    fraction_of_aquifer_area_available: float,
+    effective_screen_length: float,
+    hot_well_temperature: float,
+    cold_well_temperature: float,
+    kwh_per_kj: float = 1 / 3600,
+    mwh_per_kwh: float = 1 / 1e3,
+):
+    """
+    Calculate the TWh per m2 for ATES systems.
+    """
+
+    return (
+        aquifer_volumetric_heat_capacity
+        * fraction_of_aquifer_area_available
+        * effective_screen_length
+        * (hot_well_temperature - cold_well_temperature)
+        * kwh_per_kj
+        * mwh_per_kwh
+    )
+
+
+def suitable_aquifers(
+    aquifer_shapes: gpd.GeoDataFrame,
+    suitable_aquifer_types: list,
+):
+    """
+    Filter the aquifer shapes by the suitable aquifer types.
+    """
+
+    return aquifer_shapes[aquifer_shapes["AQUIF_NAME"].isin(suitable_aquifer_types)]
+
+
+def ates_potential_per_onshore_region(
+    suitable_aquifers: gpd.GeoDataFrame,
+    regions_onshore: gpd.GeoDataFrame,
+    dh_areas: gpd.GeoDataFrame,
+    dh_area_buffer: float,
+    mwh_per_m2: float,
+):
+    """
+    Calculate the area of the aquifer shapes in square kilometers.
+    """
+    ret_val = regions_onshore.copy(deep=True)
+    ret_val.index = ret_val["name"]
+    ret_val.drop(columns=["name"], inplace=True)
+
+    suitable_aquifers_in_onshore_regions = gpd.overlay(
+        suitable_aquifers, regions_onshore, how="intersection"
+    )
+
+    dh_areas_buffered = dh_areas.copy(deep=True)
+    dh_areas_buffered["geometry"] = dh_areas_buffered.geometry.buffer(dh_area_buffer)
+
+    aquifers_in_dh_areas = (
+        gpd.overlay(
+            dh_areas_buffered, suitable_aquifers_in_onshore_regions, how="intersection"
+        )
+        .groupby("name")["geometry"]
+        .apply(lambda x: x.area.sum())
+    )
+
+    ret_val["ates_potential"] = aquifers_in_dh_areas * mwh_per_m2
+    return ret_val
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from _helpers import mock_snakemake
+
+        snakemake = mock_snakemake("build_ates_potential", clusters="48")
+    configure_logging(snakemake)
+    set_scenario_config(snakemake)
+
+    # get onshore regions and index them by region name
+    regions_onshore = gpd.read_file(snakemake.input.regions_onshore)
+    regions_onshore = regions_onshore.to_crs(epsg=3035)
+
+    aquifer_shapes = gpd.read_file(snakemake.input.aquifer_shapes_shp)
+    aquifer_shapes = aquifer_shapes.to_crs(regions_onshore.crs)
+
+    dh_areas = gpd.read_file(snakemake.input.dh_areas)
+    dh_areas = dh_areas.to_crs(regions_onshore.crs)
+
+    forward_temperature_profiles = xr.open_dataarray(
+        snakemake.input.central_heating_forward_temperature_profiles
+    )
+    return_temperature_profiles = xr.open_dataarray(
+        snakemake.input.central_heating_return_temperature_profiles
+    )
+
+    mwh_per_m2 = mwh_ates_per_m2(
+        aquifer_volumetric_heat_capacity=snakemake.params.aquifer_volumetric_heat_capacity,
+        fraction_of_aquifer_area_available=snakemake.params.fraction_of_aquifer_area_available,
+        effective_screen_length=snakemake.params.effective_screen_length,
+        hot_well_temperature=forward_temperature_profiles.mean(dim="time").to_pandas(),
+        cold_well_temperature=return_temperature_profiles.to_pandas(),
+    )
+
+    suitable_aquifers = suitable_aquifers(
+        aquifer_shapes=aquifer_shapes,
+        suitable_aquifer_types=snakemake.params.suitable_aquifer_types,
+    )
+
+    ates_potentials = ates_potential_per_onshore_region(
+        suitable_aquifers=suitable_aquifers,
+        regions_onshore=regions_onshore,
+        dh_areas=dh_areas,
+        dh_area_buffer=snakemake.params.dh_area_buffer,
+        mwh_per_m2=mwh_per_m2,
+    )
+
+    ates_potentials.to_csv(snakemake.output.ates_potentials, index_label="name")

--- a/scripts/build_ates_potentials.py
+++ b/scripts/build_ates_potentials.py
@@ -1,8 +1,51 @@
 # SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
+"""
+Calculate the Aquifer Thermal Energy Storage (ATES) potentials for each region based on suitable aquifers, district heating areas, and temperature profiles.
+
+The script filters aquifers based on their geological suitability (currently only highly productive porous aquifers), intersects them with future district heating areas and onshore regions, and calculates the energy storage potential. The difference between average forward and return temperatures is used as temperature differentials to convert from volumetric to energetic storage potentials.
+
+The methodology is loosely based on Jackson, Regnier, Staffell (2024).
+Future district heating areas are sourced from Manz et al. (2024), based on Fallahnejad et al. (2024). Data on aquifers stems from the German Bundesanstalt für Geowissenschaften und Rohstoffe (BGR).
+
+
+Relevant Settings
+-----------------
+
+.. code:: yaml
+    sector:
+        aquifer_thermal_energy_storage:
+            aquifer_volumetric_heat_capacity:
+            fraction_of_aquifer_area_available:
+            effective_screen_length:
+            suitable_aquifer_types:
+            dh_area_buffer:
+
+Inputs
+------
+- `resources/<run_name>/regions_onshore.geojson`: Shapes of onshore regions
+- `resources/<run_name>/aquifer_shapes.shp`: Shapes of aquifers
+- `resources/<run_name>/dh_areas.geojson`: Shapes of district heating areas
+- `resources/<run_name>/central_heating_forward_temperature_profiles.nc`: Forward temperature profiles
+- `resources/<run_name>/central_heating_return_temperature_profiles.nc`: Return temperature profiles
+
+Outputs
+-------
+- `resources/<run_name>/ates_potentials.csv`: ATES potentials per region in MWh
+
+References
+----------
+- Jackson, Regnier, Staffell 2024: "Aquifer Thermal Energy Storage for low carbon heating and cooling in the United Kingdom: Current status and future prospects", Applied Energy, vol. 376, no. 124096, https://doi.org/10.1016/j.apenergy.2024.124096
+- Manz et al. 2024: "Spatial analysis of renewable and excess heat potentials for climate-neutral district heating in Europe", Renewable Energy, vol. 224, no. 120111, https://doi.org/10.1016/j.renene.2024.120111
+- Fallahnejad et al. 2024: "District heating potential in the EU-27: Evaluating the impacts of heat demand reduction and market share growth", Applied Energy, vol. 353, no. 122154, https://https://doi.org/10.1016/j.apenergy.2023.122154
+- BGR: IHME1500 - Internationale Hydrogeologische Karte von Europa 1:1.500.000 (https://www.bgr.bund.de/DE/Themen/Wasser/Projekte/laufend/Beratung/Ihme1500/ihme1500_projektbeschr.html?nn=1546102)
+"""
 
 import logging
+import sys
+import os
+from pathlib import Path
 
 import geopandas as gpd
 import pandas as pd
@@ -20,30 +63,96 @@ def mwh_ates_per_m2(
     cold_well_temperature: float,
     kwh_per_kj: float = 1 / 3600,
     mwh_per_kwh: float = 1 / 1e3,
-):
+) -> float:
     """
-    Calculate the TWh per m2 for ATES systems.
-    """
+    Calculate the MWh potential per square meter for ATES systems.
 
-    return (
-        aquifer_volumetric_heat_capacity
-        * fraction_of_aquifer_area_available
-        * effective_screen_length
-        * (hot_well_temperature - cold_well_temperature)
-        * kwh_per_kj
-        * mwh_per_kwh
-    )
+    This is based on Jackson, Regnier, Staffell 2024 (https://doi.org/10.1016/j.apenergy.2024.124096).
+    
+    Parameters
+    ----------
+    aquifer_volumetric_heat_capacity : float
+        Volumetric heat capacity of the aquifer in kJ/(m³·K)
+    fraction_of_aquifer_area_available : float
+        Fraction of the aquifer area that can be used for ATES (between 0 and 1)
+    effective_screen_length : float
+        Effective depth/thickness of the aquifer in meters
+    hot_well_temperature : float
+        Temperature of the hot well in degrees Celsius
+    cold_well_temperature : float
+        Temperature of the cold well in degrees Celsius
+    kwh_per_kj : float, optional
+        Conversion factor from kJ to kWh, by default 1/3600
+    mwh_per_kwh : float, optional
+        Conversion factor from kWh to MWh, by default 1/1000
+    
+    Returns
+    -------
+    float
+        The ATES energy storage potential in MWh per square meter
+        
+    Raises
+    ------
+    Exception
+        If calculation fails
+    
+    References
+    ----------
+    - Jackson, Regnier, Staffell 2024 (https://doi.org/10.1016/j.apenergy.2024.124096): Aquifer Thermal Energy Storages for low carbon heating and cooling in the United Kingdom: CUrrent status and future prospects
+    """
+    try:
+        return (
+            aquifer_volumetric_heat_capacity
+            * fraction_of_aquifer_area_available
+            * effective_screen_length
+            * (hot_well_temperature - cold_well_temperature)
+            * kwh_per_kj
+            * mwh_per_kwh
+        )
+    except Exception as e:
+        logger.error(f"Error calculating ATES potential per m2: {e}")
+        raise
 
 
 def suitable_aquifers(
     aquifer_shapes: gpd.GeoDataFrame,
     suitable_aquifer_types: list,
-):
+) -> gpd.GeoDataFrame:
     """
     Filter the aquifer shapes by the suitable aquifer types.
+    
+    Parameters
+    ----------
+    aquifer_shapes : geopandas.GeoDataFrame
+        GeoDataFrame containing the shapes of all aquifers
+    suitable_aquifer_types : list
+        List of aquifer types considered suitable for ATES
+    
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        Filtered GeoDataFrame containing only suitable aquifers
+        
+    Raises
+    ------
+    KeyError
+        If required column 'AQUIF_NAME' is not found in the input data
+    Exception
+        If filtering process fails
     """
-
-    return aquifer_shapes[aquifer_shapes["AQUIF_NAME"].isin(suitable_aquifer_types)]
+    try:
+        if "AQUIF_NAME" not in aquifer_shapes.columns:
+            raise KeyError("Column 'AQUIF_NAME' not found in aquifer shapes dataframe")
+        
+        filtered = aquifer_shapes[aquifer_shapes["AQUIF_NAME"].isin(suitable_aquifer_types)]
+        
+        if filtered.empty:
+            logger.warning("No suitable aquifers found with the specified types")
+            
+        return filtered
+    except Exception as e:
+        logger.error(f"Error filtering suitable aquifers: {e}")
+        raise
 
 
 def ates_potential_per_onshore_region(
@@ -52,38 +161,95 @@ def ates_potential_per_onshore_region(
     dh_areas: gpd.GeoDataFrame,
     dh_area_buffer: float,
     mwh_per_m2: float,
-):
+) -> gpd.GeoDataFrame:
     """
-    Calculate the area of the aquifer shapes in square kilometers.
+    Calculate the ATES potential for each onshore region.
+    
+    This function overlays suitable aquifers with onshore regions and district heating areas
+    to calculate the potential ATES capacity for each region.
+    
+    Parameters
+    ----------
+    suitable_aquifers : geopandas.GeoDataFrame
+        GeoDataFrame containing filtered suitable aquifers
+    regions_onshore : geopandas.GeoDataFrame
+        GeoDataFrame containing the shapes of onshore regions
+    dh_areas : geopandas.GeoDataFrame
+        GeoDataFrame containing the shapes of district heating areas
+    dh_area_buffer : float
+        Buffer distance in meters to apply around district heating areas
+    mwh_per_m2 : float
+        ATES potential in MWh per square meter
+    
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        GeoDataFrame with onshore regions and their ATES potential in MWh
+        
+    Raises
+    ------
+    KeyError
+        If required column 'name' is not found in regions_onshore dataframe
+    Exception
+        If calculation process fails
     """
-    ret_val = regions_onshore.copy(deep=True)
-    ret_val.index = ret_val["name"]
-    ret_val.drop(columns=["name"], inplace=True)
+    try:
+        if suitable_aquifers.empty or regions_onshore.empty or dh_areas.empty:
+            logger.warning("One or more input GeoDataFrames are empty")
+            
+        ret_val = regions_onshore.copy(deep=True)
+        
+        if "name" not in ret_val.columns:
+            raise KeyError("Column 'name' not found in regions_onshore dataframe")
+            
+        ret_val.index = ret_val["name"]
+        ret_val.drop(columns=["name"], inplace=True)
 
-    suitable_aquifers_in_onshore_regions = gpd.overlay(
-        suitable_aquifers, regions_onshore, how="intersection"
-    )
-
-    dh_areas_buffered = dh_areas.copy(deep=True)
-    dh_areas_buffered["geometry"] = dh_areas_buffered.geometry.buffer(dh_area_buffer)
-
-    aquifers_in_dh_areas = (
-        gpd.overlay(
-            dh_areas_buffered, suitable_aquifers_in_onshore_regions, how="intersection"
+        suitable_aquifers_in_onshore_regions = gpd.overlay(
+            suitable_aquifers, regions_onshore, how="intersection"
         )
-        .groupby("name")["geometry"]
-        .apply(lambda x: x.area.sum())
-    )
 
-    ret_val["ates_potential"] = aquifers_in_dh_areas * mwh_per_m2
-    return ret_val
+        if suitable_aquifers_in_onshore_regions.empty:
+            logger.warning("No suitable aquifers found in onshore regions")
+            ret_val["ates_potential"] = 0
+            return ret_val
+
+        dh_areas_buffered = dh_areas.copy(deep=True)
+        dh_areas_buffered["geometry"] = dh_areas_buffered.geometry.buffer(dh_area_buffer)
+
+        try:
+            aquifers_in_dh_areas = (
+                gpd.overlay(
+                    dh_areas_buffered, suitable_aquifers_in_onshore_regions, how="intersection"
+                )
+                .groupby("name")["geometry"]
+                .apply(lambda x: x.area.sum())
+            )
+            
+            # Handle regions without any ATES potential
+            missing_regions = set(ret_val.index) - set(aquifers_in_dh_areas.index)
+            if missing_regions:
+                logger.info(f"{len(missing_regions)} regions have no ATES potential")
+                
+            ret_val["ates_potential"] = 0  # Default value
+            ret_val.loc[aquifers_in_dh_areas.index, "ates_potential"] = aquifers_in_dh_areas * mwh_per_m2
+            
+        except Exception as e:
+            logger.error(f"Error in overlay calculation: {e}")
+            ret_val["ates_potential"] = 0
+            
+        return ret_val
+        
+    except Exception as e:
+        logger.error(f"Error calculating ATES potential per onshore region: {e}")
+        raise
 
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
-
         snakemake = mock_snakemake("build_ates_potential", clusters="48")
+        
     configure_logging(snakemake)
     set_scenario_config(snakemake)
 
@@ -91,19 +257,17 @@ if __name__ == "__main__":
     regions_onshore = gpd.read_file(snakemake.input.regions_onshore)
     regions_onshore = regions_onshore.to_crs(epsg=3035)
 
-    aquifer_shapes = gpd.read_file(snakemake.input.aquifer_shapes_shp)
-    aquifer_shapes = aquifer_shapes.to_crs(regions_onshore.crs)
+    aquifer_shapes = gpd.read_file(snakemake.input.aquifer_shapes_shp).to_crs(regions_onshore.crs)
 
-    dh_areas = gpd.read_file(snakemake.input.dh_areas)
-    dh_areas = dh_areas.to_crs(regions_onshore.crs)
+    dh_areas = gpd.read_file(snakemake.input.dh_areas).to_crs(regions_onshore.crs)
 
-    forward_temperature_profiles = xr.open_dataarray(
-        snakemake.input.central_heating_forward_temperature_profiles
-    )
+    forward_temperature_profiles = xr.opens_dataarray(
+        snakemake.input.forward_temperature_profiles)
     return_temperature_profiles = xr.open_dataarray(
         snakemake.input.central_heating_return_temperature_profiles
     )
 
+    logger.info("Calculating ATES potentials per m2")
     mwh_per_m2 = mwh_ates_per_m2(
         aquifer_volumetric_heat_capacity=snakemake.params.aquifer_volumetric_heat_capacity,
         fraction_of_aquifer_area_available=snakemake.params.fraction_of_aquifer_area_available,
@@ -112,17 +276,21 @@ if __name__ == "__main__":
         cold_well_temperature=return_temperature_profiles.to_pandas(),
     )
 
-    suitable_aquifers = suitable_aquifers(
+    logger.info("Filtering for suitable aquifers")
+    suitable_aquifer_df = suitable_aquifers(
         aquifer_shapes=aquifer_shapes,
         suitable_aquifer_types=snakemake.params.suitable_aquifer_types,
     )
 
+    logger.info("Calculating ATES potentials per region")
     ates_potentials = ates_potential_per_onshore_region(
-        suitable_aquifers=suitable_aquifers,
+        suitable_aquifers=suitable_aquifer_df,
         regions_onshore=regions_onshore,
         dh_areas=dh_areas,
         dh_area_buffer=snakemake.params.dh_area_buffer,
         mwh_per_m2=mwh_per_m2,
     )
 
+    logger.info(f"Writing results to {snakemake.output.ates_potentials}")
     ates_potentials.to_csv(snakemake.output.ates_potentials, index_label="name")
+

--- a/scripts/build_ates_potentials.py
+++ b/scripts/build_ates_potentials.py
@@ -261,8 +261,8 @@ if __name__ == "__main__":
 
     dh_areas = gpd.read_file(snakemake.input.dh_areas).to_crs(regions_onshore.crs)
 
-    forward_temperature_profiles = xr.opens_dataarray(
-        snakemake.input.forward_temperature_profiles)
+    forward_temperature_profiles = xr.open_dataarray(
+        snakemake.input.central_heating_forward_temperature_profiles)
     return_temperature_profiles = xr.open_dataarray(
         snakemake.input.central_heating_return_temperature_profiles
     )

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2741,6 +2741,7 @@ def add_heat(
     ates_e_nom_max: str,
     ates_capex_as_fraction_of_geothermal_heat_source: float,
     ates_recovery_factor: float,
+    ates_marginal_cost_charger: float,
     district_heat_share_file: str,
     solar_thermal_total_file: str,
     retro_cost_file: str,
@@ -3202,10 +3203,12 @@ def add_heat(
                     carrier=f"{heat_system} aquifer storage charger",
                     p_nom_extendable=True,
                     lifetime=costs.at["central geothermal heat source", "lifetime"],
-                    marginal_cost=costs.at[
-                        "central water pit charger", "marginal_cost"
-                    ] * 1.1,
-                    capital_cost=costs.at["central geothermal heat source", "capital_cost"] / 2
+                    marginal_cost=ates_marginal_cost_charger,
+                    capital_cost=costs.at[
+                        "central geothermal heat source", "capital_cost"
+                    ]
+                    * ates_capex_as_fraction_of_geothermal_heat_source
+                    / 2,
                 )
 
                 n.add(
@@ -3217,10 +3220,11 @@ def add_heat(
                     carrier=f"{heat_system} aquifer storage discharger",
                     p_nom_extendable=True,
                     lifetime=costs.at["central geothermal heat source", "lifetime"],
-                    marginal_cost=costs.at[
-                        "central water pit charger", "marginal_cost"
-                    ] * 1.1,
-                    capital_cost=costs.at["central geothermal heat source", "capital_cost"] / 2
+                    capital_cost=costs.at[
+                        "central geothermal heat source", "capital_cost"
+                    ]
+                    * ates_capex_as_fraction_of_geothermal_heat_source
+                    / 2,
                 )
 
                 n.add(
@@ -6179,6 +6183,7 @@ if __name__ == "__main__":
             ptes_e_max_pu_file=snakemake.input.ptes_e_max_pu_profiles,
             ates_e_nom_max=snakemake.input.ates_potentials,
             ates_capex_as_fraction_of_geothermal_heat_source=snakemake.params.sector["district_heating"]["ates"]["capex_as_fraction_of_geothermal_heat_source"],
+            ates_marginal_cost_charger=snakemake.params.sector["district_heating"]["ates"]["marginal_cost_charger"],
             ates_recovery_factor=snakemake.params.sector["district_heating"]["ates"]["recovery_factor"],
             district_heat_share_file=snakemake.input.district_heat_share,
             solar_thermal_total_file=snakemake.input.solar_thermal_total,

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -902,11 +902,11 @@ def add_TES_charger_ratio_constraints(n: pypsa.Network) -> None:
         If the charger and discharger indices do not align.
     """
     indices_charger_p_nom_extendable = n.links.index[
-        n.links.index.str.contains("water tanks charger|water pits charger")
+        n.links.index.str.contains("water tanks charger|water pits charger|aquifer storage charger")
         & n.links.p_nom_extendable
     ]
     indices_discharger_p_nom_extendable = n.links.index[
-        n.links.index.str.contains("water tanks discharger|water pits discharger")
+        n.links.index.str.contains("water tanks discharger|water pits discharger|aquifer storage discharger")
         & n.links.p_nom_extendable
     ]
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR adds support for ATES. 
- Highly productive porous aquifers (see [BGR](https://www.bgr.bund.de/DE/Themen/Wasser/Projekte/laufend/Beratung/Ihme1500/ihme1500_projektbeschr.html?nn=1546102)) within 1000m of future district heating areas ([Manz et al](https://fordatis.fraunhofer.de/handle/fordatis/341.5)) are assumed suitable areas.
- The computation of energetic storage potentials from suitable areas is loosely based on [Jackson et al.](https://doi.org/10.1016/j.apenergy.2024.124096) using average forward and return temperatures as temperture differentials.
- CAPEX for ATES chargers and dischargers are assumed a fraction (by default 0.75) of geothermal heat source CAPEX.
- An annual recovery factor (default 0.6, eyeballed from different sources) is used to compute constant hourly standing losses.
- ATES `stores` are not associated with investment costs but limited by the available storage potentials.

## Todos
- [ ] Final runs and feature description
- [ ] Reference sources for recovery factor

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
