### PR TITLE
follow PyPSA to name 'PyPSA-Eur' contributors as authors/copyright

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -100,8 +100,8 @@ master_doc = "index"
 
 # General information about the project.
 project = "PyPSA-Eur"
-copyright = "2017-2025 Tom Brown (TUB, KIT, FIAS), Jonas Hoersch (OET, KIT, FIAS), Fabian Hofmann (OET, TUB, FIAS), Fabian Neumann (TUB, KIT), Marta Victoria (DTU, Aarhus University), Lisa Zeyen (TUB, KIT)"
-author = "Tom Brown (TUB, KIT, FIAS), Jonas Hoersch (OET, KIT, FIAS), Fabian Hofmann (OET, TUB, FIAS), Fabian Neumann (TUB, KIT), Marta Victoria (DTU, Aarhus University), Lisa Zeyen (TUB, KIT)"
+copyright = "PyPSA-Eur Contributors"
+author = "PyPSA-Eur Contributors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Has the advantage that we do not need to keep track of this list; it's automatic through contributions.
