### PR TITLE
test: make inhouse test runs more stable

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -186,6 +186,7 @@ jobs:
     - name: Install inhouse packages from master
       if: env.pinned == 'false'
       run: |
+        conda uninstall -y ${{ matrix.inhouse }}
         python -m pip install git+https://github.com/PyPSA/${{ matrix.inhouse }}.git@master
 
     - name: Run snakemake test workflows

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -186,7 +186,7 @@ jobs:
     - name: Install inhouse packages from master
       if: env.pinned == 'false'
       run: |
-        conda uninstall -y ${{ matrix.inhouse }}
+        conda uninstall -y ${{ matrix.inhouse }} || true
         python -m pip install git+https://github.com/PyPSA/${{ matrix.inhouse }}.git@master
 
     - name: Run snakemake test workflows


### PR DESCRIPTION
Small fix for inhouse test runs to remove the previously installed package from the env file first.