### PR TITLE
Agents/fix availability matrix plotting

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -189,7 +189,7 @@ atlite:
   default_cutout: "europe-2013-sarah3-era5"
   nprocesses: 1
   show_progress: false
-  plot_availability_matrix: true
+  plot_availability_matrix: false
   cutouts:
     "europe-1940-2024-era5":
       module: era5

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -189,7 +189,7 @@ atlite:
   default_cutout: "europe-2013-sarah3-era5"
   nprocesses: 1
   show_progress: false
-  plot_availability_matrix: false
+  plot_availability_matrix: true
   cutouts:
     "europe-1940-2024-era5":
       module: era5

--- a/config/schema.default.json
+++ b/config/schema.default.json
@@ -185,8 +185,8 @@
           "type": "boolean"
         },
         "plot_availability_matrix": {
-          "default": true,
-          "description": "Whether to plot the landuse availability matrix.",
+          "default": false,
+          "description": "Whether to plot the landuse availability matrix. Warning: This requires a significant amount of memory and time and may crash for larger workflows. Use with caution.",
           "type": "boolean"
         },
         "cutouts": {
@@ -8802,8 +8802,8 @@
           "type": "boolean"
         },
         "plot_availability_matrix": {
-          "default": true,
-          "description": "Whether to plot the landuse availability matrix.",
+          "default": false,
+          "description": "Whether to plot the landuse availability matrix. Warning: This requires a significant amount of memory and time and may crash for larger workflows. Use with caution.",
           "type": "boolean"
         },
         "cutouts": {

--- a/config/schema.default.json
+++ b/config/schema.default.json
@@ -185,7 +185,7 @@
           "type": "boolean"
         },
         "plot_availability_matrix": {
-          "default": false,
+          "default": true,
           "description": "Whether to plot the landuse availability matrix.",
           "type": "boolean"
         },
@@ -8802,7 +8802,7 @@
           "type": "boolean"
         },
         "plot_availability_matrix": {
-          "default": false,
+          "default": true,
           "description": "Whether to plot the landuse availability matrix.",
           "type": "boolean"
         },

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,7 +9,7 @@ Release Notes
 .. Upcoming Release
 .. =================
 * Fix: ``atlite.plot_availability_matrix`` config option for :mod:`determine_availability_matrix` and :mod:`determine_availability_matrix_MD_UA` scripts, changed their output and behaviour to align consistently.
