### PR TITLE
fix: Broken LAU data retrieval and allow geothermal heat pumps by default

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -498,6 +498,7 @@ sector:
   heat_pump_sources:
     urban central:
     - air
+    - geothermal
     urban decentral:
     - air
     rural:

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -498,7 +498,6 @@ sector:
   heat_pump_sources:
     urban central:
     - air
-    - geothermal
     urban decentral:
     - air
     rural:

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -687,10 +687,9 @@ if config["enable"]["retrieve"]:
                 keep_local=True,
             ),
         output:
-            lau_regions="data/lau_regions.geojson",
+            lau_regions="data/lau_regions.zip",
         log:
             "logs/retrieve_lau_regions.log",
-            lau_regions="data/lau_regions.zip",
         log:
             "logs/retrieve_lau_regions.log",
         threads: 1


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
Currently, there is a bug in the retrieval of LAU region data for the computation of geothermal heat potentials (incorrectly downloading a zip and renaming it to geojson rather than unpacking it). This bug was not noticed because geothermal heating is turned off by default.

This PR fixes the data retrieval. Note that there seems to be a remaining bug related to the `efficiency2` handling in perfect foresight.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
