### PR TITLE
Fix outdated expression for 'transmission_limit'

### DIFF
--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -734,7 +734,7 @@ def update_config_from_wildcards(config, w, inplace=True):
 
         for o in opts:
             if o.startswith("lv") or o.startswith("lc"):
-                config["electricity"]["transmission_expansion"] = o[1:]
+                config["electricity"]["transmission_limit"] = o[1:]
                 break
 
     if w.get("sector_opts"):


### PR DESCRIPTION
The old expression ('transmission_expansion') is no longer in the config file and therefore fails to overwrite the 'transmission_limit' if it's used in the 'opts'

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
