### PR TITLE
fix: fix country_converter logging in build_population_layouts

### DIFF
--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
 
     configure_logging(snakemake)
     set_scenario_config(snakemake)
-    coco.logging.getLogger().setLevel(coco.logging.CRITICAL)
+    logging.getLogger("country_converter").setLevel(logging.CRITICAL)
 
     cutout = load_cutout(snakemake.input.cutout)
 


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

This PR suggests a solution to an error that will occur in future versions of `country_converter`, starting from version 1.3.1. The current fixed version is 1.2.

Fixed error

```

 Traceback (most recent call last):
  File "/home/runner/work/pypsa-eur/pypsa-eur/.snakemake/scripts/tmpffufgtvg.build_population_layouts.py", line 36, in <module>
    coco.logging.getLogger().setLevel(coco.logging.CRITICAL)
    ^^^^^^^^^^^^
AttributeError: module 'country_converter' has no attribute 'logging'
```

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
