### PR TITLE
feat: raise warnings as errors

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -9,6 +9,7 @@ tutorial: false
 logging:
   level: INFO
   format: '%(levelname)s:%(name)s:%(message)s'
+  warnings_as_errors: false
 
 remote:
   ssh: ""

--- a/config/test/config.clusters.yaml
+++ b/config/test/config.clusters.yaml
@@ -9,6 +9,9 @@ run:
     policy: false
   shared_cutouts: true
 
+logging:
+  warnings_as_errors: true
+
 scenario:
   clusters:
   - "adm"

--- a/config/test/config.electricity.yaml
+++ b/config/test/config.electricity.yaml
@@ -12,6 +12,9 @@ run:
     policy: false
   shared_cutouts: true
 
+logging:
+  warnings_as_errors: true
+
 scenario:
   clusters:
   - 5

--- a/config/test/config.myopic.yaml
+++ b/config/test/config.myopic.yaml
@@ -11,6 +11,9 @@ run:
     policy: false
   shared_cutouts: true
 
+logging:
+  warnings_as_errors: true
+
 foresight: myopic
 
 scenario:

--- a/config/test/config.overnight.yaml
+++ b/config/test/config.overnight.yaml
@@ -11,6 +11,8 @@ run:
     policy: false
   shared_cutouts: true
 
+logging:
+  warnings_as_errors: true
 
 scenario:
   clusters:

--- a/config/test/config.perfect.yaml
+++ b/config/test/config.perfect.yaml
@@ -11,6 +11,9 @@ run:
     policy: false
   shared_cutouts: true
 
+logging:
+  warnings_as_errors: true
+
 foresight: perfect
 
 scenario:

--- a/config/test/config.scenarios.yaml
+++ b/config/test/config.scenarios.yaml
@@ -14,6 +14,9 @@ run:
   disable_progressbar: true
   shared_cutouts: true
 
+logging:
+  warnings_as_errors: true
+
 scenario:
   clusters:
   - 5

--- a/config/test/config.tyndp.yaml
+++ b/config/test/config.tyndp.yaml
@@ -9,6 +9,9 @@ run:
     policy: false
   shared_cutouts: true
 
+logging:
+  warnings_as_errors: true
+
 scenario:
   clusters:
   - all

--- a/config/test/config.validator.yaml
+++ b/config/test/config.validator.yaml
@@ -5,6 +5,7 @@
 logging:
   level: INFO
   format: '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
+  warnings_as_errors: true
 
 run:
   prefix: validation

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import time
+import warnings
 from functools import partial, wraps
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -236,6 +237,14 @@ def configure_logging(snakemake, skip_handlers=False):
     """
     import logging
     import sys
+
+    # Configure warnings to be raised as errors based on config
+    warnings_as_errors = snakemake.config.get("logging").get("warnings_as_errors")
+    if warnings_as_errors:
+        warnings.filterwarnings("error", category=DeprecationWarning)
+        warnings.filterwarnings("error", category=FutureWarning)
+        warnings.filterwarnings("error", category=UserWarning)
+        warnings.filterwarnings("error", category=RuntimeWarning)
 
     kwargs = snakemake.config.get("logging", dict()).copy()
     kwargs.setdefault("level", "INFO")


### PR DESCRIPTION
See #1781 

## Changes proposed in this Pull Request
Adds config option to raise DeprecationWarning, FutureWarning, UserWarning, RuntimeWarning as errors and activates them in the test configs. All of them need to be fixed first but then we would enforce cleaner logs.

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
