### PR TITLE
chore: fix formatting in docstring

### DIFF
--- a/scripts/build_gas_network.py
+++ b/scripts/build_gas_network.py
@@ -23,10 +23,10 @@ def diameter_to_capacity(pipe_diameter_mm):
     """
     Calculate pipe capacity in MW based on diameter in mm.
 
-    20 inch (500 mm)  50 bar -> 1.5   GW CH4 pipe capacity (LHV) 24 inch
-    (600 mm)  50 bar -> 5     GW CH4 pipe capacity (LHV) 36 inch (900
-    mm)  50 bar -> 11.25 GW CH4 pipe capacity (LHV) 48 inch (1200 mm) 80
-    bar -> 21.7  GW CH4 pipe capacity (LHV)
+    20 inch (500 mm)  50 bar -> 1.5   GW CH4 pipe capacity (LHV)
+    24 inch (600 mm)  50 bar -> 5     GW CH4 pipe capacity (LHV)
+    36 inch (900 mm)  50 bar -> 11.25 GW CH4 pipe capacity (LHV)
+    48 inch (1200 mm) 80 bar -> 21.7  GW CH4 pipe capacity (LHV)
 
     Based on p.15 of
     https://gasforclimate2050.eu/wp-content/uploads/2020/07/2020_European-Hydrogen-Backbone_Report.pdf


### PR DESCRIPTION
## Changes proposed in this Pull Request

Fix formatting of a cheatsheet in a docstring of the `build_gas_network` rule so that the mapping is human-readable.

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.rst`.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.