### PR TITLE
Fix:Issue warning instead of error for non-extendable heat storage in energy-to-power ratio constraints

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,6 +13,8 @@ Upcoming Release
 
 * Introduce a new base network using TYNDP 2024 data (https://github.com/PyPSA/pypsa-eur/pull/1646). This base network can be used with `tyndp` as `base_network`. It models NTC transmission capacities between TYNDP bidding zones using unidirectional `links`. This implementation neglects KVL and is referred to as a transport model. This is consistent with the TYNDP 2024 methodology.
 
+* Changed error handling for non-extendable heat storage in energy-to-power ratio constraints to warning.
+
 PyPSA-Eur v2025.07.0 (11th July 2025)
 =====================================
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -869,9 +869,10 @@ def add_TES_energy_to_power_ratio_constraints(n: pypsa.Network) -> None:
     ]
 
     if indices_charger_p_nom_extendable.empty or indices_stores_e_nom_extendable.empty:
-        raise ValueError(
-            "No valid extendable charger links or stores found for TES energy to power constraints."
+        logger.warning(
+            "No valid extendable charger links or stores found for TES energy-to-power constraints.Not enforcing TES energy-to-power ratio constraints!"
         )
+        return
 
     energy_to_power_ratio_values = n.links.loc[
         indices_charger_p_nom_extendable, "energy to power ratio"
@@ -939,9 +940,10 @@ def add_TES_charger_ratio_constraints(n: pypsa.Network) -> None:
         indices_charger_p_nom_extendable.empty
         or indices_discharger_p_nom_extendable.empty
     ):
-        raise ValueError(
-            "No valid extendable TES discharger or charger links found for TES charger ratio constraints."
+        logger.warning(
+            "No valid extendable TES discharger or charger links found for TES charger ratio constraints. Not enforcing TES charger_ratio constraints."
         )
+        return
 
     for charger, discharger in zip(
         indices_charger_p_nom_extendable, indices_discharger_p_nom_extendable


### PR DESCRIPTION
## Changes proposed in this Pull Request
@lindnemi raised that, if all TES are non-extendable, the energy-to-power ratio constraints fail with an error message. This PR replaces the error message with a warning and a non-enforcing of the energy-to-power ratio and charger/discharger ratio constraints.
Tested by @lindnemi 


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
