### PR TITLE
Remove check-merge-conflict hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0
   hooks:
-  - id: check-merge-conflict
   - id: check-added-large-files
     args: ["--maxkb=2000"]
 


### PR DESCRIPTION
Run CI also when merge conflicts still need to be resolved