### PR TITLE
Set IISMethod for Gurobi to 1

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -1216,6 +1216,7 @@ solving:
       AggFill: 0
       PreDual: 0
       GURO_PAR_BARDENSETHRESH: 200
+      IISMethod: 1
     "gurobi-numeric-focus":
       NumericFocus: 3
       method: 2

--- a/scripts/lib/validation/config/solving.py
+++ b/scripts/lib/validation/config/solving.py
@@ -350,6 +350,7 @@ class SolvingConfig(BaseModel):
                 "AggFill": 0,
                 "PreDual": 0,
                 "GURO_PAR_BARDENSETHRESH": 200,
+                "IISMethod": 1,
             },
             "gurobi-numeric-focus": {
                 "NumericFocus": 3,


### PR DESCRIPTION
Small PR to set the default for the [Gurobi IIS Method ](https://docs.gurobi.com/projects/optimizer/en/current/reference/parameters.html#iismethod) to 1. Together with @coroa I observed this method to converge much faster and more reliable than the default `-1` option from Gurobi.

Does not affect regular solving, only the IIS in case of infeasibilities.

## Checklist

**Required:**
- [ ] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [n/a] A release note entry is added to `doc/release_notes.rst`.

**If applicable:**
- [x] Changes in configuration options are reflected in `scripts/lib/validation`.
- [n/a] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [n/a] New rules are documented in the appropriate `doc/*.rst` files.