-  Change the default config entry to plotting ``True`` (https://github.com/PyPSA/pypsa-eur/pull/2163).
+  Change the default config entry to plotting ``True`` (https://github.com/PyPSA/pypsa-eur/pull/2173).
 
 * Fix: Re-introduce capital costs for non-bicharging discharge links in ``add_electricity.py``, e.g. fuel cells.
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,7 +8,8 @@ Release Notes
 
 .. Upcoming Release
 .. =================
-* Fix: ``atlite.plot_availability_matrix`` config option for :mod:`determine_availability_matrix` and :mod:`determine_availability_matrix_MD_UA` scripts, changed their output and behaviour to align consistently (https://github.com/PyPSA/pypsa-eur/pull/2163).
+* Fix: ``atlite.plot_availability_matrix`` config option for :mod:`determine_availability_matrix` and :mod:`determine_availability_matrix_MD_UA` scripts, changed their output and behaviour to align consistently.
+  Change the default config entry to plotting ``True`` (https://github.com/PyPSA/pypsa-eur/pull/2163).
 
 * Fix: Re-introduce capital costs for non-bicharging discharge links in ``add_electricity.py``, e.g. fuel cells.
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,7 +8,7 @@ Release Notes
 
 .. Upcoming Release
 .. =================
-* Fix: The ``atlite.plot_availability_matrix`` config option was not correctly read in :mod:`determine_availability_matrix`. The PNG output is now an optional named output in the rule, only present when plotting is enabled (https://github.com/PyPSA/pypsa-eur/pull/2163).
+* Fix: ``atlite.plot_availability_matrix`` config option for :mod:`determine_availability_matrix` and :mod:`determine_availability_matrix_MD_UA` scripts, changed their output and behaviour to align consistently (https://github.com/PyPSA/pypsa-eur/pull/2163).
 
 * Fix: Re-introduce capital costs for non-bicharging discharge links in ``add_electricity.py``, e.g. fuel cells.
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,8 +8,7 @@ Release Notes
 
 .. Upcoming Release
 .. =================
-* Fix: ``atlite.plot_availability_matrix`` config option for :mod:`determine_availability_matrix` and :mod:`determine_availability_matrix_MD_UA` scripts, changed their output and behaviour to align consistently.
-  Change the default config entry to plotting ``True`` (https://github.com/PyPSA/pypsa-eur/pull/2173).
+* Fix: ``atlite.plot_availability_matrix`` config option for :mod:`determine_availability_matrix` and :mod:`determine_availability_matrix_MD_UA` scripts, changed their output and behaviour to align consistently (https://github.com/PyPSA/pypsa-eur/pull/2173).
 
 * Fix: Re-introduce capital costs for non-bicharging discharge links in ``add_electricity.py``, e.g. fuel cells.
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,6 +8,8 @@ Release Notes
 
 .. Upcoming Release
 .. =================
+* Fix: The ``atlite.plot_availability_matrix`` config option was not correctly read in :mod:`determine_availability_matrix`. The PNG output is now an optional named output in the rule, only present when plotting is enabled (https://github.com/PyPSA/pypsa-eur/pull/2163).
+
 * Fix: Re-introduce capital costs for non-bicharging discharge links in ``add_electricity.py``, e.g. fuel cells.
 
 * The lockfile update workflow now excludes packages published within the last 7 days to reduce the risk of pulling in broken or yanked releases (https://github.com/PyPSA/pypsa-eur/pull/2130).

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -333,7 +333,11 @@ rule determine_availability_matrix:
             w, config_provider("renewable", w.technology, "cutout")(w)
         ),
     output:
-        resources("availability_matrix_{clusters}_{technology}.nc"),
+        nc=resources("availability_matrix_{clusters}_{technology}.nc"),
+        plot=branch(
+            config["atlite"]["plot_availability_matrix"],
+            then=resources("availability_matrix_{clusters}_{technology}.png"),
+        ),
     log:
         logs("determine_availability_matrix_{clusters}_{technology}.log"),
     benchmark:

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -263,8 +263,10 @@ rule determine_availability_matrix_MD_UA:
             w, config_provider("renewable", w.technology, "cutout")(w)
         ),
     output:
-        availability_matrix=resources(
-            "availability_matrix_MD-UA_{clusters}_{technology}.nc"
+        nc=resources("availability_matrix_MD-UA_{clusters}_{technology}.nc"),
+        plot=branch(
+            config["atlite"]["plot_availability_matrix"],
+            then=resources("availability_matrix_MD-UA_{clusters}_{technology}.png"),
         ),
     log:
         logs("determine_availability_matrix_MD_UA_{clusters}_{technology}.log"),
@@ -275,6 +277,7 @@ rule determine_availability_matrix_MD_UA:
         mem_mb=config["atlite"].get("nprocesses", 4) * 5000,
     params:
         renewable=config_provider("renewable"),
+        plot_availability_matrix=config_provider("atlite", "plot_availability_matrix"),
     message:
         "Determining availability matrix for {wildcards.clusters} clusters and {wildcards.technology} technology"
     script:

--- a/scripts/determine_availability_matrix.py
+++ b/scripts/determine_availability_matrix.py
@@ -169,7 +169,7 @@ if __name__ == "__main__":
         f"Completed landuse availability calculation for {technology} ({duration:2.2f}s)"
     )
 
-    if params.get("plot_availability_matrix", False):
+    if snakemake.params.plot_availability_matrix:
         logger.info(f"Plotting landuse availability matrix for {technology}.")
         band, transform = shape_availability(
             regions.geometry.to_crs(excluder.crs), excluder
@@ -177,7 +177,7 @@ if __name__ == "__main__":
         fig, ax = plt.subplots(figsize=(10, 10))
         regions.to_crs(excluder.crs).plot(ax=ax, color="none")
         show(band, transform=transform, cmap="Greens", ax=ax)
-        plt.savefig(snakemake.output[0].replace(".nc", ".png"), dpi=300)
+        plt.savefig(snakemake.output["plot"], dpi=300)
 
     # For Moldova and Ukraine: Overwrite parts not covered by Corine with
     # externally determined available areas
@@ -187,4 +187,4 @@ if __name__ == "__main__":
         )
         availability.loc[availability_MDUA.coords] = availability_MDUA
 
-    availability.to_netcdf(snakemake.output[0])
+    availability.to_netcdf(snakemake.output["nc"])

--- a/scripts/determine_availability_matrix_MD_UA.py
+++ b/scripts/determine_availability_matrix_MD_UA.py
@@ -14,7 +14,10 @@ from tempfile import NamedTemporaryFile
 import atlite
 import fiona
 import geopandas as gpd
+import matplotlib.pyplot as plt
 import numpy as np
+from atlite.gis import shape_availability
+from rasterio.plot import show
 
 from scripts._helpers import configure_logging, load_cutout, set_scenario_config
 
@@ -168,5 +171,17 @@ if __name__ == "__main__":
 
     availability = availability.sel(bus=buses)
 
+    if snakemake.params.plot_availability_matrix:
+        logger.info(
+            f"Plotting landuse availability matrix for {snakemake.wildcards.technology}."
+        )
+        band, transform = shape_availability(
+            regions.geometry.to_crs(excluder.crs), excluder
+        )
+        fig, ax = plt.subplots(figsize=(10, 10))
+        regions.to_crs(excluder.crs).plot(ax=ax, color="none")
+        show(band, transform=transform, cmap="Greens", ax=ax)
+        plt.savefig(snakemake.output["plot"], dpi=300)
+
     # Save and plot for verification
-    availability.to_netcdf(snakemake.output.availability_matrix)
+    availability.to_netcdf(snakemake.output["nc"])

--- a/scripts/lib/validation/config/atlite.py
+++ b/scripts/lib/validation/config/atlite.py
@@ -122,8 +122,8 @@ class AtliteConfig(BaseModel):
         description="Whether progressbar for atlite conversion processes should be shown. False saves time.",
     )
     plot_availability_matrix: bool = Field(
-        True,
-        description="Whether to plot the landuse availability matrix.",
+        False,
+        description="Whether to plot the landuse availability matrix. Warning: This requires a significant amount of memory and time and may crash for larger workflows. Use with caution.",
     )
     cutouts: dict[str, _CutoutConfig] = Field(
         default_factory=lambda: {

--- a/scripts/lib/validation/config/atlite.py
+++ b/scripts/lib/validation/config/atlite.py
@@ -122,7 +122,7 @@ class AtliteConfig(BaseModel):
         description="Whether progressbar for atlite conversion processes should be shown. False saves time.",
     )
     plot_availability_matrix: bool = Field(
-        False,
+        True,
         description="Whether to plot the landuse availability matrix.",
     )
     cutouts: dict[str, _CutoutConfig] = Field(


### PR DESCRIPTION
## Changes proposed in this Pull Request

* The config entry for plotting availability maps for different technologies was not working - fixed. (Default always kicked in, leading to `False` being the only option.)
* Plotting was not available for UA and MD
* Changed the default for plotting by default, because the cost overhead is little


## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.rst`.

**If applicable:**
- [x] Changes in configuration options are reflected in `scripts/lib/validation`.
- [n/a] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [n/a] New rules are documented in the appropriate `doc/*.rst` files.