### PR TITLE
refactor: use snapshot_weightings to define nyears in build_transport_demand

### DIFF
--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1317,6 +1317,7 @@ rule build_transport_demand:
         sector=config_provider("sector"),
         energy_totals_year=config_provider("energy", "energy_totals_year"),
     input:
+        network=resources("networks/base_s.nc"),
         clustered_pop_layout=resources("pop_layout_base_s_{clusters}.csv"),
         pop_weighted_energy_totals=resources(
             "pop_weighted_energy_totals_s_{clusters}.csv"

--- a/scripts/build_transport_demand.py
+++ b/scripts/build_transport_demand.py
@@ -11,6 +11,7 @@ import logging
 
 import numpy as np
 import pandas as pd
+import pypsa
 import xarray as xr
 
 from scripts._helpers import (
@@ -184,7 +185,8 @@ if __name__ == "__main__":
         snakemake.params.snapshots, snakemake.params.drop_leap_day, tz="UTC"
     )
 
-    nyears = len(snapshots) / 8760
+    n = pypsa.Network(snakemake.input.network)
+    nyears = n.snapshot_weightings.generators.sum() / 8760.0
 
     energy_totals_year = snakemake.params.energy_totals_year
     nodal_transport_data = build_nodal_transport_data(


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

This PR suggests to make a consistent use of `snapshot_weightings` to define `nyears` in scripts. I only found one remaining place where `len()` was still being used. This is important for weighted annualised costs.

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
