### PR TITLE
[Fix] Increase default resources (mem_mb)

### DIFF
--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -100,7 +100,7 @@ rule base_network:
         benchmarks("base_network")
     threads: 4
     resources:
-        mem_mb=1500,
+        mem_mb=2000,
     conda:
         "../envs/environment.yaml"
     script:

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -823,7 +823,7 @@ rule build_industrial_production_per_country:
         ),
     threads: 8
     resources:
-        mem_mb=1000,
+        mem_mb=2000,
     log:
         logs("build_industrial_production_per_country.log"),
     benchmark:
@@ -973,7 +973,7 @@ rule build_industrial_energy_demand_per_country_today:
         ),
     threads: 8
     resources:
-        mem_mb=1000,
+        mem_mb=2000,
     log:
         logs("build_industrial_energy_demand_per_country_today.log"),
     benchmark:


### PR DESCRIPTION
## Changes proposed in this Pull Request
Increasing default memory requirements for the following rules:
- `base_network`: 1500 to 2000 MB
- `build_industrial_energy_demand_per_country`: 1000 to 2000 MB
- `build_industrial_energy_demand_per_country_today`: 1000 to 2000 MB

Reason:
- Out of memory with previous settings on two different computing clusters

## Checklist
- [X] I tested my contribution locally and it works as intended.
