### PR TITLE
feat:electrolyser excess heat boosting

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -985,7 +985,7 @@ adjustments:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#solving
 solving:
   options:
-    decimal_precision_p_min_max_pu: 5
+    clip_p_max_pu: 1.e-2
     load_shedding: false
     curtailment_mode: false
     noisy_costs: true

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -543,13 +543,20 @@ sector:
       geothermal:
         constant_temperature_celsius: 65
         ignore_missing_regions: false
+        requires_generator: true
+      electrolysis_excess_heat:
+        constant_temperature_celsius: 70
+        ignore_missing_regions: false
+        requires_generator: false
     direct_utilisation_heat_sources:
     - geothermal
+    - electrolysis_excess_heat
     temperature_limited_stores:
     - ptes
   heat_pump_sources:
     urban central:
     - air
+    - electrolysis_excess_heat
     urban decentral:
     - air
     rural:
@@ -740,7 +747,6 @@ sector:
   use_methanolisation_waste_heat: 0.25
   use_methanation_waste_heat: 0.25
   use_fuel_cell_waste_heat: 1
-  use_electrolysis_waste_heat: 0.25
   electricity_transmission_grid: true
   electricity_distribution_grid: true
   electricity_grid_connection: true

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -985,7 +985,7 @@ adjustments:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#solving
 solving:
   options:
-    clip_p_max_pu: 1.e-2
+    decimal_precision_p_min_max_pu: 5
     load_shedding: false
     curtailment_mode: false
     noisy_costs: true

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,8 @@ Release Notes
 .. Upcoming Release
 .. ================
 
