### PR TITLE
fix: fix rulegraph for snakemake 9.7.1

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -20,7 +20,11 @@ from scripts._helpers import (
 
 configfile: "config/config.default.yaml"
 configfile: "config/plotting.default.yaml"
-configfile: "config/config.yaml"
+
+
+if Path("config/config.yaml").exists():
+
+    configfile: "config/config.yaml"
 
 
 run = config["run"]

--- a/Snakefile
+++ b/Snakefile
@@ -202,7 +202,7 @@ rule rulegraph:
         r"""
         # Generate DOT file using nested snakemake with the dumped final config
         echo "[Rule rulegraph] Using final config file: {input.config_file}"
-        snakemake --rulegraph all --configfile {input.config_file} --quiet | sed -n "/digraph/,\$p" > {output.dot}
+        snakemake --rulegraph --configfile {input.config_file} --quiet | sed -n "/digraph/,\$p" > {output.dot}
 
         # Generate visualizations from the DOT file
         if [ -s {output.dot} ]; then


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR proposes making the `config/config.yaml` file optional. Building on top of https://github.com/PyPSA/pypsa-eur/pull/1649, this makes the workflow ready to use. Without this, we get:

```
WorkflowError in file "pypsa-eur/Snakefile", line 25:
Workflow defines configfile config/config.yaml but it is not present or accessible (full checked path: pypsa-eur/config/config.yaml).
```

In addition, this PR aims to make the `rulegraph` rule compatible with Snakemake v9.7.1. This fixes the following error:

```
snakemake: error: argument --rulegraph: invalid choice: 'all' (choose from dot, mermaid-js)
```

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
