### PR TITLE
Allow country-specific district heating potentials

### DIFF
--- a/doc/configtables/sector.csv
+++ b/doc/configtables/sector.csv
@@ -8,7 +8,7 @@ aviation,--,"{true, false}",Flag to include aviation sector.
 agriculture,--,"{true, false}",Flag to include agriculture sector.
 fossil_fuels,--,"{true, false}","Flag to include imports of fossil fuels."
 district_heating,--,,
--- potential,--,float,maximum fraction of urban demand which can be supplied by district heating
+-- potential,--,Dictionary with country codes as keys or float.,"Maximum fraction of urban demand which can be supplied by district heating. If given as dictionary, specify one value per country modeled or provide a default value with key `default` to fill values for all unspecified countries."
 -- progress,--,Dictionary with planning horizons as keys.,Increase of today's district heating demand to potential maximum district heating share. Progress = 0 means today's district heating share. Progress = 1 means maximum fraction of urban demand is supplied by district heating
 -- district_heating_loss,--,float,Share increase in district heat demand in urban central due to heat losses
 -- supply_temperature_approximation,,,

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,8 @@ Release Notes
 .. Upcoming Release
 .. ================
 
+* Allow district heating potentials to be optionally specified as a dictionary as an alternative to a float, with country codes as keys of the parameter `district_heating: potential`.
+
 * Fix: Invalid aquifer shape geometries are now fixed in `build_ates_potentials.py` (fixing https://github.com/PyPSA/pypsa-eur/issues/1696)
 
 * Fix: Sanitize columns in `add_brownfield` as it's done for `add_exisiting_baseyear` (https://github.com/PyPSA/pypsa-eur/pull/1676).

--- a/scripts/build_district_heat_share.py
+++ b/scripts/build_district_heat_share.py
@@ -66,6 +66,20 @@ if __name__ == "__main__":
 
     # maximum potential of urban demand covered by district heating
     central_fraction = snakemake.config["sector"]["district_heating"]["potential"]
+    if isinstance(central_fraction, dict):
+        if pd.Index(pop_layout.ct.unique()).difference(central_fraction.keys()).any():
+            default_value = central_fraction.get("default")
+            if default_value is None:
+                raise ValueError(
+                    "No default district heating potential was provided in the config."
+                )
+            logger.warning(
+                "Some countries do not have a district heating potential defined. "
+                f"Using default value {default_value:.2%} for these countries."
+            )
+        else:
+            default_value = None
+        central_fraction = pop_layout.ct.map(central_fraction).fillna(default_value)
 
     # district heating share at each node
     dist_fraction_node = (


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR extends the `sector:district_heating:potential` config parameter to accept either a single float (as before) or a dictionary with country-specific district heating potentials.

* **Default behavior**: If no dictionary is provided, the parameter remains a float (default: `0.6`).
* **Country-specific potentials**: Users can supply a dictionary mapping country codes to potential values:

  * For **partial coverage**, the dictionary must include:

    * country codes for countries with specific potentials
    * a `'default'` key for all other countries as a fallback value
  * For **full coverage**, the dictionary must contain a value for each country code in the model.


 
## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
