### PR TITLE
Fix: Invalid aquifer shapes in build_ates_potentials

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,8 @@ Release Notes
 .. Upcoming Release
 .. ================
 
+* Fix: Invalid aquifer shape geometries are now fixed in `build_ates_potentials.py` (fixing https://github.com/PyPSA/pypsa-eur/issues/1696)
+
 * Fix: Sanitize columns in `add_brownfield` as it's done for `add_exisiting_baseyear` (https://github.com/PyPSA/pypsa-eur/pull/1676).
 
 * (Breaking) Consolidate gap-filling strategies options under a new configuration section `load:fill_gaps` and add a switch (https://github.com/PyPSA/pypsa-eur/pull/1677). The options `load:interpolate_limit` and `load:time_shift_for_large_gaps` are now located under `load:fill_gaps` as `load:fill_gaps:interpolate_limit` and `load:fill_gaps:time_shift_for_large_gaps`.

--- a/scripts/build_ates_potentials.py
+++ b/scripts/build_ates_potentials.py
@@ -391,6 +391,8 @@ if __name__ == "__main__":
     aquifer_shapes = gpd.read_file(snakemake.input.aquifer_shapes_shp).to_crs(
         regions_onshore.crs
     )
+    # fix any invalid geometries
+    aquifer_shapes.geometry = aquifer_shapes.geometry.make_valid()
 
     dh_areas = gpd.read_file(snakemake.input.dh_areas).to_crs(regions_onshore.crs)
 


### PR DESCRIPTION
Closes # (if applicable).
#1696 

## Changes proposed in this Pull Request
Fix invalid aquifer shape geometries (so far only in Norway) in `build_ates_potentials`.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
