### PR TITLE
switch back to 2019 energy balance year until CH fix

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -525,7 +525,7 @@ pypsa_eur:
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#energy
 energy:
-  energy_totals_year: 2023
+  energy_totals_year: 2019
   base_emissions_year: 1990
   emissions: CO2
 

--- a/config/schema.json
+++ b/config/schema.json
@@ -2262,7 +2262,7 @@
       "description": "Configuration for `energy` settings.",
       "properties": {
         "energy_totals_year": {
-          "default": 2023,
+          "default": 2019,
           "description": "The year for the sector energy use. The year must be available in the Eurostat report.",
           "type": "integer"
         },
@@ -10099,7 +10099,7 @@
       "description": "Configuration for `energy` settings.",
       "properties": {
         "energy_totals_year": {
-          "default": 2023,
+          "default": 2019,
           "description": "The year for the sector energy use. The year must be available in the Eurostat report.",
           "type": "integer"
         },

--- a/scripts/lib/validation/config/energy.py
+++ b/scripts/lib/validation/config/energy.py
@@ -17,7 +17,7 @@ class EnergyConfig(ConfigModel):
     """Configuration for `energy` settings."""
 
     energy_totals_year: int = Field(
-        2023,
+        2019,
         description="The year for the sector energy use. The year must be available in the Eurostat report.",
     )
     base_emissions_year: int = Field(


### PR DESCRIPTION
Energy balances for Switzerland also need to be updated first.