### PR TITLE
ci: run model runs only with src changes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,23 @@ jobs:
         shell: bash -l {0}
 
     steps:
+    - uses: actions/checkout@v6
+
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          src:
+            - 'scripts/**'
+            - 'rules/**'
+            - 'data/**'
+            - 'Snakefile'
+            - 'config/**'
+            - 'test/**'
+            - 'pixi.toml'
+            - 'pixi.lock'
+            - '.github/workflows/test.yaml'
+
     - name: Free up disk space
       run: |
         echo "Initial disk space"
@@ -42,23 +59,6 @@ jobs:
         sudo docker builder prune -a --force
         echo "Final disk space"
         df -h
-
-    - uses: actions/checkout@v6
-
-    - uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          src:
-            - 'scripts/**'
-            - 'rules/**'
-            - 'Snakefile'
-            - 'config/**'
-            - 'test/**'
-            - 'pixi.toml'
-            - 'pixi.lock'
-            - '.github/workflows/test.yaml'
-
     - name: Skip - no source changes
       if: steps.filter.outputs.src != 'true' && github.event_name != 'schedule'
       run: echo "Skipping tests because no source code changes detected"


### PR DESCRIPTION
To save some resources for PR's which only change docs. Now model tests are only triggered with changes in those files:
```
- 'scripts/**'
- 'rules/**'
- 'data/**'
- 'Snakefile'
- 'config/**'
- 'test/**'
- 'pixi.toml'
- 'pixi.lock'
- '.github/workflows/test.yaml'
```