### PR TITLE
test: remove perfect foresight and mark as not stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,6 @@ test:
 	snakemake -call solve_elec_networks --configfile config/test/config.electricity.yaml
 	snakemake -call --configfile config/test/config.overnight.yaml
 	snakemake -call --configfile config/test/config.myopic.yaml
-	snakemake -call make_summary_perfect --configfile config/test/config.perfect.yaml
 	snakemake -call resources/test-elec-clusters/networks/base_s_adm.nc --configfile config/test/config.clusters.yaml
 	snakemake -call --configfile config/test/config.scenarios.yaml -n
 	snakemake -call plot_power_networks_clustered --configfile config/test/config.tyndp.yaml

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -48,6 +48,8 @@ Upcoming Release
 
 * Increase minimum required `pypsa` version to 0.33.2 (https://github.com/PyPSA/pypsa-eur/pull/1849)
 
+* Running perfect foresight is now marked as unstable and may not work as expected.
+
 PyPSA-Eur v2025.07.0 (11th July 2025)
 =====================================
 

--- a/scripts/prepare_perfect_foresight.py
+++ b/scripts/prepare_perfect_foresight.py
@@ -30,6 +30,15 @@ else:
 
 logger = logging.getLogger(__name__)
 
+logger.warning(
+    "Running perfect foresight is not properly tested and may not work as expected. "
+    "Use at your own risk!"
+)
+
+if PYPSA_V1:
+    msg = "PyPSA versions >=1.0 are not supported for perfect foresight."
+    raise UserWarning(msg)
+
 
 # helper functions ---------------------------------------------------
 def get_missing(df: pd.DataFrame, n: pypsa.Network, c: str) -> pd.DataFrame:


### PR DESCRIPTION
Running perfect foresight is not stable and properly used and with the fix in https://github.com/PyPSA/PyPSA/pull/1361 (issue https://github.com/PyPSA/PyPSA/issues/765) also not compatible with PyPSA v1.0 anymore.

This PR marks it as not stable and removes the test.