### PR TITLE
Fix: activate missing losses for "H2 pipeline retrofitted" links

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -909,12 +909,16 @@ sector:
     enable:
     - DC
     - H2 pipeline
+    - H2 pipeline retrofitted
     - gas pipeline
     - electricity distribution grid
     DC:
       efficiency_static: 0.98
       efficiency_per_1000km: 0.977
     H2 pipeline:
+      efficiency_per_1000km: 1
+      compression_per_1000km: 0.018
+    H2 pipeline retrofitted:
       efficiency_per_1000km: 1
       compression_per_1000km: 0.018
     gas pipeline:

--- a/config/schema.default.json
+++ b/config/schema.default.json
@@ -4878,6 +4878,13 @@
               "description": "H2 pipeline transmission efficiency.",
               "type": "object"
             },
+            "H2 pipeline retrofitted": {
+              "additionalProperties": {
+                "type": "number"
+              },
+              "description": "H2 pipeline retrofitted transmission efficiency.",
+              "type": "object"
+            },
             "gas pipeline": {
               "additionalProperties": {
                 "type": "number"
@@ -8093,6 +8100,13 @@
             "type": "number"
           },
           "description": "H2 pipeline transmission efficiency.",
+          "type": "object"
+        },
+        "H2 pipeline retrofitted": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "H2 pipeline retrofitted transmission efficiency.",
           "type": "object"
         },
         "gas pipeline": {
@@ -11325,6 +11339,13 @@
                 "type": "number"
               },
               "description": "H2 pipeline transmission efficiency.",
+              "type": "object"
+            },
+            "H2 pipeline retrofitted": {
+              "additionalProperties": {
+                "type": "number"
+              },
+              "description": "H2 pipeline retrofitted transmission efficiency.",
               "type": "object"
             },
             "gas pipeline": {

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,6 +8,8 @@ Release Notes
 
 .. Upcoming Release
 .. =================
+* Fix: Activate losses for `H2 pipeline retrofitted` links by default, to ensure consistency with `H2 pipeline` links.
+
 * Fix: Re-introduce capital costs for non-bicharging discharge links in ``add_electricity.py``, e.g. fuel cells.
 
 * The lockfile update workflow now excludes packages published within the last 7 days to reduce the risk of pulling in broken or yanked releases (https://github.com/PyPSA/pypsa-eur/pull/2130).

--- a/scripts/lib/validation/config/sector.py
+++ b/scripts/lib/validation/config/sector.py
@@ -231,6 +231,7 @@ class _TransmissionEfficiencyConfig(BaseModel):
         default_factory=lambda: [
             "DC",
             "H2 pipeline",
+            "H2 pipeline retrofitted",
             "gas pipeline",
             "electricity distribution grid",
         ],
@@ -250,6 +251,14 @@ class _TransmissionEfficiencyConfig(BaseModel):
         },
         alias="H2 pipeline",
         description="H2 pipeline transmission efficiency.",
+    )
+    H2_pipeline_retrofitted: dict[str, float] = Field(
+        default_factory=lambda: {
+            "efficiency_per_1000km": 1,
+            "compression_per_1000km": 0.018,
+        },
+        alias="H2 pipeline retrofitted",
+        description="H2 pipeline retrofitted transmission efficiency.",
     )
     gas_pipeline: dict[str, float] = Field(
         default_factory=lambda: {


### PR DESCRIPTION
Bugfix: Activate losses for `H2 pipeline retrofitted` links. Previously these were omitted which caused the model to utilize them much more than the standard `H2 pipeline` links.

## Checklist

**Required:**
- [ ] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.rst`.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.