### PR TITLE
fix: remove asynchronous model for distributed client

### DIFF
--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1064,7 +1064,7 @@ def load_cutout(
 def setup_dask(nprocesses: int) -> dict:
     if nprocesses > 1:
         cluster = LocalCluster(n_workers=nprocesses, threads_per_worker=1)
-        client = Client(cluster, asynchronous=True)
+        client = Client(cluster)
         atexit.register(client.shutdown)
     else:
         client = None


### PR DESCRIPTION
## Changes proposed in this Pull Request

Fixup of #2137 , I took `Client(asynchronous=True)` from build_daily_heat_demand and build_temperature_profiles without investigating what it does.

https://distributed.dask.org/en/stable/api.html#client :
```
asynchronous: bool (False by default)
    Set to True if using this client within async/await functions or within Tornado 
    gen.coroutines. Otherwise this should remain False for normal use.
```

We and atlite are not running our own async event loop so this should always be False for us.

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.rst`.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.