### PR TITLE
Solar aggregation in CCL plus minor fixes

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -987,6 +987,7 @@ solving:
 
   agg_p_nom_limits:
     agg_offwind: false
+    agg_solar: false
     include_existing: false
     file: data/agg_p_nom_minmax.csv
 

--- a/doc/configtables/solving.csv
+++ b/doc/configtables/solving.csv
@@ -29,6 +29,7 @@ options,,,
 -- keep_files, bool, False, Whether to keep LPs and MPS files after solving.
 agg_p_nom_limits,,,Configure per carrier generator nominal capacity constraints for individual countries if ``'CCL'`` is in ``{opts}`` wildcard.
 -- agg_offwind,bool,"{'true','false'}",Aggregate together all the types of offwind when writing the constraint. Default is false.
+-- agg_solar,bool,"{'true','false'}",Aggregate together all the types of electric solar when writing the constraint. Default is false.
 -- include_existing,bool,"{'true','false'}",Take existing capacities into account when writing the constraint. Default is false.
 -- file,file,path,Reference to ``.csv`` file specifying per carrier generator nominal capacity constraints for individual countries and planning horizons. Defaults to ``data/agg_p_nom_minmax.csv``.
 "constraints ",,,

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -54,6 +54,8 @@ Release Notes
   SVG output format has also been added for these graphs, and error handling during 
   graph generation has been enhanced.
 
+* Improved the behavior of ``agg_p_nom_limits``: added the ability to aggregate all ``solar`` electric technologies.
+
 PyPSA-Eur v2025.04.0 (6th April 2025)
 ========================================
 

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -553,13 +553,20 @@ def add_heating_capacities_installed_before_baseyear(
             )
 
             assert valid_grouping_years.is_monotonic_increasing
-
-            # get number of years of each interval
-            _years = valid_grouping_years.diff()
-            # Fill NA from .diff() with value for the first interval
-            _years[0] = valid_grouping_years[0] - baseyear + default_lifetime
-            # Installation is assumed to be linear for the past
-            ratios = _years / _years.sum()
+            
+            if len(valid_grouping_years) == 0:
+                logger.warning(
+                    f"No valid grouping years found for {heat_system}. "
+                    "No existing capacities will be added."
+                )
+                ratios = []
+            else:
+                # get number of years of each interval
+                _years = valid_grouping_years.diff()
+                # Fill NA from .diff() with value for the first interval
+                _years[0] = valid_grouping_years[0] - baseyear + default_lifetime
+                # Installation is assumed to be linear for the past
+                ratios = _years / _years.sum()
 
         for ratio, grouping_year in zip(ratios, valid_grouping_years):
             # Add heat pumps

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -553,7 +553,7 @@ def add_heating_capacities_installed_before_baseyear(
             )
 
             assert valid_grouping_years.is_monotonic_increasing
-            
+
             if len(valid_grouping_years) == 0:
                 logger.warning(
                     f"No valid grouping years found for {heat_system}. "

--- a/scripts/build_transmission_projects.py
+++ b/scripts/build_transmission_projects.py
@@ -48,7 +48,7 @@ def add_new_buses(n, new_ports):
     to_add = new_ports[~duplicated]
     added_buses = n.add(
         "Bus",
-        names=to_add.index,
+        name=to_add.index,
         suffix=" bus",
         x=to_add.x,
         y=to_add.y,

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -564,6 +564,13 @@ def add_CCL_constraints(
             "offwind": "offwind-all",
         }
         gens = gens.replace(rename_offwind)
+    if config["solving"]["agg_p_nom_limits"]["agg_solar"]:
+        rename_solar = {
+            "solar": "solar-all",
+            "solar-hsat": "solar-all",
+            "solar rooftop": "solar-all",
+        }
+        gens = gens.replace(rename_solar)
     grouper = pd.concat([gens.bus.map(n.buses.country), gens.carrier], axis=1)
     lhs = p_nom.groupby(grouper).sum().rename(bus="country")
 
@@ -576,6 +583,8 @@ def add_CCL_constraints(
         ]
         if config["solving"]["agg_p_nom_limits"]["agg_offwind"]:
             gens_cst = gens_cst.replace(rename_offwind)
+        if config["solving"]["agg_p_nom_limits"]["agg_solar"]:
+            gens_cst = gens_cst.replace(rename_solar)
         rhs_cst = (
             pd.concat(
                 [gens_cst.bus.map(n.buses.country), gens_cst[["carrier", "p_nom"]]],


### PR DESCRIPTION
## Changes proposed in this Pull Request
Improved the behavior of ``agg_p_nom_limits``: added the ability to aggregate all ``solar`` electric technologies.
Improved the handling of heating capacities from before the first planning horizon: if no older heating capacity is available, a warning is displayed instead of causing an error later.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
