### PR TITLE
fix: fix compatibility with numpy >=2.4

### DIFF
--- a/scripts/make_cumulative_costs.py
+++ b/scripts/make_cumulative_costs.py
@@ -10,6 +10,12 @@ import logging
 import numpy as np
 import pandas as pd
 
+try:
+    from numpy import trapezoid
+except ImportError:
+    # before numpy 2.0
+    from numpy import trapz as trapezoid
+
 from scripts._helpers import configure_logging, set_scenario_config
 
 idx = pd.IndexSlice
@@ -34,7 +40,7 @@ def calculate_cumulative_cost(costs, planning_horizons):
         for cluster in cumulative_cost.index.get_level_values(level=0).unique():
             for sector_opts in cumulative_cost.index.get_level_values(level=1).unique():
                 cumulative_cost.loc[(cluster, sector_opts, "cumulative cost"), r] = (
-                    np.trapz(
+                    trapezoid(
                         cumulative_cost.loc[
                             idx[cluster, sector_opts, planning_horizons], r
                         ].values,

--- a/scripts/make_summary_perfect.py
+++ b/scripts/make_summary_perfect.py
@@ -13,6 +13,12 @@ import pypsa
 from pypsa.descriptors import get_active_assets
 from six import iteritems
 
+try:
+    from numpy import trapezoid
+except ImportError:
+    # before numpy 2.0
+    from numpy import trapz as trapezoid
+
 from scripts._helpers import load_costs, set_scenario_config
 from scripts.make_summary import (
     assign_carriers,
@@ -140,7 +146,7 @@ def calculate_cumulative_cost():
         for cluster in cumulative_cost.index.get_level_values(level=0).unique():
             for sector_opts in cumulative_cost.index.get_level_values(level=1).unique():
                 cumulative_cost.loc[(cluster, sector_opts, "cumulative cost"), r] = (
-                    np.trapz(
+                    trapezoid(
                         cumulative_cost.loc[
                             idx[cluster, sector_opts, planning_horizons], r
                         ].values,


### PR DESCRIPTION
## Changes proposed in this Pull Request

np.trapz was deprecated in favour of np.trapezoid in numpy 2.0 and removed in 2.4.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [x] A release note `doc/release_notes.rst` is added.
