### PR TITLE
fix: URL for SCIGRID gas 1.1.2. archive on data.pypsa.org

### DIFF
--- a/data/versions.csv
+++ b/data/versions.csv
@@ -139,7 +139,7 @@ powerplants,0.7.1,archive,supported,2026-01-20,Part of the `powerplantmatching` 
 powerplants,0.7.0,primary,supported,2025-12-02,Part of the `powerplantmatching` package and versioned on GitHub.,https://raw.githubusercontent.com/PyPSA/powerplantmatching/refs/tags/v0.7.0/powerplants.csv
 powerplants,0.7.0,archive,supported,2026-01-20,Part of the `powerplantmatching` package and versioned on GitHub.,https://data.pypsa.org/workflows/eur/powerplants/0.7.0
 scigrid_gas,1.1.2,primary,latest supported,2025-12-02,the primary is already from Zenodo published by original authors,https://zenodo.org/records/4767098/files/IGGIELGN.zip
-scigrid_gas,1.1.2,archive,latest supported,2026-01-20,the primary is already from Zenodo published by original authors,https://data.pypsa.org/workflows/eur/scigrid_gas/1.1.2
+scigrid_gas,1.1.2,archive,latest supported,2026-01-20,the primary is already from Zenodo published by original authors,https://data.pypsa.org/workflows/eur/scigrid_gas/1.1.2/IGGIELGN.zip
 scigrid_gas,1.1.1,archive,deprecated not-supported,2026-01-13,,https://data.pypsa.org/workflows/eur/scigrid_gas/1.1.1/IGGIELGN.zip
 scigrid_gas,1.1.0,archive,deprecated not-supported,2026-01-13,,https://data.pypsa.org/workflows/eur/scigrid_gas/1.1.0/IGGIELGN.zip
 seawater_temperature,v1.0,primary,latest supported,2026-01-21,Test cutout seawater temperature,https://zenodo.org/records/15828866/files/seawater_temperature.nc

--- a/data/versions.csv
+++ b/data/versions.csv
@@ -149,7 +149,7 @@ ship_raster,v5,archive,latest supported,2026-01-13,,https://data.pypsa.org/workf
 swiss_energy_balances,2025-10-01,primary,latest supported,2026-02-12,,https://pubdb.bfe.admin.ch/de/publication/download/12361
 swiss_energy_balances,2025-10-01,archive,latest supported,2026-02-16,,https://web.archive.org/web/20260216/https%3A//pubdb.bfe.admin.ch/de/publication/download/12361
 synthetic_electricity_demand,v2,primary,latest supported,2025-12-02,the primary is already from Zenodo published by original authors,https://zenodo.org/records/10820928/files/demand_hourly.csv
-synthetic_electricity_demand,v2,archive,latest supported,2026-01-20,the primary is already from Zenodo published by original authors,https://data.pypsa.org/workflows/eur/synthetic_electricity_demand/v2
+synthetic_electricity_demand,v2,archive,latest supported,2026-01-20,the primary is already from Zenodo published by original authors,https://data.pypsa.org/workflows/eur/synthetic_electricity_demand/v2/demand_hourly.csv
 synthetic_electricity_demand,0.1.0,archive,deprecated might-work,2026-01-13,,https://data.pypsa.org/workflows/eur/synthetic_electricity_demand/0.1.0/demand_hourly.csv
 tyndp,2024,primary,latest supported,2025-12-02,,https://2024-data.entsos-tyndp-scenarios.eu/files/scenarios-inputs
 tyndp,2024,archive,latest supported,2026-01-13,,https://data.pypsa.org/workflows/eur/tyndp/2024


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Fix URL for SCIGRID gas 1.1.2. stored on data.pypsa.org:
- `https://data.pypsa.org/workflows/eur/scigrid_gas/1.1.2/IGGIELGN.zip`: zip file at the end of URL was missing

## Checklist

**Required:**
- [X] Changes are tested locally and behave as expected.