### PR TITLE
Install snakemake plugins from bioconda

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -169,16 +169,8 @@ jobs:
       with:
         activate-environment: pypsa-eur
 
-    - name: Cache Conda env
-      if: env.pinned == 'false'
-      uses: actions/cache@v4
-      with:
-        path: ${{ env.CONDA }}/envs
-        key: conda-${{ runner.os }}-${{ runner.arch }}-${{  matrix.inhouse  }}-${{ hashFiles(format('{0}', env.env_file)) }}
-      id: cache-env
-
     - name: Update environment
-      if: env.pinned == 'false' && steps.cache-env.outputs.cache-hit != 'true'
+      if: env.pinned == 'false'
       run: |
         conda env update -n pypsa-eur -f ${{ env.env_file }}
         echo "Run conda list" && conda list
@@ -186,8 +178,6 @@ jobs:
     - name: Install inhouse packages from master
       if: env.pinned == 'false'
       run: |
-        conda uninstall -y --force ${{ matrix.inhouse }} || true
-        conda list
         python -m pip install git+https://github.com/PyPSA/${{ matrix.inhouse }}.git@master
         conda list
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -194,6 +194,9 @@ jobs:
     - name: Run snakemake test workflows
       if: env.pinned == 'false'
       run: |
+        conda env list
+        conda info
+        conda list
         make test
 
     - name: Upload artifacts

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -189,6 +189,7 @@ jobs:
         conda uninstall -y --force ${{ matrix.inhouse }} || true
         conda list
         python -m pip install git+https://github.com/PyPSA/${{ matrix.inhouse }}.git@master
+        conda list
 
     - name: Run snakemake test workflows
       if: env.pinned == 'false'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -184,9 +184,6 @@ jobs:
     - name: Run snakemake test workflows
       if: env.pinned == 'false'
       run: |
-        conda env list
-        conda info
-        conda list
         make test
 
     - name: Upload artifacts

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -187,6 +187,7 @@ jobs:
       if: env.pinned == 'false'
       run: |
         conda uninstall -y --force ${{ matrix.inhouse }} || true
+        conda list
         python -m pip install git+https://github.com/PyPSA/${{ matrix.inhouse }}.git@master
 
     - name: Run snakemake test workflows

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -186,7 +186,7 @@ jobs:
     - name: Install inhouse packages from master
       if: env.pinned == 'false'
       run: |
-        conda uninstall -y ${{ matrix.inhouse }} || true
+        conda uninstall -y --force ${{ matrix.inhouse }} || true
         python -m pip install git+https://github.com/PyPSA/${{ matrix.inhouse }}.git@master
 
     - name: Run snakemake test workflows

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -22,6 +22,9 @@ dependencies:
 - openpyxl
 - seaborn
 - snakemake-minimal>=9
+- snakemake-storage-plugin-http>=0.3
+- snakemake-executor-plugin-slurm
+- snakemake-executor-plugin-cluster-generic
 - memory_profiler
 - yaml
 - pytables
@@ -67,6 +70,3 @@ dependencies:
   - pyscipopt # See https://github.com/scipopt/PySCIPOpt/issues/944
   - tsam>=2.3.1
   - entsoe-py
-  - snakemake-storage-plugin-http>=0.3
-  - snakemake-executor-plugin-slurm
-  - snakemake-executor-plugin-cluster-generic


### PR DESCRIPTION
Instead of installing with `pip`.

I encountered errors when running with the mixed `bioconda` (`snakemake-minimal`) and `pypi` (`snakemake-*`) install.
Since the `snakemake-*` things seem to be on `bioconda` nowadays, I suggest we switch over.
`bioconda` is also the recommended channel for `snakemake`, so that should be fine?

## Changes proposed in this Pull Request


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
