### PR TITLE
fix: disable PTES booster HP by default, enable in test config

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -483,7 +483,7 @@ sector:
       dynamic_capacity: true
       supplemental_heating:
         enable: false
-        booster_heat_pump: true
+        booster_heat_pump: false
       max_top_temperature: 90
       min_bottom_temperature: 35
     ates:

--- a/config/test/config.myopic.yaml
+++ b/config/test/config.myopic.yaml
@@ -39,6 +39,7 @@ sector:
     ptes:
       supplemental_heating:
         enable: true
+        booster_heat_pump: true
 
 electricity:
   extendable_carriers:

--- a/config/test/config.overnight.yaml
+++ b/config/test/config.overnight.yaml
@@ -65,6 +65,7 @@ sector:
     ptes:
       supplemental_heating:
         enable: true
+        booster_heat_pump: true
     ates:
       enable: true
 

--- a/config/test/config.perfect.yaml
+++ b/config/test/config.perfect.yaml
@@ -48,6 +48,7 @@ sector:
     ptes:
       supplemental_heating:
         enable: true
+        booster_heat_pump: true
     ates:
       enable: true
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

The code in ``prepare_sector_network.py`` raises an error if ``supplemental_heating: enable: false`` while ``supplemental_heating: booster_heat_pump: true``. To avoid this, both parameters are now set to ``false`` by default.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
