### PR TITLE
fix flag for ignoring missing geothermal data in non-EU countries

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -1457,7 +1457,7 @@ data:
     source: archive
     version: latest
   lake_data:
-    source: archive
+    source: primary
     version: latest
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#overpass_api

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -696,6 +696,7 @@ sector:
       sabatier_waste: 200
       methanolisation_waste: 200
     fallback_ptx_heat_losses: 0.05
+    ignore_missing_geothermal_data: false
   heat_sources:
     urban central:
     - air

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -329,12 +329,10 @@ rule build_geothermal_heat_potential:
             "heat_source_temperatures",
             "geothermal",
         ),
-        ignore_missing_regions=config_provider(
+        ignore_missing_geothermal_data=config_provider(
             "sector",
             "district_heating",
-            "limited_heat_sources",
-            "geothermal",
-            "ignore_missing_regions",
+            "ignore_missing_geothermal_data",
         ),
         heat_source_cooling=config_provider(
             "sector", "district_heating", "heat_source_cooling"

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -1702,7 +1702,7 @@ if (LAKE_DATA_DATASET := dataset_version("lake_data"))["source"] in [
         output:
             zip_file=f"{LAKE_DATA_DATASET['folder']}/HydroLAKES_polys_v10.gdb.zip",
             lake_data=directory(
-                f"{LAKE_DATA_DATASET['folder']}/HydroLAKES_polys_v10.gdb"
+                f"{LAKE_DATA_DATASET['folder']}/HydroLAKES_polys_v10.gdb/HydroLAKES_polys_v10.gdb"
             ),
         run:
             copy2(input["zip_file"], output["zip_file"])

--- a/scripts/build_geothermal_heat_potential.py
+++ b/scripts/build_geothermal_heat_potential.py
@@ -242,8 +242,8 @@ def get_heat_source_power(
     supply_potentials: gpd.GeoDataFrame,
     full_load_hours: float,
     input_unit: str,
+    ignore_missing_data: bool,
     output_unit: str = "MWh",
-    ignore_missing_regions: bool = False,
 ) -> pd.DataFrame:
     """
     Get the heat source power from supply potentials.
@@ -309,7 +309,7 @@ def get_heat_source_power(
 
     if not non_covered_regions.empty:
         if all(non_covered_regions.str.contains("|".join(not_eu_27))):
-            if ignore_missing_regions:
+            if ignore_missing_data:
                 logger.warning(
                     f"The onshore regions outside EU 27 ({non_covered_regions.to_list()}) have no heat source power. Filling with zeros."
                 )
@@ -318,7 +318,7 @@ def get_heat_source_power(
                 )
             else:
                 raise ValueError(
-                    f"The onshore regions outside EU 27 {non_covered_regions.to_list()} have no heat source power. Set the ignore_missing_regions parameter in the config to true if you want to include these countries in your analysis despite missing geothermal data."
+                    f"The onshore regions outside EU 27 {non_covered_regions.to_list()} have no heat source power. Set the ignore_missing_geothermal_data parameter in the config to true if you want to include these countries in your analysis despite missing geothermal data."
                 )
         else:
             raise ValueError(
@@ -390,7 +390,7 @@ if __name__ == "__main__":
         supply_potentials=geothermal_supply_potentials,
         full_load_hours=FULL_LOAD_HOURS,
         input_unit=input_unit,
-        ignore_missing_regions=snakemake.params.ignore_missing_regions,
+        ignore_missing_data=snakemake.params.ignore_missing_geothermal_data,
     )
 
     # Load temperature profiles for scaling

--- a/scripts/lib/validation/config/sector.py
+++ b/scripts/lib/validation/config/sector.py
@@ -189,6 +189,11 @@ class _DistrictHeatingConfig(ConfigModel):
         0.05,
         description="Default heat loss fraction for PtX processes when waste heat recovery is enabled but no specific loss value is provided.",
     )
+    ignore_missing_geothermal_data: bool = Field(
+        False,
+        description="If true, missing geothermal data for non-EU countries will be ignored. If false, an error will be raised if countries with missing data are modelled while geothermal heat is included as a heat source.",
+    )
+
     heat_source_temperatures: dict[str, float] = Field(
         default_factory=lambda: {
             "geothermal": 65,


### PR DESCRIPTION
Fixes the config flag for ignoring missing (non-EU) regions in ISI geothermal heat source data.

## Changes proposed in this Pull Request
- introduce config setting `sector:district_heating:ignore_missing_geothermal_data`
- updated naming of flag in `build_sector.smk` and `build_geothermal_heat_potentials.py`
- removed default value `false` in `build_geothermal_heat_potentials.py` 

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.rst`.

**If applicable:**
- [x] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.