### PR TITLE
Capture raw osm `power=circuit` route relation

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,9 +9,11 @@ Release Notes
 Upcoming Release
 ================
 
+* Fixed missing raw OSM HVDC links defined using the ``power=circuit`` tag (NOTE: ``type=route``+``route=power`` is `deprecated <https://wiki.openstreetmap.org/wiki/Tag%3Aroute%3Dpower>`_).
+
 * Fixed bugs with load shedding due to incorrect use of `sign` argument in `n.add` and `np.isscalar` (https://github.com/PyPSA/pypsa-eur/pull/1908).
 
-* chore: disable PTES dynamic capacity by default 
+* chore: disable PTES dynamic capacity by default
 
 * Add CO2 emission prices configurable per planning horizon for sector-coupled models.
   The CO2 price is added as a marginal cost on the `co2 atmosphere` Store.

--- a/scripts/retrieve_osm_data.py
+++ b/scripts/retrieve_osm_data.py
@@ -60,11 +60,11 @@ def retrieve_osm_data(
     overpass_url = "https://overpass-api.de/api/interpreter"
 
     features_dict = {
-        "cables_way": 'way["power"="cable"]',
-        "lines_way": 'way["power"="line"]',
-        "routes_relation": 'relation["route"="power"]',
-        "substations_way": 'way["power"="substation"]',
-        "substations_relation": 'relation["power"="substation"]',
+        "cables_way": ['way["power"="cable"]'],
+        "lines_way": ['way["power"="line"]'],
+        "routes_relation": ['relation["route"="power"]', 'relation["power"="circuit"]'],
+        "substations_way": ['way["power"="substation"]'],
+        "substations_relation": ['relation["power"="substation"]'],
     }
 
     wait_time = 5
@@ -90,7 +90,7 @@ def retrieve_osm_data(
                 [out:json];
                 {op_area}->.searchArea;
                 (
-                {features_dict[f]}(area.searchArea);
+                {" ".join(f"{i}(area.searchArea);" for i in features_dict[f])}
                 );
                 out body geom;
             """


### PR DESCRIPTION
We capture HVDC links from OSM according to the `type=route`+`route=power` tag combo. However, [this is deprecated](https://wiki.openstreetmap.org/wiki/Tag%3Aroute%3Dpower).

Now, HVDC links are on OSM using both the deprecated (e.g. [here](https://www.openstreetmap.org/relation/8099179/history)) and recommended (e.g. [here](https://www.openstreetmap.org/relation/8099179)) tagging. So, this PR introduces a union to the overpass API query, for the old and the new.  

## Changes proposed in this Pull Request


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
