### PR TITLE
fix: remove Dask client.shutdown() in build_renewable_profiles

### DIFF
--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -326,6 +326,3 @@ if __name__ == "__main__":
         ds["profile"] = ds["profile"].where(ds["profile"] >= min_p_max_pu, 0)
 
     ds.to_netcdf(snakemake.output.profile)
-
-    if client is not None:
-        client.shutdown()


### PR DESCRIPTION
## Changes proposed in this Pull Request

Removes the explicit `client.shutdown()` call at the end of `build_renewable_profiles.py`. This call can fail with a `TimeoutError` when Dask worker processes don't exit within the nanny timeout on shared filesystems (e.g. BeeGFS), converting a completed run into a false Snakemake failure.

Both output files (`.nc` profile and `.geojson` class regions) are written before the shutdown call. The other Dask-using scripts in the repo (`build_hac_features`, `build_line_rating`, `build_daily_heat_demand`) do not call `client.shutdown()` and rely on process exit for cleanup — this change aligns `build_renewable_profiles` with that pattern.

Observed on a SLURM/BeeGFS cluster: 3 false failures out of ~130 runs (2.3%) over 4 weeks, all during the Dask teardown phase after successful computation and output file writing.

## Checklist

- [x] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.rst`.