### PR TITLE
Fix issue #1792 : updated colours in plot_balance_map

### DIFF
--- a/scripts/plot_balance_map.py
+++ b/scripts/plot_balance_map.py
@@ -94,11 +94,15 @@ if __name__ == "__main__":
     bus_sizes = eb.groupby(level=["bus", "carrier"]).sum().div(conversion)
     bus_sizes = bus_sizes.sort_values(ascending=False)
 
+    # Get colors for carriers
+    n.carriers.update({"color": snakemake.params.plotting["tech_colors"]})
+    carrier_colors = n.carriers.color.copy().replace("", "grey")
+
     colors = (
         bus_sizes.index.get_level_values("carrier")
         .unique()
         .to_series()
-        .map(n.carriers.color)
+        .map(carrier_colors)
     )
 
     # line and links widths according to optimal capacity


### PR DESCRIPTION
Closes #1792 

## Changes proposed in this Pull Request
- Fixes a bug where carrier colors were not updated in the balance map plotting script after a config change post solving a network.
- Ensures `tech_colors` are now read directly from the Snakemake config at runtime for the balance map.
- This brings consistency with all the other plotting functions e.g. `plot_balance_timeseries`

- Modified `scripts/plot_balance_map.py` to fetch `tech_colors` from current config.

## Checklist

- [✔️ ] I tested my contribution locally and it works as intended.
- [✔️ ] Code and workflow changes are sufficiently documented.
- [ ❌] Changed dependencies are added to `envs/environment.yaml`.
- [❌ ] Changes in configuration options are added in `config/config.default.yaml`.
- [❌ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [❌ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [❌] A release note `doc/release_notes.rst` is added.
