### PR TITLE
remove pinned environment reference from pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
   rev: v2.15.0
   hooks:
   - id: pretty-format-yaml
-    exclude: (pinned\.yaml|\.lock\.yaml)$
+    exclude: (\.lock\.yaml)$
     args: [--autofix, --indent, "2", --preserve-quotes]
 
   # Format Snakemake rule / workflow files


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
The pinned environment files are still mentioned in the `.pre-commit-config.yaml`.

This pull request addresses this issue.

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
