### PR TITLE
chore: add job to autoupdate lockfiles via direct commit on PRs

### DIFF
--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -45,7 +45,8 @@ jobs:
   update-locked-environment:
     if: |
       needs.check-diff.outputs.has_diff == 'true' &&
-      (github.event_name != 'schedule' || github.ref == 'refs/heads/master')
+      (github.event_name == 'schedule' && github.ref == 'refs/heads/master' || 
+       github.event_name != 'schedule' && github.ref != 'refs/heads/master')
     needs: check-diff
     name: Update lockfiles
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR proposes to adjust `update-lockfile.yaml`, so that the lockfiles are updated with a direct commit on PR branches if a diff to Master is introduced in `pixi.toml` and `pixi.lock`.

The regular scheduled autoupdate on Master is untouched by this and will still create a PR to be manually merged.

It is still to be verified if this implementation properly functions with necessary permissions on PRs from a pypsa-eur fork.

## Workflow
Auotupdate runs:
- on Master if it is a scheduled run (creates a PR to Master)
- on any other branch if it is not a scheduled run but triggered by a change to `pixi.toml` or `pixi.lock` compared to Master (pushes the update directly to the PR branch as a new commit)

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] A release note `doc/release_notes.rst` is added.
