### PR TITLE
fix: don't mutate config in cluster_network

### DIFF
--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -409,9 +409,9 @@ def clustering_for_n_clusters(
     if aggregation_strategies is None:
         aggregation_strategies = dict()
 
-    line_strategies = aggregation_strategies.get("lines", dict())
+    line_strategies = dict(aggregation_strategies.get("lines", {}))
 
-    bus_strategies = aggregation_strategies.get("buses", dict())
+    bus_strategies = dict(aggregation_strategies.get("buses", {}))
     bus_strategies.setdefault("substation_lv", lambda x: bool(x.sum()))
     bus_strategies.setdefault("substation_off", lambda x: bool(x.sum()))
 


### PR DESCRIPTION
A small fix which prevents mutating the params, since it was passed as mutable object 