### PR TITLE
Bugfix submodule filenotfounderror

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,20 @@ Release Notes
 Upcoming Release
 ================
 
+* Fixed `FileNotFoundError` bugs preventing pypsa from being run as a Snakemake
+  module. The cause of this bug was that intermediate zip files in rules were being
+  saved in directories that didn't exist yet (without creating the parent directories).
+  This didn't fail when using PyPSA-Eur as a standalone module, because the directory
+  was the same as the rule's output file. However, when using PyPSA-Eur as a Snakemake
+  module, this was not the case as Snakemake prepends a prefix to all the input and
+  output files, but not to any file locations listed as parameters. The fix was to use
+  Snakemake's built-in shadow directories and save intermediate zip files at the top
+  level within these. This was fixed for many rules in `retrieve.smk`, i.e.,
+  `retrieve_eez`, `retrieve_nuts_2021_shapes`, `retrieve_nuts_2013_shapes`,
+  `retrieve_worldbank_urban_population`, `retrieve_co2stop`, `download_wdpa`,
+  `download_wdpa_marine`.
+  (https://github.com/pypsa/pypsa-eur/pull/_PLACEHOLDER_)
+
 * Introduce a new base network using TYNDP 2024 data (https://github.com/PyPSA/pypsa-eur/pull/1646). This base network can be used with `tyndp` as `base_network`. It models NTC transmission capacities between TYNDP bidding zones using unidirectional `links`. This implementation neglects KVL and is referred to as a transport model. This is consistent with the TYNDP 2024 methodology.
 
 PyPSA-Eur v2025.07.0 (11th July 2025)

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -356,11 +356,11 @@ if config["enable"]["retrieve"]:
 
     rule retrieve_eez:
         params:
-            zip="data/eez/World_EEZ_v12_20231025_LR.zip",
+            zip="World_EEZ_v12_20231025_LR.zip",
         output:
             gpkg="data/eez/World_EEZ_v12_20231025_LR/eez_v12_lowres.gpkg",
+        shadow: "minimal"
         run:
-            import os
             import requests
             from uuid import uuid4
 
@@ -383,7 +383,7 @@ if config["enable"]["retrieve"]:
 
             with open(params["zip"], "wb") as f:
                 f.write(response.content)
-            output_folder = Path(params["zip"]).parent
+            output_folder = Path(output.gpkg).parent.parent
             unpack_archive(params["zip"], output_folder)
             os.remove(params["zip"])
 

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -91,9 +91,13 @@ if config["enable"]["retrieve"]:
             shapes_level_3="data/nuts/NUTS_RG_03M_2013_4326_LEVL_3.geojson",
             shapes_level_2="data/nuts/NUTS_RG_03M_2013_4326_LEVL_2.geojson",
         params:
-            zip_file="data/nuts/ref-nuts-2013-03m.geojson.zip",
+            zip_file="ref-nuts-2013-03m.geojson.zip",
+        shadow: "minimal"
         run:
-            os.rename(input.shapes, params.zip_file)
+            # Copy file and ensure proper permissions
+            shcopy2(input.shapes, params.zip_file)
+            os.chmod(params.zip_file, 0o644)  # rw-r--r--
+
             with ZipFile(params.zip_file, "r") as zip_ref:
                 for level in ["LEVL_3", "LEVL_2"]:
                     filename = f"NUTS_RG_03M_2013_4326_{level}.geojson"
@@ -102,7 +106,6 @@ if config["enable"]["retrieve"]:
                     extracted_file.rename(
                         getattr(output, f"shapes_level_{level[-1]}")
                     )
-            os.remove(params.zip_file)
 
 
 

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -426,24 +426,23 @@ if config["enable"]["retrieve"]:
 
     rule retrieve_co2stop:
         params:
-            zip="data/co2jrc_openformats.zip",
+            zip_file="co2jrc_openformats.zip",
         output:
             "data/CO2JRC_OpenFormats/CO2Stop_DataInterrogationSystem/Hydrocarbon_Storage_Units.csv",
-            "data/CO2JRC_OpenFormats/CO2Stop_Polygons Data/StorageUnits_March13.kml",
             "data/CO2JRC_OpenFormats/CO2Stop_DataInterrogationSystem/Hydrocarbon_Traps.csv",
             "data/CO2JRC_OpenFormats/CO2Stop_DataInterrogationSystem/Hydrocarbon_Traps_Temp.csv",
             "data/CO2JRC_OpenFormats/CO2Stop_DataInterrogationSystem/Hydrocarbon_Traps1.csv",
             "data/CO2JRC_OpenFormats/CO2Stop_Polygons Data/DaughterUnits_March13.kml",
+            "data/CO2JRC_OpenFormats/CO2Stop_Polygons Data/StorageUnits_March13.kml",
+        shadow: "minimal"
         run:
-            import requests
-
             response = requests.get(
                 "https://setis.ec.europa.eu/document/download/786a884f-0b33-4789-b744-28004b16bd1a_en?filename=co2jrc_openformats.zip",
             )
-            with open(params["zip"], "wb") as f:
+            with open(params["zip_file"], "wb") as f:
                 f.write(response.content)
-            output_folder = Path(params["zip"]).parent
-            unpack_archive(params["zip"], output_folder)
+            output_folder = Path(output[0]).parent.parent.parent
+            unpack_archive(params["zip_file"], output_folder)
 
 
 

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -765,7 +765,7 @@ if config["enable"]["retrieve"]:
 
     rule retrieve_aquifer_data_bgr:
         input:
-            zip=storage(
+            zip_file=storage(
                 "https://download.bgr.de/bgr/grundwasser/IHME1500/v12/shp/IHME1500_v12.zip"
             ),
         output:
@@ -785,7 +785,7 @@ if config["enable"]["retrieve"]:
             filename_sbn="IHME1500_v12/shp/ihme1500_aquif_ec4060_v12_poly.sbn",
             filename_sbx="IHME1500_v12/shp/ihme1500_aquif_ec4060_v12_poly.sbx",
         run:
-            with ZipFile(input.zip, "r") as zip_ref:
+            with ZipFile(input.zip_file, "r") as zip_ref:
                 for fn, outpt in zip(
                     params,
                     output,

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -513,20 +513,24 @@ if config["enable"]["retrieve"]:
     # Website: https://www.protectedplanet.net/en/thematic-areas/wdpa
     rule download_wdpa:
         input:
-            zip=storage(url, keep_local=True),
+            zip_file=storage(url, keep_local=True),
         params:
-            zip="data/WDPA_shp.zip",
-            folder=directory("data/WDPA"),
+            zip_file="WDPA_shp.zip",
+            folder_name="WDPA",
         output:
             gpkg="data/WDPA.gpkg",
+        shadow: "minimal"
         run:
-            shcopy2(input.zip, params.zip)
-            unpack_archive(params.zip, params.folder)
+            # Copy file and ensure proper permissions
+            shcopy2(input.zip_file, params.zip_file)
+            os.chmod(params.zip_file, 0o644)  # rw-r--r--
+            output_folder = Path(output.gpkg).parent / params.folder_name
+            unpack_archive(params.zip_file, output_folder)
 
             for i in range(3):
                 # vsizip is special driver for directly working with zipped shapefiles in ogr2ogr
                 layer_path = (
-                    f"/vsizip/{params.folder}/WDPA_{bYYYY}_Public_shp_{i}.zip"
+                    f"/vsizip/{output_folder}/WDPA_{bYYYY}_Public_shp_{i}.zip"
                 )
                 print(f"Adding layer {i+1} of 3 to combined output file.")
                 shell("ogr2ogr -f gpkg -update -append {output.gpkg} {layer_path}")

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -360,7 +360,7 @@ if config["enable"]["retrieve"]:
 
     rule retrieve_eez:
         params:
-            zip="World_EEZ_v12_20231025_LR.zip",
+            zip_file="World_EEZ_v12_20231025_LR.zip",
         output:
             gpkg="data/eez/World_EEZ_v12_20231025_LR/eez_v12_lowres.gpkg",
         shadow: "minimal"
@@ -385,11 +385,10 @@ if config["enable"]["retrieve"]:
                 },
             )
 
-            with open(params["zip"], "wb") as f:
+            with open(params["zip_file"], "wb") as f:
                 f.write(response.content)
             output_folder = Path(output.gpkg).parent.parent
-            unpack_archive(params["zip"], output_folder)
-            os.remove(params["zip"])
+            unpack_archive(params["zip_file"], output_folder)
 
 
 
@@ -521,7 +520,7 @@ if config["enable"]["retrieve"]:
         output:
             gpkg="data/WDPA.gpkg",
         run:
-            shcopy(input.zip, params.zip)
+            shcopy2(input.zip, params.zip)
             unpack_archive(params.zip, params.folder)
 
             for i in range(3):
@@ -547,7 +546,7 @@ if config["enable"]["retrieve"]:
         output:
             gpkg="data/WDPA_WDOECM_marine.gpkg",
         run:
-            shcopy(input.zip, params.zip)
+            shcopy2(input.zip, params.zip)
             unpack_archive(params.zip, params.folder)
 
             for i in range(3):

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -368,7 +368,6 @@ if config["enable"]["retrieve"]:
             gpkg="data/eez/World_EEZ_v12_20231025_LR/eez_v12_lowres.gpkg",
         shadow: "minimal"
         run:
-            import requests
             from uuid import uuid4
 
             name = str(uuid4())[:8]
@@ -452,8 +451,6 @@ if config["enable"]["retrieve"]:
         output:
             "data/gem/Europe-Gas-Tracker-2024-05.xlsx",
         run:
-            import requests
-
             # mirror of https://globalenergymonitor.org/wp-content/uploads/2024/05/Europe-Gas-Tracker-2024-05.xlsx
             url = "https://tubcloud.tu-berlin.de/s/LMBJQCsN6Ez5cN2/download/Europe-Gas-Tracker-2024-05.xlsx"
             response = requests.get(url)
@@ -468,8 +465,6 @@ if config["enable"]["retrieve"]:
         output:
             "data/gem/Global-Steel-Plant-Tracker-April-2024-Standard-Copy-V1.xlsx",
         run:
-            import requests
-
             # mirror or https://globalenergymonitor.org/wp-content/uploads/2024/04/Global-Steel-Plant-Tracker-April-2024-Standard-Copy-V1.xlsx
             url = "https://tubcloud.tu-berlin.de/s/Aqebo3rrQZWKGsG/download/Global-Steel-Plant-Tracker-April-2024-Standard-Copy-V1.xlsx"
             response = requests.get(url)
@@ -745,8 +740,6 @@ if config["enable"]["retrieve"]:
             ardeco_gdp="data/jrc-ardeco/ARDECO-SUVGDP.2021.table.csv",
             ardeco_pop="data/jrc-ardeco/ARDECO-SNPTD.2021.table.csv",
         run:
-            import requests
-
             urls = {
                 "ardeco_gdp": "https://urban.jrc.ec.europa.eu/ardeco-api-v2/rest/export/SUVGDP?version=2021&format=csv-table",
                 "ardeco_pop": "https://urban.jrc.ec.europa.eu/ardeco-api-v2/rest/export/SNPTD?version=2021&format=csv-table",

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -399,21 +399,19 @@ if config["enable"]["retrieve"]:
 
     rule retrieve_worldbank_urban_population:
         params:
-            zip="data/worldbank/API_SP.URB.TOTL.IN.ZS_DS2_en_csv_v2.zip",
+            zip_file="API_SP.URB.TOTL.IN.ZS_DS2_en_csv_v2.zip",
         output:
             gpkg="data/worldbank/API_SP.URB.TOTL.IN.ZS_DS2_en_csv_v2.csv",
+        shadow: "minimal"
         run:
-            import os
-            import requests
-
             response = requests.get(
                 "https://api.worldbank.org/v2/en/indicator/SP.URB.TOTL.IN.ZS?downloadformat=csv",
             )
 
-            with open(params["zip"], "wb") as f:
+            with open(params["zip_file"], "wb") as f:
                 f.write(response.content)
-            output_folder = Path(params["zip"]).parent
-            unpack_archive(params["zip"], output_folder)
+            output_folder = Path(output.gpkg).parent
+            unpack_archive(params["zip_file"], output_folder)
 
             for f in os.listdir(output_folder):
                 if f.startswith(


### PR DESCRIPTION
Closes #1762

## Changes proposed in this Pull Request
This request fixes `FileNotFoundError` bugs preventing pypsa from being run as a Snakemake module. 

The cause of this bug was that intermediate zip files in rules were being saved in directories that didn't exist yet (without creating the parent directories). This didn't fail when using PyPSA-Eur as a standalone module, because the directory was the same as the rule's output file. However, when using PyPSA-Eur as a Snakemake module, this was not the case as Snakemake prepends a prefix to all the input and output files, but not to any file locations listed as parameters. The fix was to use Snakemake's built-in shadow directories and save intermediate zip files at the top level within these. This was fixed for many rules in `retrieve.smk`, i.e., `retrieve_eez`, `retrieve_nuts_2021_shapes`, `retrieve_nuts_2013_shapes`, `retrieve_worldbank_urban_population`, `retrieve_co2stop`, `download_wdpa`, `download_wdpa_marine`.

## Fixes detail

- When calling a rule imported using a snakemake module, before it is run, snakemake will prepend the given prefix (in our case, “pypsa-eur”) to all the input and output files of the rule. However, snakemake does not prepend the prefix for any file or directory locations listed as params. Therefore, any rules using params to list file or directory locations will return a `FileNotFoundError` as soon as a function looks for a file based on the location given in a param. Concretely, snakemake saves any input (including those fetched using the storage function) in the prefix directory (e.g., `pypsa-eur/data/your/file.here`), and if you try to access this file using a location derived from a param (e.g., `data/your/file.here`), you’ll get a `FileNotFoundError`. The fix is to never indicate a path relative to a param.
- Use Snakemake’s shadow directories (with setting “minimal”) to enable the temporary saving of zip files that are cleaned up automatically.
- Replace os.rename with shutil.copy2 to ensure the code has explicit permission to read zip files
- Change shutil.copy to shutil.copy2 to preserve the file metadata
- Change potentially problematic variable name `zip` to `zip_file`

## Commands that didn’t work that now work

- `snakemake pypsa-eur/data/eez/World_EEZ_v12_20231025_LR/eez_v12_lowres.gpkg --cores 1` (calls rule `retrieve_eez`)
- `snakemake pypsa-eur/data/nuts/NUTS_RG_01M_2021_4326_LEVL_3.geojson --cores 1` (calls rule `retrieve_nuts_2021_shapes`)
- `snakemake pypsa-eur/data/nuts/NUTS_RG_03M_2013_4326_LEVL_3.geojson --cores 1` (calls rule `retrieve_nuts_2013_shapes`)
- `snakemake pypsa-eur/data/worldbank/API_SP.URB.TOTL.IN.ZS_DS2_en_csv_v2.csv --cores 1` (calls rule `retrieve_worldbank_urban_population`)
- `snakemake pypsa-eur/data/CO2JRC_OpenFormats/CO2Stop_DataInterrogationSystem/Hydrocarbon_Storage_Units.csv --cores 1` (calls rule `retrieve_co2stop`)
- `snakemake pypsa-eur/data/WDPA.gpkg --cores 1` (calls rule `download_wdpa`)
- `snakemake pypsa-eur/data/WDPA_WDOECM_marine.gpkg --cores 1` (calls rule `download_wdpa_marine`)
- This rule ran successfully before, since all filepaths were already relative to outputs, not params: `snakemake pypsa-eur/data/bgr/ihme1500_aquif_ec4060_v12_poly.shp --cores 1` (calls rule `retrieve_aquifer_data_bgr`)

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
