### PR TITLE
Allow allow subregional NUTS selection.

### DIFF
--- a/config/schema.default.json
+++ b/config/schema.default.json
@@ -488,7 +488,7 @@
               "additionalProperties": {
                 "type": "integer"
               },
-              "description": "Optionally include dictionary of individual country or NUTS codes and their individual resolution. Overwrites country-specific `level`. For example: `{'DE': 1, 'FR': 2, 'DEA': 3}`. Only applies when mode is set to `administrative`.",
+              "description": "Optionally include dictionary of individual country codes and their individual NUTS levels. Overwrites country-specific `level`. For example: `{'DE': 1, 'FR': 2}`. Only applies when mode is set to `administrative`.",
               "type": "object"
             }
           }

--- a/config/schema.default.json
+++ b/config/schema.default.json
@@ -488,7 +488,7 @@
               "additionalProperties": {
                 "type": "integer"
               },
-              "description": "Optionally include dictionary of individual country codes and their individual NUTS levels. Overwrites country-specific `level`. For example: `{'DE': 1, 'FR': 2}`. Only applies when mode is set to `administrative`.",
+              "description": "Optionally include dictionary of individual country or NUTS codes and their individual resolution. Overwrites country-specific `level`. For example: `{'DE': 1, 'FR': 2, 'DEA': 3}`. Only applies when mode is set to `administrative`.",
               "type": "object"
             }
           }

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -1472,21 +1472,39 @@ def build_admin_shapes(
         nuts3_regions["column"] = level_map[level]
 
         countries_config = admin_levels.get("countries", {})
-        country_level = {k: v for k, v in countries_config.items() if len(k) == 2 and k in countries}
-        subregion_level = {k: v for k, v in countries_config.items() if len(k) > 2 and k[:2] in countries}
+        country_level = {
+            k: v for k, v in countries_config.items() if len(k) == 2 and k in countries
+        }
+        subregion_level = {
+            k: v
+            for k, v in countries_config.items()
+            if len(k) > 2 and k[:2] in countries
+        }
 
         if country_level:
-            logger.info("Setting individual administrative levels for:\n" + "\n".join(f"- {k}: level {v}" for k, v in country_level.items()))
-            nuts3_regions.loc[nuts3_regions["country"].isin(country_level), "column"] = (
-                nuts3_regions.loc[nuts3_regions["country"].isin(country_level), "country"]
+            logger.info(
+                "Setting individual administrative levels for:\n"
+                + "\n".join(f"- {k}: level {v}" for k, v in country_level.items())
+            )
+            nuts3_regions.loc[
+                nuts3_regions["country"].isin(country_level), "column"
+            ] = (
+                nuts3_regions.loc[
+                    nuts3_regions["country"].isin(country_level), "country"
+                ]
                 .map(country_level)
                 .map(level_map)
             )
 
         if subregion_level:
-            logger.info("Setting individual administrative levels for subregions:\n" + "\n".join(f"- {k}: level {v}" for k, v in subregion_level.items()))
+            logger.info(
+                "Setting individual administrative levels for subregions:\n"
+                + "\n".join(f"- {k}: level {v}" for k, v in subregion_level.items())
+            )
             for k, v in subregion_level.items():
-                nuts3_regions.loc[nuts3_regions.index.str.startswith(k), "column"] = level_map[v]
+                nuts3_regions.loc[nuts3_regions.index.str.startswith(k), "column"] = (
+                    level_map[v]
+                )
 
         # If GB is in the countries, set the level, aggregate London area to level 1 due to converging issues
         if "GB" in countries and level != "bz":

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -1469,41 +1469,22 @@ def build_admin_shapes(
 
     if clustering == "administrative":
         logger.info(f"Building bus regions at administrative level {level}")
-
         nuts3_regions["column"] = level_map[level]
 
-        # Only keep the values whose keys are in countries
-        country_level = {
-            k: v for k, v in admin_levels.items() if (k != "level") and (k in countries)
-        }
+        countries_config = admin_levels.get("countries", {})
+        country_level = {k: v for k, v in countries_config.items() if len(k) == 2 and k in countries}
+        subregion_level = {k: v for k, v in countries_config.items() if len(k) > 2 and k[:2] in countries}
+
         if country_level:
-            country_level_list = "\n".join(
-                [f"- {k}: level {v}" for k, v in country_level.items()]
-            )
-            logger.info(
-                f"Setting individual administrative levels for:\n{country_level_list}"
-            )
-            nuts3_regions.loc[
-                nuts3_regions["country"].isin(country_level.keys()), "column"
-            ] = (
-                nuts3_regions.loc[
-                    nuts3_regions["country"].isin(country_level.keys()), "country"
-                ]
+            logger.info("Setting individual administrative levels for:\n" + "\n".join(f"- {k}: level {v}" for k, v in country_level.items()))
+            nuts3_regions.loc[nuts3_regions["country"].isin(country_level), "column"] = (
+                nuts3_regions.loc[nuts3_regions["country"].isin(country_level), "country"]
                 .map(country_level)
                 .map(level_map)
             )
-        
-        # Overwrite if more specified subregions are available
-        subregion_level = {
-            k: v for k, v in admin_levels.items() if (k != "level") and (k[:2] in countries) and len(k)>2
-        }
+
         if subregion_level:
-            subregion_level_list = "\n".join(
-                [f"- {k}: level {v}" for k, v in subregion_level.items()]
-            )
-            logger.info(
-                f"Setting individual administrative levels for subregions:\n{subregion_level_list}"
-            )
+            logger.info("Setting individual administrative levels for subregions:\n" + "\n".join(f"- {k}: level {v}" for k, v in subregion_level.items()))
             for k, v in subregion_level.items():
                 nuts3_regions.loc[nuts3_regions.index.str.startswith(k), "column"] = level_map[v]
 

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -1492,6 +1492,20 @@ def build_admin_shapes(
                 .map(country_level)
                 .map(level_map)
             )
+        
+        # Overwrite if more specified subregions are available
+        subregion_level = {
+            k: v for k, v in admin_levels.items() if (k != "level") and (k[:2] in countries) and len(k)>2
+        }
+        if subregion_level:
+            subregion_level_list = "\n".join(
+                [f"- {k}: level {v}" for k, v in subregion_level.items()]
+            )
+            logger.info(
+                f"Setting individual administrative levels for subregions:\n{subregion_level_list}"
+            )
+            for k, v in subregion_level.items():
+                nuts3_regions.loc[nuts3_regions.index.str.startswith(k), "column"] = level_map[v]
 
         # If GB is in the countries, set the level, aggregate London area to level 1 due to converging issues
         if "GB" in countries and level != "bz":


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Extension of NUTS administrative clustering
- Allows a more fine-grained resolution with NUTS regions, e.g. "DEA" at level 3, while the neighbouring NUTS regions within DE are level 1 or 2 for example

<img width="1351" height="1123" alt="image" src="https://github.com/user-attachments/assets/fd3c545c-a0e8-4c1b-98e6-575473967781" />

## Checklist

**Required:**
- [X] Changes are tested locally and behave as expected.
- [X] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.rst`.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.