### PR TITLE
Test workflow: Use arm specific lockfile for macos setup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
       if: matrix.os != 'ubuntu'
       run: |
         if [[ "${{ matrix.os }}" == "macos" ]]; then
-          echo "env_file=envs/osx-64.lock.yaml" >> $GITHUB_ENV
+          echo "env_file=envs/osx-arm64.lock.yaml" >> $GITHUB_ENV
         else
           echo "env_file=envs/win-64.lock.yaml" >> $GITHUB_ENV
         fi


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

I think this might fix the current [issue](https://github.com/PyPSA/pypsa-eur/actions/runs/14998353967/job/42138277711#step:10:1) we're having with the macos setup for the test workflow.

@lkstrp 

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
