### PR TITLE
fix:add geothermal-sourced HP to HP cost names and turn on geothermal heating in test configs

### DIFF
--- a/config/test/config.myopic.yaml
+++ b/config/test/config.myopic.yaml
@@ -40,6 +40,15 @@ sector:
       supplemental_heating:
         enable: true
         booster_heat_pump: true
+    heat_pump_sources:
+        urban central:
+        - air
+        - geothermal
+        urban decentral:
+        - air
+        rural:
+        - air
+        - ground
   hydrogen_turbine: false
   regional_oil_demand: false
   regional_co2_sequestration_potential:

--- a/config/test/config.myopic.yaml
+++ b/config/test/config.myopic.yaml
@@ -41,14 +41,14 @@ sector:
         enable: true
         booster_heat_pump: true
     heat_pump_sources:
-        urban central:
-        - air
-        - geothermal
-        urban decentral:
-        - air
-        rural:
-        - air
-        - ground
+      urban central:
+      - air
+      - geothermal
+      urban decentral:
+      - air
+      rural:
+      - air
+      - ground
   hydrogen_turbine: false
   regional_oil_demand: false
   regional_co2_sequestration_potential:

--- a/config/test/config.overnight.yaml
+++ b/config/test/config.overnight.yaml
@@ -69,14 +69,14 @@ sector:
     ates:
       enable: true
     heat_pump_sources:
-        urban central:
-        - air
-        - geothermal
-        urban decentral:
-        - air
-        rural:
-        - air
-        - ground
+      urban central:
+      - air
+      - geothermal
+      urban decentral:
+      - air
+      rural:
+      - air
+      - ground
   hydrogen_turbine: false
   regional_oil_demand: false
   regional_co2_sequestration_potential:

--- a/config/test/config.overnight.yaml
+++ b/config/test/config.overnight.yaml
@@ -68,6 +68,15 @@ sector:
         booster_heat_pump: true
     ates:
       enable: true
+    heat_pump_sources:
+        urban central:
+        - air
+        - geothermal
+        urban decentral:
+        - air
+        rural:
+        - air
+        - ground
   hydrogen_turbine: false
   regional_oil_demand: false
   regional_co2_sequestration_potential:

--- a/config/test/config.perfect.yaml
+++ b/config/test/config.perfect.yaml
@@ -52,14 +52,14 @@ sector:
     ates:
       enable: true
     heat_pump_sources:
-        urban central:
-        - air
-        - geothermal
-        urban decentral:
-        - air
-        rural:
-        - air
-        - ground
+      urban central:
+      - air
+      - geothermal
+      urban decentral:
+      - air
+      rural:
+      - air
+      - ground
     hydrogen_turbine: false
   regional_oil_demand: false
   regional_co2_sequestration_potential:

--- a/config/test/config.perfect.yaml
+++ b/config/test/config.perfect.yaml
@@ -51,6 +51,15 @@ sector:
         booster_heat_pump: true
     ates:
       enable: true
+    heat_pump_sources:
+        urban central:
+        - air
+        - geothermal
+        urban decentral:
+        - air
+        rural:
+        - air
+        - ground
     hydrogen_turbine: false
   regional_oil_demand: false
   regional_co2_sequestration_potential:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,6 +13,8 @@ Upcoming Release
 
 * Introduce a new base network using TYNDP 2024 data (https://github.com/PyPSA/pypsa-eur/pull/1646). This base network can be used with `tyndp` as `base_network`. It models NTC transmission capacities between TYNDP bidding zones using unidirectional `links`. This implementation neglects KVL and is referred to as a transport model. This is consistent with the TYNDP 2024 methodology.
 
+* Fixed missing costs name for geothermal-sourced heat pump and allowed geothermal heat pumps in test configs.
+
 PyPSA-Eur v2025.07.0 (11th July 2025)
 =====================================
 

--- a/scripts/definitions/heat_system.py
+++ b/scripts/definitions/heat_system.py
@@ -223,7 +223,7 @@ class HeatSystem(Enum):
         str
             The name for the heat pump costs.
         """
-        if heat_source in ["ptes"]:
+        if heat_source in ["ptes", "geothermal"]:
             return f"{self.central_or_decentral} excess-heat-sourced heat pump"
         else:
             return f"{self.central_or_decentral} {heat_source}-sourced heat pump"

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3193,6 +3193,7 @@ def add_heat(
                 n.add(
                     "Bus",
                     nodes,
+                    location=nodes,
                     suffix=f" {heat_carrier}",
                     carrier=heat_carrier,
                 )


### PR DESCRIPTION
Closes # (if applicable).
Partially closes #1763. 

## Changes proposed in this Pull Request
@mareenjp raised that there is no heat-pump-cost name for geothermal heating. This is fixed by assuming the same costs as for other water-water heat pumps (DEA costs for excess-heat-sourced heat pumps).

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
