### PR TITLE
Eliminate runtime warning caused by division by zero

### DIFF
--- a/scripts/build_industrial_production_per_country_tomorrow.py
+++ b/scripts/build_industrial_production_per_country_tomorrow.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
 
     al_primary_fraction = get(params["Al_primary_fraction"], investment_year)
     fraction_persistent_primary = (
-        al_primary_fraction * total_aluminium.sum() / production[key_pri].sum()
+        al_primary_fraction * total_aluminium.sum() / (production[key_pri].sum() or 1)
     )
 
     production[key_pri] = fraction_persistent_primary * production[key_pri]


### PR DESCRIPTION
### Part of #1781 

This PR eliminates the runtime warning caused by the division by zero in `build_industry_production_per_country_tomorrow`.

## Checklist

- [x] I tested my contribution locally and it works as intended.