+* Fix: Allocate heat pump CAPEX on heat instead of electricity bus instead and remove nominal efficiency from CAPEX calculation
+
 * Fix: Configsettings for `heat_pump_cop_approximation` are now correctly passed to `CentralHeatingCopApproximator.py`
 
 * Fix: Ensure the `rulegraph` rule is compatible with Snakemake v9.7.1, and that the `config/config.yaml` file is completely optional (https://github.com/PyPSA/pypsa-eur/pull/1745)

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1250,7 +1250,9 @@ rule build_egs_potentials:
 
 
 def input_heat_source_power(w):
-
+    limited_heat_sources = config_provider(
+        "sector", "district_heating", "limited_heat_sources"
+    )(w)
     return {
         heat_source_name: resources(
             "heat_source_power_" + heat_source_name + "_base_s_{clusters}.csv"
@@ -1258,10 +1260,8 @@ def input_heat_source_power(w):
         for heat_source_name in config_provider(
             "sector", "heat_pump_sources", "urban central"
         )(w)
-        if heat_source_name
-        in config_provider("sector", "district_heating", "limited_heat_sources")(
-            w
-        ).keys()
+        if heat_source_name in limited_heat_sources.keys()
+        and limited_heat_sources[heat_source_name]["requires_generator"]
     }
 
 

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -598,17 +598,15 @@ def add_heating_capacities_installed_before_baseyear(
                     "Link",
                     nodes,
                     suffix=f" {heat_system} {heat_source} heat pump-{grouping_year}",
-                    bus0=nodes_elec,
-                    bus1=nodes + " " + heat_system.value + " heat",
+                    bus0=nodes + " " + heat_system.value + " heat",
+                    bus1=nodes_elec,
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=efficiency,
+                    efficiency=1/efficiency.clip(upper=-0.01),
                     capital_cost=costs.at[costs_name, "efficiency"]
                     * costs.at[costs_name, "capital_cost"],
                     p_nom=existing_capacities.loc[
                         nodes, (heat_system.value, f"{heat_source} heat pump")
-                    ]
-                    * ratio
-                    / costs.at[costs_name, "efficiency"],
+                    ]* ratio,
                     build_year=int(grouping_year),
                     lifetime=costs.at[costs_name, "lifetime"],
                 )

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -602,8 +602,7 @@ def add_heating_capacities_installed_before_baseyear(
                     bus1=nodes_elec,
                     carrier=f"{heat_system} {heat_source} heat pump",
                     efficiency=(1 / efficiency.clip(lower=0.001)).replace(1000, 0),
-                    capital_cost=costs.at[costs_name, "efficiency"]
-                    * costs.at[costs_name, "capital_cost"],
+                    capital_cost=costs.at[costs_name, "capital_cost"],
                     p_nom=existing_capacities.loc[
                         nodes, (heat_system.value, f"{heat_source} heat pump")
                     ]

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -601,7 +601,7 @@ def add_heating_capacities_installed_before_baseyear(
                     bus0=nodes + " " + heat_system.value + " heat",
                     bus1=nodes_elec,
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1 / efficiency.clip(upper=-0.01),
+                    efficiency=1 / efficiency.clip(lower=0.01),
                     capital_cost=costs.at[costs_name, "efficiency"]
                     * costs.at[costs_name, "capital_cost"],
                     p_nom=existing_capacities.loc[

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -608,7 +608,7 @@ def add_heating_capacities_installed_before_baseyear(
                     ]
                     * ratio,
                     p_max_pu=0,
-                    p_min_pu=-1*efficiency / efficiency.clip(lower=0.001),
+                    p_min_pu=-1 * efficiency / efficiency.clip(lower=0.001),
                     build_year=int(grouping_year),
                     lifetime=costs.at[costs_name, "lifetime"],
                 )

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -601,12 +601,13 @@ def add_heating_capacities_installed_before_baseyear(
                     bus0=nodes + " " + heat_system.value + " heat",
                     bus1=nodes_elec,
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1/efficiency.clip(upper=-0.01),
+                    efficiency=1 / efficiency.clip(upper=-0.01),
                     capital_cost=costs.at[costs_name, "efficiency"]
                     * costs.at[costs_name, "capital_cost"],
                     p_nom=existing_capacities.loc[
                         nodes, (heat_system.value, f"{heat_source} heat pump")
-                    ]* ratio,
+                    ]
+                    * ratio,
                     build_year=int(grouping_year),
                     lifetime=costs.at[costs_name, "lifetime"],
                 )

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -601,7 +601,7 @@ def add_heating_capacities_installed_before_baseyear(
                     bus0=nodes + " " + heat_system.value + " heat",
                     bus1=nodes_elec,
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1 / efficiency.clip(lower=0.01),
+                    efficiency=(1 / efficiency.clip(lower=0.001)).replace(1000, 0),
                     capital_cost=costs.at[costs_name, "efficiency"]
                     * costs.at[costs_name, "capital_cost"],
                     p_nom=existing_capacities.loc[

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -608,6 +608,8 @@ def add_heating_capacities_installed_before_baseyear(
                         nodes, (heat_system.value, f"{heat_source} heat pump")
                     ]
                     * ratio,
+                    p_max_pu=0,
+                    p_min_pu=-1,
                     build_year=int(grouping_year),
                     lifetime=costs.at[costs_name, "lifetime"],
                 )

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -608,7 +608,7 @@ def add_heating_capacities_installed_before_baseyear(
                     ]
                     * ratio,
                     p_max_pu=0,
-                    p_min_pu=-1,
+                    p_min_pu=-1*efficiency / efficiency.clip(lower=0.001),
                     build_year=int(grouping_year),
                     lifetime=costs.at[costs_name, "lifetime"],
                 )

--- a/scripts/definitions/heat_system.py
+++ b/scripts/definitions/heat_system.py
@@ -223,7 +223,7 @@ class HeatSystem(Enum):
         str
             The name for the heat pump costs.
         """
-        if heat_source in ["ptes"]:
+        if heat_source in ["ptes", "geothermal"]:
             return f"{self.central_or_decentral} excess-heat-sourced heat pump"
         else:
             return f"{self.central_or_decentral} {heat_source}-sourced heat pump"

--- a/scripts/definitions/heat_system.py
+++ b/scripts/definitions/heat_system.py
@@ -223,7 +223,7 @@ class HeatSystem(Enum):
         str
             The name for the heat pump costs.
         """
-        if heat_source in ["ptes", "geothermal"]:
+        if heat_source in ["ptes", "geothermal", "electrolysis_excess_heat"]:
             return f"{self.central_or_decentral} excess-heat-sourced heat pump"
         else:
             return f"{self.central_or_decentral} {heat_source}-sourced heat pump"

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3293,7 +3293,9 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_system} water pits",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(1000, 0),
+                    efficiency=(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(
+                        1000, 0
+                    ),
                     efficiency2=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3234,8 +3234,6 @@ def add_heat(
                     carrier=f"{heat_system} {heat_source} heat pump",
                     efficiency=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
                     efficiency2=1 - (1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
-                    efficiency2=1
-                    / (cop_heat_pump - 1).clip(lower=0.001).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
@@ -3299,9 +3297,6 @@ def add_heat(
                         1000, 0
                     ),
                     efficiency2=1 - (1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
-                    efficiency=1
-                    / (cop_heat_pump - 1).clip(lower=0.001).replace(1000, 0),
-                    efficiency2=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3298,6 +3298,8 @@ def add_heat(
                     p_nom_extendable=True,
                     p_max_pu=0,
                     p_min_pu=-1,
+                    p_max_pu=0,
+                    p_min_pu=-1,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1576,7 +1576,7 @@ def insert_electricity_distribution_grid(
     n.links.loc[v2gs, "bus1"] += " low voltage"
 
     hps = n.links.index[n.links.carrier.str.contains("heat pump")]
-    n.links.loc[hps, "bus0"] += " low voltage"
+    n.links.loc[hps, "bus1"] += " low voltage"
 
     rh = n.links.index[n.links.carrier.str.contains("resistive heater")]
     n.links.loc[rh, "bus0"] += " low voltage"
@@ -3226,16 +3226,17 @@ def add_heat(
                     "Link",
                     nodes,
                     suffix=f" {heat_system} {heat_source} heat pump",
-                    bus0=nodes,
-                    bus1=nodes + f" {heat_carrier}",
-                    bus2=nodes + f" {heat_system} heat",
+                    bus0=nodes + f" {heat_system} heat",
+                    bus1=nodes,
+                    bus2=nodes + f" {heat_carrier}",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=(-(cop_heat_pump - 1)).clip(upper=0),
-                    efficiency2=cop_heat_pump,
-                    capital_cost=costs.at[costs_name_heat_pump, "efficiency"]
-                    * costs.at[costs_name_heat_pump, "capital_cost"]
+                    efficiency=1/cop_heat_pump.clip(upper=0),
+                    efficiency2=1/((cop_heat_pump - 1)).clip(upper=0),
+                    capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
+                    p_max_pu=0,
+                    p_min_pu=-1,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 
@@ -3286,14 +3287,13 @@ def add_heat(
                     "Link",
                     nodes,
                     suffix=f" {heat_system} {heat_source} heat pump",
-                    bus0=nodes,
-                    bus1=nodes + f" {heat_system} water pits",
-                    bus2=nodes + f" {heat_system} heat",
+                    bus0=nodes + f" {heat_system} heat",
+                    bus1=nodes,
+                    bus2=nodes + f" {heat_system} water pits",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=(-(cop_heat_pump - 1)).clip(upper=0),
-                    efficiency2=cop_heat_pump,
-                    capital_cost=costs.at[costs_name_heat_pump, "efficiency"]
-                    * costs.at[costs_name_heat_pump, "capital_cost"]
+                    efficiency=1/((cop_heat_pump - 1)).clip(upper=0),
+                    efficiency2=1/cop_heat_pump.clip(upper=0),
+                    capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
@@ -3304,13 +3304,14 @@ def add_heat(
                     "Link",
                     nodes,
                     suffix=f" {heat_system} {heat_source} heat pump",
-                    bus0=nodes,
-                    bus1=nodes + f" {heat_system} heat",
+                    bus0=nodes + f" {heat_system} heat",
+                    bus1=nodes,
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=cop_heat_pump,
-                    capital_cost=costs.at[costs_name_heat_pump, "efficiency"]
-                    * costs.at[costs_name_heat_pump, "capital_cost"]
+                    efficiency=1/cop_heat_pump,
+                    capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
+                    p_max_pu=0,
+                    p_min_pu=-1,
                     p_nom_extendable=True,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3230,8 +3230,8 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_carrier}",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1 / cop_heat_pump.clip(upper=0),
-                    efficiency2=1 / (cop_heat_pump - 1).clip(upper=0),
+                    efficiency=1 / cop_heat_pump.clip(upper=1e-6),
+                    efficiency2=1 / (cop_heat_pump - 1).clip(upper=1e-6),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
@@ -3291,8 +3291,8 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_system} water pits",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1 / (cop_heat_pump - 1).clip(upper=0),
-                    efficiency2=1 / cop_heat_pump.clip(upper=0),
+                    efficiency=1 / (cop_heat_pump - 1).clip(upper=1e-6),
+                    efficiency2=1 / cop_heat_pump.clip(upper=1e-6),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
@@ -3315,7 +3315,7 @@ def add_heat(
                     bus0=nodes + f" {heat_system} heat",
                     bus1=nodes,
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1 / cop_heat_pump,
+                    efficiency=1 / cop_heat_pump.clip(upper=1e-6),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_max_pu=0,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3300,6 +3300,8 @@ def add_heat(
                     p_min_pu=-1,
                     p_max_pu=0,
                     p_min_pu=-1,
+                    p_max_pu=0,
+                    p_min_pu=-1,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3230,8 +3230,8 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_carrier}",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1 / cop_heat_pump.clip(upper=1e-6),
-                    efficiency2=1 / (cop_heat_pump - 1).clip(upper=1e-6),
+                    efficiency=1 / cop_heat_pump.clip(upper=-0.01),
+                    efficiency2=1 / (cop_heat_pump - 1).clip(upper=-0.01),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
@@ -3291,8 +3291,8 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_system} water pits",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1 / (cop_heat_pump - 1).clip(upper=1e-6),
-                    efficiency2=1 / cop_heat_pump.clip(upper=1e-6),
+                    efficiency=1 / (cop_heat_pump - 1).clip(upper=-0.01),
+                    efficiency2=1 / cop_heat_pump.clip(upper=-0.01),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
@@ -3309,7 +3309,7 @@ def add_heat(
                     bus0=nodes + f" {heat_system} heat",
                     bus1=nodes,
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1 / cop_heat_pump.clip(upper=1e-6),
+                    efficiency=1 / cop_heat_pump.clip(upper=-0.01),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_max_pu=0,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3233,7 +3233,9 @@ def add_heat(
                     bus2=nodes + f" {heat_carrier}",
                     carrier=f"{heat_system} {heat_source} heat pump",
                     efficiency=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
-                    efficiency2=(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(1000, 0),
+                    efficiency2=(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(
+                        1000, 0
+                    ),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3293,8 +3293,8 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_system} water pits",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1 / (cop_heat_pump - 1).clip(lower=0.01),
-                    efficiency2=1 / cop_heat_pump.clip(lower=0.01),
+                    efficiency=(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(1000, 0),
+                    efficiency2=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
@@ -3311,7 +3311,7 @@ def add_heat(
                     bus0=nodes + f" {heat_system} heat",
                     bus1=nodes,
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1 / cop_heat_pump.clip(lower=0.01),
+                    efficiency=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_max_pu=0,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3298,12 +3298,6 @@ def add_heat(
                     p_nom_extendable=True,
                     p_max_pu=0,
                     p_min_pu=-1,
-                    p_max_pu=0,
-                    p_min_pu=-1,
-                    p_max_pu=0,
-                    p_min_pu=-1,
-                    p_max_pu=0,
-                    p_min_pu=-1,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3238,7 +3238,7 @@ def add_heat(
                     * overdim_factor,
                     p_nom_extendable=True,
                     p_max_pu=0,
-                    p_min_pu=-1*cop_heat_pump / cop_heat_pump.clip(lower=0.001),
+                    p_min_pu=-1 * cop_heat_pump / cop_heat_pump.clip(lower=0.001),
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 
@@ -3301,7 +3301,7 @@ def add_heat(
                     * overdim_factor,
                     p_nom_extendable=True,
                     p_max_pu=0,
-                    p_min_pu=-1*cop_heat_pump / cop_heat_pump.clip(lower=0.001),
+                    p_min_pu=-1 * cop_heat_pump / cop_heat_pump.clip(lower=0.001),
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 
@@ -3317,7 +3317,7 @@ def add_heat(
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_max_pu=0,
-                    p_min_pu=-1*cop_heat_pump / cop_heat_pump.clip(lower=0.001),
+                    p_min_pu=-1 * cop_heat_pump / cop_heat_pump.clip(lower=0.001),
                     p_nom_extendable=True,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3296,6 +3296,8 @@ def add_heat(
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
+                    p_max_pu=0,
+                    p_min_pu=-1,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3233,9 +3233,8 @@ def add_heat(
                     bus2=nodes + f" {heat_carrier}",
                     carrier=f"{heat_system} {heat_source} heat pump",
                     efficiency=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
-                    efficiency2=1 / (cop_heat_pump - 1).clip(lower=0.001).replace(
-                        1000, 0
-                    ),
+                    efficiency2=1
+                    / (cop_heat_pump - 1).clip(lower=0.001).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
@@ -3295,9 +3294,8 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_system} water pits",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1 / (cop_heat_pump - 1).clip(lower=0.001).replace(
-                        1000, 0
-                    ),
+                    efficiency=1
+                    / (cop_heat_pump - 1).clip(lower=0.001).replace(1000, 0),
                     efficiency2=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3238,7 +3238,7 @@ def add_heat(
                     * overdim_factor,
                     p_nom_extendable=True,
                     p_max_pu=0,
-                    p_min_pu=-1,
+                    p_min_pu=-1*cop_heat_pump / cop_heat_pump.clip(lower=0.001),
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 
@@ -3301,7 +3301,7 @@ def add_heat(
                     * overdim_factor,
                     p_nom_extendable=True,
                     p_max_pu=0,
-                    p_min_pu=-1,
+                    p_min_pu=-1*cop_heat_pump / cop_heat_pump.clip(lower=0.001),
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 
@@ -3317,7 +3317,7 @@ def add_heat(
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_max_pu=0,
-                    p_min_pu=-1,
+                    p_min_pu=-1*cop_heat_pump / cop_heat_pump.clip(lower=0.001),
                     p_nom_extendable=True,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3230,8 +3230,8 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_carrier}",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1/cop_heat_pump.clip(upper=0),
-                    efficiency2=1/((cop_heat_pump - 1)).clip(upper=0),
+                    efficiency=1 / cop_heat_pump.clip(upper=0),
+                    efficiency2=1 / (cop_heat_pump - 1).clip(upper=0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
@@ -3291,8 +3291,8 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_system} water pits",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1/((cop_heat_pump - 1)).clip(upper=0),
-                    efficiency2=1/cop_heat_pump.clip(upper=0),
+                    efficiency=1 / (cop_heat_pump - 1).clip(upper=0),
+                    efficiency2=1 / cop_heat_pump.clip(upper=0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
@@ -3307,7 +3307,7 @@ def add_heat(
                     bus0=nodes + f" {heat_system} heat",
                     bus1=nodes,
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1/cop_heat_pump,
+                    efficiency=1 / cop_heat_pump,
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_max_pu=0,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3233,7 +3233,8 @@ def add_heat(
                     bus2=nodes + f" {heat_carrier}",
                     carrier=f"{heat_system} {heat_source} heat pump",
                     efficiency=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
-                    efficiency2=1 - (1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
+                    efficiency2=1
+                    - (1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
@@ -3296,7 +3297,8 @@ def add_heat(
                     efficiency=(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(
                         1000, 0
                     ),
-                    efficiency2=1 - (1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
+                    efficiency2=1
+                    - (1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3233,7 +3233,9 @@ def add_heat(
                     bus2=nodes + f" {heat_carrier}",
                     carrier=f"{heat_system} {heat_source} heat pump",
                     efficiency=-(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
-                    efficiency2=-(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(1000, 0),
+                    efficiency2=-(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(
+                        1000, 0
+                    ),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3302,6 +3302,8 @@ def add_heat(
                     p_min_pu=-1,
                     p_max_pu=0,
                     p_min_pu=-1,
+                    p_max_pu=0,
+                    p_min_pu=-1,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3232,14 +3232,13 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_carrier}",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=-(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
-                    efficiency2=-(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(
-                        1000, 0
-                    ),
+                    efficiency=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
+                    efficiency2=(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
-                    p_max_pu=cop_heat_pump / cop_heat_pump.clip(lower=0.001),
+                    p_max_pu=-cop_heat_pump / cop_heat_pump.clip(lower=0.001),
+                    p_min_pu=0,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 
@@ -3294,14 +3293,15 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_system} water pits",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=-(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(
+                    efficiency=(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(
                         1000, 0
                     ),
-                    efficiency2=-(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
+                    efficiency2=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
-                    p_max_pu=cop_heat_pump / cop_heat_pump.clip(lower=0.001),
+                    p_min_pu=-cop_heat_pump / cop_heat_pump.clip(lower=0.001),
+                    p_max_pu=0
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 
@@ -3313,10 +3313,11 @@ def add_heat(
                     bus0=nodes + f" {heat_system} heat",
                     bus1=nodes,
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=-(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
+                    efficiency=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
-                    p_max_pu=cop_heat_pump / cop_heat_pump.clip(lower=0.001),
+                    p_min_pu=-cop_heat_pump / cop_heat_pump.clip(lower=0.001),
+                    p_max_pu=0,
                     p_nom_extendable=True,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3232,13 +3232,12 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_carrier}",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
-                    efficiency2=(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(1000, 0),
+                    efficiency=-(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
+                    efficiency2=-(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
-                    p_max_pu=0,
-                    p_min_pu=-1 * cop_heat_pump / cop_heat_pump.clip(lower=0.001),
+                    p_max_pu=cop_heat_pump / cop_heat_pump.clip(lower=0.001),
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 
@@ -3293,15 +3292,14 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_system} water pits",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(
+                    efficiency=-(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(
                         1000, 0
                     ),
-                    efficiency2=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
+                    efficiency2=-(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
-                    p_max_pu=0,
-                    p_min_pu=-1 * cop_heat_pump / cop_heat_pump.clip(lower=0.001),
+                    p_max_pu=cop_heat_pump / cop_heat_pump.clip(lower=0.001),
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 
@@ -3313,11 +3311,10 @@ def add_heat(
                     bus0=nodes + f" {heat_system} heat",
                     bus1=nodes,
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
+                    efficiency=-(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
-                    p_max_pu=0,
-                    p_min_pu=-1 * cop_heat_pump / cop_heat_pump.clip(lower=0.001),
+                    p_max_pu=cop_heat_pump / cop_heat_pump.clip(lower=0.001),
                     p_nom_extendable=True,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3238,8 +3238,8 @@ def add_heat(
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
-                    p_max_pu=-cop_heat_pump / cop_heat_pump.clip(lower=0.001),
-                    p_min_pu=0,
+                    p_min_pu=-cop_heat_pump / cop_heat_pump.clip(lower=0.001),
+                    p_max_pu=0,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3181,12 +3181,6 @@ def add_heat(
             )
 
             if heat_source in params.limited_heat_sources:
-                # get potential
-                p_max_source = pd.read_csv(
-                    heat_source_profile_files[heat_source],
-                    index_col=0,
-                ).squeeze()[nodes]
-
                 # add resource
                 heat_carrier = f"{heat_system} {heat_source} heat"
                 n.add("Carrier", heat_carrier)
@@ -3197,31 +3191,42 @@ def add_heat(
                     carrier=heat_carrier,
                 )
 
-                if heat_source in params.direct_utilisation_heat_sources:
-                    capital_cost = (
-                        costs.at[
-                            heat_system.heat_source_costs_name(heat_source),
-                            "capital_cost",
+                # Check if heat source requires a separate generator
+                heat_source_config = params.limited_heat_sources[heat_source]
+                requires_generator = heat_source_config["requires_generator"]
+
+                if requires_generator:
+                    # Standard heat source with potential file and generator
+                    p_max_source = pd.read_csv(
+                        heat_source_profile_files[heat_source],
+                        index_col=0,
+                    ).squeeze()[nodes]
+
+                    if heat_source in params.direct_utilisation_heat_sources:
+                        capital_cost = (
+                            costs.at[
+                                heat_system.heat_source_costs_name(heat_source),
+                                "capital_cost",
+                            ]
+                            * overdim_factor
+                        )
+                        lifetime = costs.at[
+                            heat_system.heat_source_costs_name(heat_source), "lifetime"
                         ]
-                        * overdim_factor
+                    else:
+                        capital_cost = 0.0
+                        lifetime = np.inf
+                    n.add(
+                        "Generator",
+                        nodes,
+                        suffix=f" {heat_carrier}",
+                        bus=nodes + f" {heat_carrier}",
+                        carrier=heat_carrier,
+                        p_nom_extendable=True,
+                        capital_cost=capital_cost,
+                        lifetime=lifetime,
+                        p_nom_max=p_max_source,
                     )
-                    lifetime = costs.at[
-                        heat_system.heat_source_costs_name(heat_source), "lifetime"
-                    ]
-                else:
-                    capital_cost = 0.0
-                    lifetime = np.inf
-                n.add(
-                    "Generator",
-                    nodes,
-                    suffix=f" {heat_carrier}",
-                    bus=nodes + f" {heat_carrier}",
-                    carrier=heat_carrier,
-                    p_nom_extendable=True,
-                    capital_cost=capital_cost,
-                    lifetime=lifetime,
-                    p_nom_max=p_max_source,
-                )
 
                 # add heat pump converting source heat + electricity to urban central heat
                 n.add(
@@ -5389,15 +5394,17 @@ def add_waste_heat(
 
         # Electrolysis waste heat
         if (
-            options["use_electrolysis_waste_heat"]
+            "electrolysis_excess_heat"
+            in options["district_heating"]["heat_pump_sources"]["urban central"]
             and "H2 Electrolysis" in link_carriers
         ):
+            # Connect electrolysis waste heat to electrolysis excess heat bus for heat pump boosting
             n.links.loc[urban_central + " H2 Electrolysis", "bus2"] = (
-                urban_central + " urban central heat"
+                urban_central + " urban central electrolysis excess heat"
             )
             n.links.loc[urban_central + " H2 Electrolysis", "efficiency2"] = (
                 0.84 - n.links.loc[urban_central + " H2 Electrolysis", "efficiency"]
-            ) * options["use_electrolysis_waste_heat"]
+            )
 
         # Fuel cell waste heat
         if options["use_fuel_cell_waste_heat"] and "H2 Fuel Cell" in link_carriers:

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3233,14 +3233,14 @@ def add_heat(
                     bus2=nodes + f" {heat_carrier}",
                     carrier=f"{heat_system} {heat_source} heat pump",
                     efficiency=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
-                    efficiency2=(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(
+                    efficiency2=1 / (cop_heat_pump - 1).clip(lower=0.001).replace(
                         1000, 0
                     ),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
-                    p_max_pu=-cop_heat_pump / cop_heat_pump.clip(lower=0.001),
-                    p_min_pu=0,
+                    p_min_pu=-cop_heat_pump / cop_heat_pump.clip(lower=0.001),
+                    p_max_pu=0,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 
@@ -3295,7 +3295,7 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_system} water pits",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(
+                    efficiency=1 / (cop_heat_pump - 1).clip(lower=0.001).replace(
                         1000, 0
                     ),
                     efficiency2=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3232,8 +3232,8 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_carrier}",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1 / cop_heat_pump.clip(lower=0.01),
-                    efficiency2=1 / (cop_heat_pump - 1).clip(lower=0.01),
+                    efficiency=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
+                    efficiency2=(1 / (cop_heat_pump - 1).clip(lower=0.01)).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3232,8 +3232,8 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_carrier}",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1 / cop_heat_pump.clip(upper=-0.01),
-                    efficiency2=1 / (cop_heat_pump - 1).clip(upper=-0.01),
+                    efficiency=1 / cop_heat_pump.clip(lower=0.01),
+                    efficiency2=1 / (cop_heat_pump - 1).clip(lower=0.01),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
@@ -3293,8 +3293,8 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_system} water pits",
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1 / (cop_heat_pump - 1).clip(upper=-0.01),
-                    efficiency2=1 / cop_heat_pump.clip(upper=-0.01),
+                    efficiency=1 / (cop_heat_pump - 1).clip(lower=0.01),
+                    efficiency2=1 / cop_heat_pump.clip(lower=0.01),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
@@ -3311,7 +3311,7 @@ def add_heat(
                     bus0=nodes + f" {heat_system} heat",
                     bus1=nodes,
                     carrier=f"{heat_system} {heat_source} heat pump",
-                    efficiency=1 / cop_heat_pump.clip(upper=-0.01),
+                    efficiency=1 / cop_heat_pump.clip(lower=0.01),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_max_pu=0,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3233,13 +3233,14 @@ def add_heat(
                     bus2=nodes + f" {heat_carrier}",
                     carrier=f"{heat_system} {heat_source} heat pump",
                     efficiency=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
+                    efficiency2=1 - (1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
                     efficiency2=1
                     / (cop_heat_pump - 1).clip(lower=0.001).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,
-                    p_min_pu=-cop_heat_pump / cop_heat_pump.clip(lower=0.001),
-                    p_max_pu=0,
+                    p_max_pu=-cop_heat_pump / cop_heat_pump.clip(lower=0.001),
+                    p_min_pu=0,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 
@@ -3294,6 +3295,10 @@ def add_heat(
                     bus1=nodes,
                     bus2=nodes + f" {heat_system} water pits",
                     carrier=f"{heat_system} {heat_source} heat pump",
+                    efficiency=(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(
+                        1000, 0
+                    ),
+                    efficiency2=1 - (1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
                     efficiency=1
                     / (cop_heat_pump - 1).clip(lower=0.001).replace(1000, 0),
                     efficiency2=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3301,7 +3301,7 @@ def add_heat(
                     * overdim_factor,
                     p_nom_extendable=True,
                     p_min_pu=-cop_heat_pump / cop_heat_pump.clip(lower=0.001),
-                    p_max_pu=0
+                    p_max_pu=0,
                     lifetime=costs.at[costs_name_heat_pump, "lifetime"],
                 )
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3233,7 +3233,7 @@ def add_heat(
                     bus2=nodes + f" {heat_carrier}",
                     carrier=f"{heat_system} {heat_source} heat pump",
                     efficiency=(1 / cop_heat_pump.clip(lower=0.001)).replace(1000, 0),
-                    efficiency2=(1 / (cop_heat_pump - 1).clip(lower=0.01)).replace(1000, 0),
+                    efficiency2=(1 / (cop_heat_pump - 1).clip(lower=0.001)).replace(1000, 0),
                     capital_cost=costs.at[costs_name_heat_pump, "capital_cost"]
                     * overdim_factor,
                     p_nom_extendable=True,

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -443,14 +443,15 @@ def prepare_network(
     pypsa.Network
         Modified PyPSA network with added constraints
     """
-    for df in (
-        n.generators_t.p_max_pu,
-        n.generators_t.p_min_pu,
-        n.links_t.p_max_pu,
-        n.links_t.p_min_pu,
-        n.storage_units_t.inflow,
-    ):
-        df = df.round(solve_opts["decimal_precision_p_min_max_pu"])
+    if "clip_p_max_pu" in solve_opts:
+        for df in (
+            n.generators_t.p_max_pu,
+            n.generators_t.p_min_pu,
+            n.links_t.p_max_pu,
+            n.links_t.p_min_pu,
+            n.storage_units_t.inflow,
+        ):
+            df.where(df > solve_opts["clip_p_max_pu"], other=0.0, inplace=True)
 
     if load_shedding := solve_opts.get("load_shedding"):
         # intersect between macroeconomic and surveybased willingness to pay

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -451,7 +451,7 @@ def prepare_network(
             n.links_t.p_min_pu,
             n.storage_units_t.inflow,
         ):
-            df.where(df > solve_opts["clip_p_max_pu"], other=0.0, inplace=True)
+            df.where(df.abs() > solve_opts["clip_p_max_pu"], other=0.0, inplace=True)
 
     if load_shedding := solve_opts.get("load_shedding"):
         # intersect between macroeconomic and surveybased willingness to pay

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -443,15 +443,14 @@ def prepare_network(
     pypsa.Network
         Modified PyPSA network with added constraints
     """
-    if "clip_p_max_pu" in solve_opts:
-        for df in (
-            n.generators_t.p_max_pu,
-            n.generators_t.p_min_pu,
-            n.links_t.p_max_pu,
-            n.links_t.p_min_pu,
-            n.storage_units_t.inflow,
-        ):
-            df.where(df > solve_opts["clip_p_max_pu"], other=0.0, inplace=True)
+    for df in (
+        n.generators_t.p_max_pu,
+        n.generators_t.p_min_pu,
+        n.links_t.p_max_pu,
+        n.links_t.p_min_pu,
+        n.storage_units_t.inflow,
+    ):
+        df = df.round(solve_opts["decimal_precision_p_min_max_pu"])
 
     if load_shedding := solve_opts.get("load_shedding"):
         # intersect between macroeconomic and surveybased willingness to pay


### PR DESCRIPTION
This PR introduces boosting for electrolyser excess heat, defaulting to 70C.

## Changes proposed in this Pull Request
- Replace `config:sector:use_electrolysis_waste_heat:0.25` with `config:limited_heat_sources:electrolysis_waste_heat` and related entries in `config:direct_utilisation_heat_sources` and `config:heat_pump_sources`. 
- Introduce an electrolysis waste heat bus and reroute the electrolysis process accordingly.
- Introduce `config:limited_heat_sources:requires_generator` (`true` for geothermal, `false` for electrolysis excess heat)
- Use `excess-heat heat pump` for electrolysis waste heat in `heat_system.heat_pump_costs_name`
- Update `build_sector` accordingly


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
