### PR TITLE
Fix: Re-introduce capital_cost for non-bicharging stores

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,6 +8,8 @@ Release Notes
 
 .. Upcoming Release
 .. =================
+* Fix: Re-introduce capital costs for non-bicharging discharge links in ``add_electricity.py``, e.g. fuel cells.
+
 * The lockfile update workflow now excludes packages published within the last 7 days to reduce the risk of pulling in broken or yanked releases (https://github.com/PyPSA/pypsa-eur/pull/2130).
 
 * The industry reference year and the ammonia production data have been updated to 2023 (https://github.com/PyPSA/pypsa-eur/pull/2103)

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -1128,6 +1128,13 @@ def attach_stores(
             "Fuel Cell" if lookup_discharge == "fuel cell" else "discharger"
         )
 
+        discharge_capital_cost = (
+            0.0 if "bicharger" in lookup else costs.at[lookup_discharge, "capital_cost"]
+        )
+        if lookup_discharge == "fuel cell":
+            # NB: fuel cell investment cost is per MWel
+            discharge_capital_cost *= costs.at[lookup_discharge, "efficiency"]
+
         n.add(
             "Bus",
             bus_names,
@@ -1172,6 +1179,7 @@ def attach_stores(
             bus1=buses_i,
             carrier=f"{carrier} {discharge_name}",
             efficiency=costs.at[lookup_discharge, "efficiency"] ** roundtrip_correction,
+            capital_cost=discharge_capital_cost,
             p_nom_extendable=True,
             marginal_cost=costs.at[lookup_discharge, "marginal_cost"],
             lifetime=costs.at[lookup_discharge, "lifetime"],


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR is a bugfix that re-introduces capital costs for non-bicharging stores in `add_electricity.py`.

Currently, `attach_stores` does not add any `capital_cost` to discharging links, which is correct for storage technologies with a bicharger such as batteries, but not correct for other storage technologies with a dedicated discharger such as fuel cells. These technologies, e.g. fuel cells, currently have `capital_cost=0`.

The PR also adjusts the capital costs of fuel cells by the efficiency as investment costs are given per MWel, in line with `add_h2_gas_infrastructure` in `prepare_sector_network.py`.

I ran a quick test (electricity only, Germany as an island, 4 nodes, 3 hourly, no CO2 emissions), which confirmed the current issue due to free fuel cells.

<img width="2180" height="1702" alt="combined_comparison_panels" src="https://github.com/user-attachments/assets/0c4b7549-6188-4fb7-bebb-82c6366b5478" />

Happy to hear your thoughts.

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.rst`.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.