### PR TITLE
Fix JRC ARDECO API change.

### DIFF
--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -737,8 +737,8 @@ if config["enable"]["retrieve"]:
             ardeco_pop="data/jrc-ardeco/ARDECO-SNPTD.2021.table.csv",
         run:
             urls = {
-                "ardeco_gdp": "https://urban.jrc.ec.europa.eu/ardeco-api-v2/rest/export/SUVGDP?version=2021&format=csv-table",
-                "ardeco_pop": "https://urban.jrc.ec.europa.eu/ardeco-api-v2/rest/export/SNPTD?version=2021&format=csv-table",
+                "ardeco_gdp": "https://territorial.ec.europa.eu/ardeco-api-v2/rest/export/SUVGDP?versions=2021&unit=EUR&level_id=0&level_id=1&level_id=2&level_id=3&format=csv-table",
+                "ardeco_pop": "https://territorial.ec.europa.eu/ardeco-api-v2/rest/export/SNPTD?versions=2021&unit=NR&level_id=0&level_id=1&level_id=2&level_id=3&format=csv-table",
             }
 
             for key, url in urls.items():


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Fixing `retrieve_jrc_ardeco` rule that led to breaking workflow in `build_shapes` due to breaking changes in the JRC ARDECO API
- Updated retrieved csvs to:
  - "ardeco_gdp": "https://territorial.ec.europa.eu/ardeco-api-v2/rest/export/SUVGDP?versions=2021&unit=EUR&level_id=0&level_id=1&level_id=2&level_id=3&format=csv-table",
  - "ardeco_pop": "https://territorial.ec.europa.eu/ardeco-api-v2/rest/export/SNPTD?versions=2021&unit=NR&level_id=0&level_id=1&level_id=2&level_id=3&format=csv-table", 
  - which are identical to the previous input file; 

## Checklist
- [ X] I tested my contribution locally and it works as intended.
