### PR TITLE
doc: Remove retrieve_natural_earth reference

### DIFF
--- a/doc/data-retrieval.rst
+++ b/doc/data-retrieval.rst
@@ -159,13 +159,6 @@ Data in this section is retrieved and extracted in rules specified in ``rules/re
 - **License:** CC-BY 4.0
 - **Description:** Contains share of urban population by country.
 
-``data/naturalearth``
-
-- **Source:** Natural Earth
-- **Link:** https://www.naturalearthdata.com/downloads/10m-cultural-vectors/
-- **License:** CC0 (`reference <https://www.naturalearthdata.com/about/terms-of-use/>`__)
-- **Description:** Country shapes, using point-of-view (POV) variant of Germany so that Crimea is included.
-
 ``data/gem/Europe-Gas-Tracker-2024-05.xlsx``
 
 - **Source:** Global Energy Monitor


### PR DESCRIPTION
Natural Earth was removed as data dependency in 1d8bb3d583cc3c25a1ed2acad88021c0045fd4f7 .
The doc reference is an artifact.

NE is still used in the pytest, but only temporarily downloaded and stored (and for other purposes as described).


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
