### PR TITLE
feat:electrolyser excess heat boosting

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -549,13 +549,20 @@ sector:
       geothermal:
         constant_temperature_celsius: 65
         ignore_missing_regions: false
+        requires_generator: true
+      electrolysis_excess_heat:
+        constant_temperature_celsius: 70
+        ignore_missing_regions: false
+        requires_generator: false
     direct_utilisation_heat_sources:
     - geothermal
+    - electrolysis_excess_heat
     temperature_limited_stores:
     - ptes
   heat_pump_sources:
     urban central:
     - air
+    - electrolysis_excess_heat
     urban decentral:
     - air
     rural:
@@ -743,7 +750,6 @@ sector:
   use_methanolisation_waste_heat: 0.25
   use_methanation_waste_heat: 0.25
   use_fuel_cell_waste_heat: 1
-  use_electrolysis_waste_heat: 0.25
   electricity_transmission_grid: true
   electricity_distribution_grid: true
   electricity_grid_connection: true

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1250,7 +1250,9 @@ rule build_egs_potentials:
 
 
 def input_heat_source_power(w):
-
+    limited_heat_sources = config_provider(
+        "sector", "district_heating", "limited_heat_sources"
+    )(w)
     return {
         heat_source_name: resources(
             "heat_source_power_" + heat_source_name + "_base_s_{clusters}.csv"
@@ -1258,10 +1260,8 @@ def input_heat_source_power(w):
         for heat_source_name in config_provider(
             "sector", "heat_pump_sources", "urban central"
         )(w)
-        if heat_source_name
-        in config_provider("sector", "district_heating", "limited_heat_sources")(
-            w
-        ).keys()
+        if heat_source_name in limited_heat_sources.keys()
+        and limited_heat_sources[heat_source_name]["requires_generator"]
     }
 
 

--- a/scripts/definitions/heat_system.py
+++ b/scripts/definitions/heat_system.py
@@ -223,7 +223,7 @@ class HeatSystem(Enum):
         str
             The name for the heat pump costs.
         """
-        if heat_source in ["ptes", "geothermal"]:
+        if heat_source in ["ptes", "geothermal", "electrolysis_excess_heat"]:
             return f"{self.central_or_decentral} excess-heat-sourced heat pump"
         else:
             return f"{self.central_or_decentral} {heat_source}-sourced heat pump"

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -5402,8 +5402,7 @@ def add_waste_heat(
 
         # Electrolysis waste heat
         if (
-            "electrolysis_excess_heat"
-            in options["district_heating"]["heat_pump_sources"]["urban central"]
+            "electrolysis_excess_heat" in options["heat_pump_sources"]["urban central"]
             and "H2 Electrolysis" in link_carriers
         ):
             # Connect electrolysis waste heat to electrolysis excess heat bus for heat pump boosting


### PR DESCRIPTION
This PR introduces boosting for electrolyser excess heat, defaulting to 70C.

## Changes proposed in this Pull Request
- Replace `config:sector:use_electrolysis_waste_heat:0.25` with `config:limited_heat_sources:electrolysis_waste_heat` and related entries in `config:direct_utilisation_heat_sources` and `config:heat_pump_sources`. 
- Introduce an electrolysis waste heat bus and reroute the electrolysis process accordingly.
- Introduce `config:limited_heat_sources:requires_generator` (`true` for geothermal, `false` for electrolysis excess heat)
- Use `excess-heat heat pump` for electrolysis waste heat in `heat_system.heat_pump_costs_name`
- Update `build_sector` accordingly


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
