### PR TITLE
Fixing error in solve_network when networks contains inactive components subject to constraints

### DIFF
--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1001,7 +1001,7 @@ def add_lossy_bidirectional_link_constraints(n):
 
     carriers = n.links.loc[n.links.reversed, "carrier"].unique()  # noqa: F841
     backwards = n.links.query(
-        "carrier in @carriers and p_nom_extendable and reversed"
+        "carrier in @carriers and p_nom_extendable and reversed and active"
     ).index
     forwards = backwards.str.replace("-reversed", "")
     lhs = n.model["Link-p_nom"].loc[backwards]
@@ -1070,10 +1070,10 @@ def add_pipe_retrofit_constraint(n):
     if "reversed" not in n.links.columns:
         n.links["reversed"] = False
     gas_pipes_i = n.links.query(
-        "carrier == 'gas pipeline' and p_nom_extendable and ~reversed"
+        "carrier == 'gas pipeline' and p_nom_extendable and ~reversed and active"
     ).index
     h2_retrofitted_i = n.links.query(
-        "carrier == 'H2 pipeline retrofitted' and p_nom_extendable and ~reversed"
+        "carrier == 'H2 pipeline retrofitted' and p_nom_extendable and ~reversed and active"
     ).index
 
     if h2_retrofitted_i.empty or gas_pipes_i.empty:


### PR DESCRIPTION
In case the prenetwork that's passed to rule `solve_network` contains components that are set `active=False`, the rule fails due to missing time dependent variables in `add_lossy_bidirectional_link_constraints(n)`.

For landuse constraints and other renewables potential constraint this is not queried. Logic behind is if solar, offwind, onwind are down due to maintenance, they are still counted towards those constraints.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`). _not applicable_ 
- [ ] Changes in configuration options are added in `config/config.default.yaml`. _not applicable_ 
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`. _not applicable_ 
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed. _not applicable_ 
- [ ] A release note `doc/release_notes.rst` is added. _not applicable_ 
