### PR TITLE
Update pixi to use relative exclude-newer

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
     - name: Setup Pixi
       uses: prefix-dev/setup-pixi@v0.9.5
       with:
-        pixi-version: v0.59.0
+        pixi-version: v0.68.1
         cache: true
         # Do not cache in branches
         cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
     - name: Setup Pixi
       uses: prefix-dev/setup-pixi@v0.9.5
       with:
-        pixi-version: v0.59.0
+        pixi-version: v0.68.1
         cache: true
         cache-write: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
 
@@ -89,7 +89,7 @@ jobs:
       if: steps.filter.outputs.src == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       uses: prefix-dev/setup-pixi@v0.9.5
       with:
-        pixi-version: v0.59.0
+        pixi-version: v0.68.1
         cache: true
         cache-write: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
 

--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -18,18 +18,13 @@ jobs:
     - name: Setup Pixi
       uses: prefix-dev/setup-pixi@v0.9.5
       with:
-        pixi-version: v0.59.0
+        pixi-version: v0.68.1
 
-    - name: Full resolve (exclude packages newer than 7 days)
-      # Exclude recently published packages to avoid pulling in broken or
-      # yanked releases before upstream has had time to react
+    - name: Full resolve
       run: |
-        EXCLUDE_DATE=$(date -u -d '7 days ago' +%Y-%m-%dT00:00:00Z)
-        sed -i "/^\[workspace\]/a exclude-newer = \"$EXCLUDE_DATE\"" pixi.toml
         rm pixi.lock
         pixi install --all
         git checkout pixi.toml
-        sed -i '/^\s*exclude-newer:/d' pixi.lock
 
     - name: Export conda environment files
       if: ${{ !vars.PYPSA_BOT_ID }}

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,6 +8,7 @@ channels = ["conda-forge", "bioconda", "gurobi"]
 name = "pypsa-eur"
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
 version = "2025.07.0"
+exclude-newer = "7d"
 
 [tasks]
 


### PR DESCRIPTION
Fixes the CD hack to inject the date 7 days prior by using recent functionality added to `pixi` to use relative `exclude-newer`.

It is also possible to override this on a per dependency basis, in case there is a vulnerability that would be fixed by using _the_ most recent release.

Requires `pixi` v0.67 or higher. Run `pixi self-update`.

## Checklist

**Required:**
- [ ] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.rst`.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.