### PR TITLE
Revert "Update lock file workflow to remove push trigger"

### DIFF
--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -1,5 +1,8 @@
 name: Update locked envs
 on:
+  push:
+    paths:
+    - pixi.toml
   schedule:
   - cron: "0 8 1,16 * *" # Bi-weekly
   workflow_dispatch:


### PR DESCRIPTION
Reverts PyPSA/pypsa-eur#1975

A little brain lag, since we still need to update the conda env.

@daniel-rdt If https://github.com/open-energy-transition/open-tyndp/pull/356 works out, happy to get the on PR commit here as well!