### PR TITLE
respect config when setting extendable stores

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2076,12 +2076,14 @@ def add_storage_and_grids(
             lifetime=costs.at["H2 (g) pipeline", "lifetime"],
         )
 
-
-    if "battery" in snakemake.params.electricity["extendable_carriers"].get("Store", []):
-
+    if "battery" in snakemake.params.electricity["extendable_carriers"].get(
+        "Store", []
+    ):
         n.add("Carrier", "battery")
 
-        n.add("Bus", nodes + " battery", location=nodes, carrier="battery", unit="MWh_el")
+        n.add(
+            "Bus", nodes + " battery", location=nodes, carrier="battery", unit="MWh_el"
+        )
 
         n.add(
             "Store",


### PR DESCRIPTION
## Changes proposed in this Pull Request
`prepare_sector_network` currently does not respect the `extendable_carrier` settings for Stores in the configuration file. If stores are **not** added as extendable there, the sector coupled model will still add them.

Fix only suggested for `battery`, depending on decision it could also be extended to `H2`

While opening that topic, shouldn't the `extendable` option for techs such as `solar rooftop`, `solar-hsat`, etc... also be configurable, rather than assuming that they are?

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
