### PR TITLE
Move config dump in `n.meta` to own key

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,6 +9,9 @@ Release Notes
 Upcoming Release
 ================
 
+* The Snakemake config is now stored in `n.meta["snakemake_config"]` instead of
+  overwriting the entire `n.meta` to allow for additional metadata fields to be set.
+
 * Fixed `AttributeError` in `prepare_sector_network.py` when running sector-coupled
   PyPSA-Eur with only one country and cluster. 
   (https://github.com/PyPSA/pypsa-eur/pull/1835)

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -372,7 +372,9 @@ if __name__ == "__main__":
 
     disable_grid_expansion_if_limit_hit(n)
 
-    n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
+    n.meta["snakemake_config"] = dict(
+        snakemake.config, **dict(wildcards=dict(snakemake.wildcards))
+    )
 
     sanitize_custom_columns(n)
     sanitize_carriers(n, snakemake.config)

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -1290,5 +1290,7 @@ if __name__ == "__main__":
     if "location" in n.buses:
         sanitize_locations(n)
 
-    n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
+    n.meta["snakemake_config"] = dict(
+        snakemake.config, **dict(wildcards=dict(snakemake.wildcards))
+    )
     n.export_to_netcdf(snakemake.output[0])

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -801,7 +801,9 @@ if __name__ == "__main__":
     if options.get("cluster_heat_buses", False):
         cluster_heat_buses(n)
 
-    n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
+    n.meta["snakemake_config"] = dict(
+        snakemake.config, **dict(wildcards=dict(snakemake.wildcards))
+    )
 
     sanitize_custom_columns(n)
     sanitize_carriers(n, snakemake.config)

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -1644,7 +1644,7 @@ if __name__ == "__main__":
     )
 
     # Export network
-    n.meta = snakemake.config
+    n.meta["snakemake_config"] = snakemake.config
     n.export_to_netcdf(snakemake.output.base_network)
 
     # Export shapes

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -364,5 +364,7 @@ if __name__ == "__main__":
         only_crossborder = snakemake.params.autarky["by_country"]
         enforce_autarky(n, only_crossborder=only_crossborder)
 
-    n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
+    n.meta["snakemake_config"] = dict(
+        snakemake.config, **dict(wildcards=dict(snakemake.wildcards))
+    )
     n.export_to_netcdf(snakemake.output[0])

--- a/scripts/prepare_perfect_foresight.py
+++ b/scripts/prepare_perfect_foresight.py
@@ -673,7 +673,9 @@ if __name__ == "__main__":
     )
 
     # update meta
-    n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
+    n.meta["snakemake_config"] = dict(
+        snakemake.config, **dict(wildcards=dict(snakemake.wildcards))
+    )
 
     # update heat pump efficiency
     update_heat_pump_efficiency(n=n, years=years)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -6498,7 +6498,9 @@ if __name__ == "__main__":
         n, snakemake.params["adjustments"], investment_year
     )
 
-    n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
+    n.meta["snakemake_config"] = dict(
+        snakemake.config, **dict(wildcards=dict(snakemake.wildcards))
+    )
 
     sanitize_carriers(n, snakemake.config)
     sanitize_locations(n)

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -495,7 +495,9 @@ if __name__ == "__main__":
         clustered_regions.to_file(snakemake.output[which])
         # append_bus_shapes(n, clustered_regions, type=which.split("_")[1])
 
-    n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
+    n.meta["snakemake_config"] = dict(
+        snakemake.config, **dict(wildcards=dict(snakemake.wildcards))
+    )
     n.export_to_netcdf(snakemake.output.network)
 
     logger.info(

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1436,7 +1436,9 @@ if __name__ == "__main__":
 
     logger.info(f"Maximum memory usage: {mem.mem_usage}")
 
-    n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
+    n.meta["snakemake_config"] = dict(
+        snakemake.config, **dict(wildcards=dict(snakemake.wildcards))
+    )
     n.export_to_netcdf(snakemake.output.network)
 
     with open(snakemake.output.config, "w") as file:

--- a/scripts/solve_operations_network.py
+++ b/scripts/solve_operations_network.py
@@ -55,5 +55,7 @@ if __name__ == "__main__":
         rule_name=snakemake.rule,
     )
 
-    n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
+    n.meta["snakemake_config"] = dict(
+        snakemake.config, **dict(wildcards=dict(snakemake.wildcards))
+    )
     n.export_to_netcdf(snakemake.output[0])


### PR DESCRIPTION
## Changes proposed in this Pull Request
The full snakemake config is currently saved in `n.meta`. This PR moves it instead to `n.meta['snakemake_config']`. I want to add additional metadata to the Network to use somewhere else, so having it's own key is more organised.

But this is breaking if people rely on it somewhere. 