### PR TITLE
fix: sanitize columns in add_brownfield

### DIFF
--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -15,10 +15,11 @@ import xarray as xr
 from scripts._helpers import (
     configure_logging,
     get_snapshots,
+    sanitize_custom_columns,
     set_scenario_config,
     update_config_from_wildcards,
 )
-from scripts.add_electricity import flatten
+from scripts.add_electricity import flatten, sanitize_carriers
 from scripts.add_existing_baseyear import add_build_year_to_new_assets
 
 logger = logging.getLogger(__name__)
@@ -371,4 +372,7 @@ if __name__ == "__main__":
     disable_grid_expansion_if_limit_hit(n)
 
     n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
+
+    sanitize_custom_columns(n)
+    sanitize_carriers(n, snakemake.config)
     n.export_to_netcdf(snakemake.output[0])


### PR DESCRIPTION
## Changes proposed in this Pull Request

Sanitize columns in `add_brownfield` as it's done for `add_exisiting_baseyear` (see [here](https://github.com/PyPSA/pypsa-eur/blob/master/scripts/add_existing_baseyear.py#L787-L788)). 

This is especially relevant for the `reversed` column if it is added by `solve_network`. In this the case, the `n_p` in `add_brownfield` will have the `reversed` column while the `n` will not. When all the links are added together, this results in `nan`, which are filled by the sanitize routines.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
