### PR TITLE
Fix clean-tests section in pixi.toml

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -135,12 +135,12 @@ integration-tests = """
     echo "All tests completed successfully."
 """
 clean-tests = """
-    snakemake -call solve_elec_networks --configfile config/test/config.electricity.yaml --delete-all-output &&
-    snakemake -call --configfile config/test/config.overnight.yaml --delete-all-output &&
-    snakemake -call --configfile config/test/config.myopic.yaml --delete-all-output &&
-    snakemake -call resources/test-elec-clusters/networks/base_s_adm.nc --configfile config/test/config.clusters.yaml --delete-all-output &&
-    snakemake -call --configfile config/test/config.scenarios.yaml -n --delete-all-output &&
-    snakemake -call plot_power_networks_clustered --configfile config/test/config.tyndp.yaml --delete-all-output &&
+    snakemake -call solve_elec_networks --configfile config/test/config.electricity.yaml --delete-all-output ;
+    snakemake -call --configfile config/test/config.overnight.yaml --delete-all-output ;
+    snakemake -call --configfile config/test/config.myopic.yaml --delete-all-output ;
+    snakemake -call resources/test-elec-clusters/networks/base_s_adm.nc --configfile config/test/config.clusters.yaml --delete-all-output ;
+    snakemake -call --configfile config/test/config.scenarios.yaml -n --delete-all-output ;
+    snakemake -call plot_power_networks_clustered --configfile config/test/config.tyndp.yaml --delete-all-output ;
 	echo "All test outputs have been cleaned up."
 """
 unit-tests = "pytest test"


### PR DESCRIPTION
Follow up to #1886 . `clean-tests` task was not working because of surplus `||`. And I think they are meant to be `&&` instead.

## Changes proposed in this Pull Request


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
