### PR TITLE
Update lock file workflow to remove push trigger

### DIFF
--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -1,8 +1,5 @@
 name: Update locked envs
 on:
-  push:
-    paths:
-    - pixi.toml
   schedule:
   - cron: "0 8 1,16 * *" # Bi-weekly
   workflow_dispatch:


### PR DESCRIPTION
Not needed anymore, since the lock file is git tracked and already updated with the PR, which changes deps.