### PR TITLE
fix: increase has_internet timeout

### DIFF
--- a/rules/common.smk
+++ b/rules/common.smk
@@ -113,7 +113,7 @@ def input_custom_extra_functionality(w):
     return []
 
 
-def has_internet_access(url: str = "https://www.zenodo.org", timeout: int = 3) -> bool:
+def has_internet_access(url: str = "https://www.zenodo.org", timeout: int = 5) -> bool:
     """
     Checks if internet connection is available by sending a HEAD request
     to a reliable server like Zenodo.


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR suggests increasing  `has_internet` timeout to 5s. I believe this could help in cases where CI fails due to  a slow internet connection.

For example : https://github.com/open-energy-transition/open-tyndp/actions/runs/15020171901/job/42207244070#step:10:33

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
