### PR TITLE
refactor: add low voltage nodes based on AC buses from network instead of pop_layout index

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1518,7 +1518,7 @@ def insert_electricity_distribution_grid(
     - Resistive heaters
     - Micro-CHP units
     """
-    nodes = pop_layout.index
+    nodes = n.buses.query("carrier == 'AC'").index
 
     n.add(
         "Bus",


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR proposes to use the AC buses from the PyPSA network directly to define the nodes for the low-voltage buses instead of the population layout index. This is intended to make the implementation more robust to create a low-voltage bus for each AC bus.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
