### PR TITLE
Select properly capital_cost for  offwind-float

### DIFF
--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -559,11 +559,20 @@ def attach_wind_and_solar(
                     distance * submarine_cost + landfall_length * underground_cost
                 )
 
-                capital_cost = (
-                    costs.at["offwind", "capital_cost"]
-                    + costs.at[car + "-station", "capital_cost"]
-                    + connection_cost
-                )
+                # Take 'offwind-float' capital cost for 'float', and 'offwind' capital cost for the rest ('ac' and 'dc')
+                midcar = car.split("-", 2)[1]
+                if midcar == 'float':
+                    capital_cost = (
+                        costs.at[car, "capital_cost"]
+                        + costs.at[car + "-station", "capital_cost"]
+                        + connection_cost
+                    )
+                else:
+                    capital_cost = (
+                        costs.at["offwind", "capital_cost"]
+                        + costs.at[car + "-station", "capital_cost"]
+                        + connection_cost
+                    )
                 logger.info(
                     f"Added connection cost of {connection_cost.min():0.0f}-{connection_cost.max():0.0f} Eur/MW/a to {car}"
                 )

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -561,7 +561,7 @@ def attach_wind_and_solar(
 
                 # Take 'offwind-float' capital cost for 'float', and 'offwind' capital cost for the rest ('ac' and 'dc')
                 midcar = car.split("-", 2)[1]
-                if midcar == 'float':
+                if midcar == "float":
                     capital_cost = (
                         costs.at[car, "capital_cost"]
                         + costs.at[car + "-station", "capital_cost"]

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -486,7 +486,7 @@ def update_wind_solar_costs(
 
             # Take 'offwind-float' capital cost for 'float', and 'offwind' capital cost for the rest ('ac' and 'dc')
             midtech = tech.split("-", 2)[1]
-            if midtech == 'float':
+            if midtech == "float":
                 capital_cost = (
                     costs.at[tech, "capital_cost"]
                     + costs.at[tech + "-station", "capital_cost"]

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -484,11 +484,20 @@ def update_wind_solar_costs(
                 distance * submarine_cost + landfall_length * underground_cost
             )
 
-            capital_cost = (
-                costs.at["offwind", "capital_cost"]
-                + costs.at[tech + "-station", "capital_cost"]
-                + connection_cost
-            )
+            # Take 'offwind-float' capital cost for 'float', and 'offwind' capital cost for the rest ('ac' and 'dc')
+            midtech = tech.split("-", 2)[1]
+            if midtech == 'float':
+                capital_cost = (
+                    costs.at[tech, "capital_cost"]
+                    + costs.at[tech + "-station", "capital_cost"]
+                    + connection_cost
+                )
+            else:
+                capital_cost = (
+                    costs.at["offwind", "capital_cost"]
+                    + costs.at[tech + "-station", "capital_cost"]
+                    + connection_cost
+                )
 
             logger.info(
                 f"Added connection cost of {connection_cost.min():0.0f}-{connection_cost.max():0.0f} Eur/MW/a to {tech}"


### PR DESCRIPTION
In the script *add_electricity*, the capital costs for offwind technologies are taken from the 'offwind' field at the costs dataframe in all the cases ('ac', 'dc' and 'float') .

https://github.com/PyPSA/pypsa-eur/blob/b7e701adb9953f9b27a271abd0981f768a504e97/scripts/add_electricity.py#L563

This makes sense for 'ac' and 'dc', which do not actually have their own 'investment' entry in the costs.csv file. However, there is an entry for offwind-float investment costs in the costs.csv file. This makes sense because floating is more expensive. But this value does not seem to be used in the above code line.

The same thing seems to be happening in *prepare_sector_network*:

https://github.com/PyPSA/pypsa-eur/blob/b7e701adb9953f9b27a271abd0981f768a504e97/scripts/prepare_sector_network.py#L488


## Changes proposed in this Pull Request

This PR includes patchs to properly select the capital cost for offwind-float in both scripts, based on the investment costs for offwind-float defined in costs.csv.


## Checklist

- [ x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
