### PR TITLE
Update minimum pypsa version to 0.35.2

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
 - pip
 
 # Inhouse packages
-- pypsa>=0.32.1
+- pypsa>=0.35.2
 - atlite>=0.3
 - linopy>=0.4.4
 - powerplantmatching>=0.5.15


### PR DESCRIPTION
Minimum version for pypsa was pinned too low, some features in the PyPSA-Eur workflow are not supported by the minimum version.

See e.g. the CI problems in #1675 

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
