### PR TITLE
fix: add pydeck lower version bound that was missing from pypsa <1.0.6

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -70,6 +70,7 @@ powerplantmatching = ">=0.5.15"
 pre-commit = ">=4.3.0"
 proj = ">=9.6.2"
 pylint = ">=4.0.2"
+pydeck = ">0.6"  # pypsa fails to import with pydeck <0.6, lower bound was only added from pypsa 1.0.6
 pypsa = ">=0.35.2"
 pyscipopt = ">=5.6.0"
 pytables = ">=3.10.2"


### PR DESCRIPTION
## Changes proposed in this Pull Request

In some soft-forks through some version constraint interaction pydeck is pulled in at version 0.4. Here we make the minimum version of 0.6 explicit.

See also companion PRs: https://github.com/conda-forge/pypsa-feedstock/pull/77 and https://github.com/PyPSA/PyPSA/pull/1518

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] A release note `doc/release_notes.rst` is added.
