### PR TITLE
add pixi files and data folder to .sync-send

### DIFF
--- a/.sync-send
+++ b/.sync-send
@@ -9,3 +9,7 @@ config/test
 envs
 matplotlibrc
 Snakefile
+data
+pixi.toml
+pixi.lock
+matplotlibrc


### PR DESCRIPTION
So that on cluster you can just use `pixi run snakemake --profile slurm ....`.