### PR TITLE
Bug fix logger in cluster_network

### DIFF
--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -334,7 +334,7 @@ def distribute_n_clusters_to_countries(
     # leave out constant in objective (L * n_clusters) ** 2
     m.objective = (clusters * clusters - 2 * clusters * L * n_clusters).sum()
     if solver_name == "gurobi":
-        logger.getLogger("gurobipy").propagate = False
+        logging.getLogger("gurobipy").propagate = False
     elif solver_name not in ["scip", "cplex", "xpress", "copt", "mosek"]:
         logger.info(
             f"The configured solver `{solver_name}` does not support quadratic objectives. Falling back to `scip`."


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Fixes bug in `cluster_network` when gurobi is selected as a solver, introduced with https://github.com/PyPSA/pypsa-eur/pull/1646, where `logger.getLogger("gurobipy")` does not exist
- Instead refer to `logging.getLogger("gurobipy")`

## Checklist

- [X] I tested my contribution locally and it works as intended.
- [X] Code and workflow changes are sufficiently documented.
