### PR TITLE
feat: split console and file logging levels

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -11,6 +11,8 @@ tutorial: false
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#logging
 logging:
   level: INFO
+  console_level: WARNING
+  file_level:
   format: "%(levelname)s:%(name)s:%(message)s"
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#remote

--- a/config/schema.default.json
+++ b/config/schema.default.json
@@ -2848,7 +2848,7 @@
       "properties": {
         "level": {
           "default": "INFO",
-          "description": "Restrict console outputs to all infos, warning or errors only",
+          "description": "Root log level. Messages below this level are discarded before reaching any handler.",
           "enum": [
             "DEBUG",
             "INFO",
@@ -2857,6 +2857,37 @@
             "CRITICAL"
           ],
           "type": "string"
+        },
+        "console_level": {
+          "default": "WARNING",
+          "description": "Minimum level emitted to the console (stderr). Defaults to ``WARNING`` so parallel rule output stays readable; the full log is kept in the rule's log file.",
+          "enum": [
+            "DEBUG",
+            "INFO",
+            "WARNING",
+            "ERROR",
+            "CRITICAL"
+          ],
+          "type": "string"
+        },
+        "file_level": {
+          "anyOf": [
+            {
+              "enum": [
+                "DEBUG",
+                "INFO",
+                "WARNING",
+                "ERROR",
+                "CRITICAL"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum level written to the rule log file. Defaults to ``level`` when unset."
         },
         "format": {
           "default": "%(levelname)s:%(name)s:%(message)s",
@@ -8182,7 +8213,7 @@
       "properties": {
         "level": {
           "default": "INFO",
-          "description": "Restrict console outputs to all infos, warning or errors only",
+          "description": "Root log level. Messages below this level are discarded before reaching any handler.",
           "enum": [
             "DEBUG",
             "INFO",
@@ -8191,6 +8222,37 @@
             "CRITICAL"
           ],
           "type": "string"
+        },
+        "console_level": {
+          "default": "WARNING",
+          "description": "Minimum level emitted to the console (stderr). Defaults to ``WARNING`` so parallel rule output stays readable; the full log is kept in the rule's log file.",
+          "enum": [
+            "DEBUG",
+            "INFO",
+            "WARNING",
+            "ERROR",
+            "CRITICAL"
+          ],
+          "type": "string"
+        },
+        "file_level": {
+          "anyOf": [
+            {
+              "enum": [
+                "DEBUG",
+                "INFO",
+                "WARNING",
+                "ERROR",
+                "CRITICAL"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum level written to the rule log file. Defaults to ``level`` when unset."
         },
         "format": {
           "default": "%(levelname)s:%(name)s:%(message)s",

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -20,6 +20,8 @@ Release Notes
 
 * perf: Optimize dask settings for computing weather-dependent profiles (https://github.com/PyPSA/pypsa-eur/pull/2137).
 
+* Split logging levels between console and log file: the console now defaults to ``WARNING`` while the rule log file still captures ``INFO``. Configure via ``logging.console_level`` and ``logging.file_level`` (https://github.com/PyPSA/pypsa-eur/pull/2144).
+
 PyPSA-Eur v2026.02.0 (18th February 2026)
 =========================================
 

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -262,6 +262,8 @@ def configure_logging(snakemake, skip_handlers=False):
 
     kwargs = snakemake.config.get("logging", dict()).copy()
     kwargs.setdefault("level", "INFO")
+    console_level = kwargs.pop("console_level", "WARNING")
+    file_level = kwargs.pop("file_level", None) or kwargs["level"]
 
     if skip_handlers is False:
         fallback_path = Path(__file__).parent.joinpath(
@@ -270,16 +272,11 @@ def configure_logging(snakemake, skip_handlers=False):
         logfile = snakemake.log.get(
             "python", snakemake.log[0] if snakemake.log else fallback_path
         )
-        kwargs.update(
-            {
-                "handlers": [
-                    # Prefer the 'python' log, otherwise take the first log for each
-                    # Snakemake rule
-                    logging.FileHandler(logfile),
-                    logging.StreamHandler(),
-                ]
-            }
-        )
+        file_handler = logging.FileHandler(logfile)
+        file_handler.setLevel(file_level)
+        stream_handler = logging.StreamHandler()
+        stream_handler.setLevel(console_level)
+        kwargs["handlers"] = [file_handler, stream_handler]
     logging.basicConfig(**kwargs)
 
     # Setup a function to handle uncaught exceptions and include them with their stacktrace into logfiles

--- a/scripts/lib/validation/config/_schema.py
+++ b/scripts/lib/validation/config/_schema.py
@@ -46,7 +46,15 @@ class LoggingConfig(ConfigModel):
 
     level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(
         "INFO",
-        description="Restrict console outputs to all infos, warning or errors only",
+        description="Root log level. Messages below this level are discarded before reaching any handler.",
+    )
+    console_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(
+        "WARNING",
+        description="Minimum level emitted to the console (stderr). Defaults to ``WARNING`` so parallel rule output stays readable; the full log is kept in the rule's log file.",
+    )
+    file_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] | None = Field(
+        None,
+        description="Minimum level written to the rule log file. Defaults to ``level`` when unset.",
     )
     format: str = Field(
         "%(levelname)s:%(name)s:%(message)s",


### PR DESCRIPTION
## Changes proposed in this Pull Request

Splits the logging level between the console and the rule log file so that parallel atlite-based rules stay readable on the console while the log file still captures full `INFO` output.

`configure_logging` now sets per-handler levels:

- `logging.level` — root log level (unchanged default: `INFO`)
- `logging.console_level` — stream handler (new, default: `WARNING`)
- `logging.file_level` — file handler (new, defaults to `level`)

Users who want the old behaviour set `logging.console_level: INFO`.

Follow-up on the discussion in https://github.com/PyPSA/pypsa-eur/pull/2144#issuecomment-4243259364. The xarray MultiIndex fix has been dropped from this PR and is now tracked upstream in https://github.com/PyPSA/atlite/pull/501.

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.rst`.