### PR TITLE
fix: Update modify_attribute function according to changes in PyPSA API

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,8 @@ Release Notes
 .. Upcoming Release
 .. ================
 
+* Fix: Adjusted the `modify_attribute` function in `prepare_network` to align with changes in the PyPSA API.
+
 * Fix: Configsettings for `heat_pump_cop_approximation` are now correctly passed to `CentralHeatingCopApproximator.py`
 
 * Fix: Ensure the `rulegraph` rule is compatible with Snakemake v9.7.1, and that the `config/config.yaml` file is completely optional (https://github.com/PyPSA/pypsa-eur/pull/1745)

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -49,7 +49,7 @@ def modify_attribute(n, adjustments, investment_year, modification="factor"):
         return
     change_dict = adjustments[modification]
     for c in change_dict.keys():
-        if c not in n.components.keys():
+        if c not in n.component_attrs.keys():
             logger.warning(f"{c} needs to be a PyPSA Component")
             continue
         for carrier in change_dict[c].keys():


### PR DESCRIPTION
## Changes proposed in this Pull Request
The call to n.components.keys() now returns the "list_names" of components rather than their "names". Since component names are specified in the config file for modifying parameters via the adjustments parameter, the function has been updated accordingly to ensure correct behavior.

@lkstrp: I have the feeling that this could break again with API changes in 1.0, so thankful for your suggestions to make this change more future-proof.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] A release note `doc/release_notes.rst` is added.
