### PR TITLE
Add multi-circuit rendering to OSM interactive map

### DIFF
--- a/scripts/prepare_osm_network_release.py
+++ b/scripts/prepare_osm_network_release.py
@@ -1494,7 +1494,7 @@ if __name__ == "__main__":
         get_position=["x", "y"],
         get_fill_color=[255, 0, 155, 160],
         radius=20,
-        get_elevation=195,
+        get_elevation=10,
         pickable=True,
         auto_highlight=True,
         parameters={"depthTest": False},


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Add multi-circuit rendering to OSM interactive map 
- <img width="1739" height="1493" alt="image" src="https://github.com/user-attachments/assets/c138f3e7-472a-4f98-a0a4-cb77bf895b6d" />
- Inspired by Maplibre and https://openinframap.org 
- This does not touch the underlying network file or geometries, only on rendering in the browser during runtime, the parallel geometries are computed (all JavaScript) 
- Example demo: https://bxio.ng/assets/osm#dark/12.90/53.5695/9.5556
- Multi-circuit rendering triggered on zoom level 12 and higher

## Checklist
- [X] I tested my contribution locally and it works as intended.
- [X] Code and workflow changes are sufficiently documented.
