### PR TITLE
Adjusted layered PTES model

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -666,6 +666,12 @@ sector:
       bottom_temperature: 35
       design_top_temperature: 90
       design_bottom_temperature: 35
+      # If true, the return-level and heat-pump reinjection layers are chosen as
+      # the warmest layer at/below the target temperature (floor) instead of the
+      # closest layer, guaranteeing discharge cannot generate energy (no free
+      # lunch) at the cost of a small conservative leak. If false, the closest
+      # layer is used and build_ptes_operations warns when a free lunch is risked.
+      conservative_return_layer: false
       layered:
         layer_temperatures: [90]
         heat_transfer_coefficient: 0.01  # H [W/(m²·K)]

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -677,9 +677,6 @@ rule build_cop_profiles:
         ptes_layer_temperatures=config_provider(
             "sector", "district_heating", "ptes", "layered", "layer_temperatures"
         ),
-        layered_ptes=config_provider(
-            "sector", "district_heating", "ptes", "layered", "enable"
-        ),
         snapshots=config_provider("snapshots"),
     input:
         unpack(input_heat_source_temperature),
@@ -746,6 +743,18 @@ rule build_ptes_operations:
             "district_heating",
             "ptes",
             "interlayer_heat_transfer_coefficient",
+        ),
+        conservative_return_layer=config_provider(
+            "sector",
+            "district_heating",
+            "ptes",
+            "conservative_return_layer",
+        ),
+        heat_source_cooling_central_heating=config_provider(
+            "sector", "district_heating", "heat_source_cooling"
+        ),
+        heat_pump_cop_approximation_central_heating=config_provider(
+            "sector", "district_heating", "heat_pump_cop_approximation"
         ),
     input:
         central_heating_forward_temperature_profiles=resources(

--- a/scripts/build_cop_profiles/run.py
+++ b/scripts/build_cop_profiles/run.py
@@ -262,12 +262,30 @@ def expand_heat_sources_for_ptes_layers(
     heat_sources_by_system: dict[str, list[str]],
     ptes_layer_temperatures: list[float] | None,
 ) -> dict[str, list[str]]:
-    """Replace 'ptes' by per-layer labels when multiple PTES layers exist."""
+    """Replace plain PTES with per-layer labels when multiple PTES layers exist."""
 
-    for layer in range(len(ptes_layer_temperatures)):
-        heat_sources_by_system["urban central"].append(f"ptes layer {layer}")
+    if not ptes_layer_temperatures or len(ptes_layer_temperatures) <= 1:
+        return heat_sources_by_system
 
-    return heat_sources_by_system
+    expanded_heat_sources_by_system = {
+        heat_system_type: list(heat_sources)
+        for heat_system_type, heat_sources in heat_sources_by_system.items()
+    }
+
+    urban_central_heat_sources = expanded_heat_sources_by_system.get(
+        HeatSystemType.URBAN_CENTRAL.value, []
+    )
+
+    try:
+        ptes_index = urban_central_heat_sources.index(HeatSource.PTES.value)
+    except ValueError:
+        return expanded_heat_sources_by_system
+
+    urban_central_heat_sources[ptes_index : ptes_index + 1] = [
+        f"ptes layer {layer}" for layer in range(len(ptes_layer_temperatures))
+    ]
+
+    return expanded_heat_sources_by_system
 
 
 if __name__ == "__main__":
@@ -288,13 +306,10 @@ if __name__ == "__main__":
         snakemake.input.central_heating_return_temperature_profiles
     )
 
-    if snakemake.params.layered_ptes:
-        heat_sources_by_system = expand_heat_sources_for_ptes_layers(
-            heat_sources_by_system=snakemake.params.heat_sources,
-            ptes_layer_temperatures=snakemake.params.ptes_layer_temperatures,
-        )
-    else:
-        heat_sources_by_system = snakemake.params.heat_sources
+    heat_sources_by_system = expand_heat_sources_for_ptes_layers(
+        heat_sources_by_system=snakemake.params.heat_sources,
+        ptes_layer_temperatures=snakemake.params.ptes_layer_temperatures,
+    )
 
     cop_all_system_types = []
     for heat_system_type, heat_sources in heat_sources_by_system.items():

--- a/scripts/build_ptes_operations/ptes_approximator.py
+++ b/scripts/build_ptes_operations/ptes_approximator.py
@@ -18,12 +18,19 @@ class PtesApproximator:
         design_standing_losses: float,
         interlayer_heat_transfer_coefficient: float,
         cop: xr.DataArray,
+        conservative_return_layer: bool = False,
         rho=1000,
         # Specific heat in MWh/kg/K to keep rho*c_p*DeltaT in MWh/m3.
         c_p=4184 / 3.6e9,
     ):
         self.forward_temperature = forward_temperature
         self.return_temperature = return_temperature
+        # When True, the return-level and heat-pump reinjection layers are chosen
+        # as the warmest layer at/below the target temperature (floor), so direct
+        # and boosted discharge never deposit spent volume above the return level
+        # -> no energy generation on discharge. When False, the closest layer is
+        # used (and discharge_free_lunch_warnings flags any free-lunch risk).
+        self.conservative_return_layer = bool(conservative_return_layer)
 
         layer_temperatures = np.asarray(layer_temperatures, dtype=float)
 
@@ -155,13 +162,30 @@ class PtesApproximator:
 
     @property
     def return_temp_layer(self) -> xr.DataArray:
-        """Closest layer index to node-wise mean return temperature."""
+        """
+        Layer index used as the return level.
 
-        return (
-            np.abs(self.layer_temperatures_da - self.return_temperature)
-            .argmin(dim="layer")
-            .astype(int)
-        )
+        With ``conservative_return_layer`` the warmest layer at or below the
+        return temperature is chosen (floor), so direct discharge never deposits
+        spent volume above the return level (no energy generation). If no layer is
+        at/below the return temperature the coldest (bottom) layer is used.
+        Otherwise the closest layer is chosen (nearest).
+        """
+        layer_t = self.layer_temperatures_da
+        return_t = self.return_temperature
+        if self._time_dim in getattr(return_t, "dims", ()):
+            # Floor against the coldest return temperature to stay conservative
+            # at every timestep.
+            return_t = return_t.min(dim=self._time_dim)
+
+        if self.conservative_return_layer:
+            at_or_below = layer_t <= return_t
+            floored = at_or_below.argmax(dim="layer")  # warmest layer with T <= T_ret
+            return xr.where(
+                at_or_below.any(dim="layer"), floored, self.num_layers - 1
+            ).astype(int)
+
+        return np.abs(layer_t - return_t).argmin(dim="layer").astype(int)
 
     @property
     def preheater_return_layer(self) -> xr.DataArray:
@@ -226,17 +250,31 @@ class PtesApproximator:
         # take min over time (target layer must be constant)
         target_temp = target_temp.min(dim="time")
 
+        layer_t = self.layer_temperatures_da
+        layer_idx = layer_t.layer
         ret_val = []
         for l in range(self.num_layers):
-            closest_layer = abs(
-                self.layer_temperatures_da - target_temp.sel(layer=l)
-            ).argmin(dim="layer")
-            closest_layer = xr.where(
-                (closest_layer <= l) & (closest_layer < self.num_layers - 1),
-                closest_layer + 1,
-                closest_layer,
-            )
-            ret_val.append(closest_layer)
+            target = target_temp.sel(layer=l)
+            colder = layer_idx > l  # candidates must be strictly colder than source
+            if self.conservative_return_layer:
+                # Warmest strictly-colder layer at/below the target depth (floor),
+                # so the boosted volume is never deposited above its reference
+                # temperature -> the heat pump can never create energy. Fall back
+                # to the bottom layer if none is cold enough.
+                at_or_below = (layer_t <= target) & colder
+                chosen = xr.where(
+                    at_or_below.any(dim="layer"),
+                    at_or_below.argmax(dim="layer"),
+                    self.num_layers - 1,
+                )
+            else:
+                closest_layer = abs(layer_t - target).argmin(dim="layer")
+                chosen = xr.where(
+                    (closest_layer <= l) & (closest_layer < self.num_layers - 1),
+                    closest_layer + 1,
+                    closest_layer,
+                )
+            ret_val.append(chosen)
 
         return xr.concat(
             ret_val, dim=pd.Index(np.arange(self.num_layers), name="layer")
@@ -287,6 +325,97 @@ class PtesApproximator:
     def standing_losses(self) -> float:
         """Tbd."""
         return np.full(self.num_layers, self.design_standing_losses)
+
+    def discharge_free_lunch_warnings(self, tol: float = 0.5) -> list[str]:
+        """
+        Flag nodes whose discretisation risks energy generation on discharge.
+
+        Direct (non-boosted) discharge cools a layer from ``T_layer`` down to the
+        district-heating return temperature and deposits the spent volume at the
+        return-level layer, delivering ``rho*c_p*(T_layer - T_return)`` of heat
+        while debiting the store by ``rho*c_p*(T_layer - T_return_layer)``. If the
+        chosen (nearest) return-level layer sits *above* the actual return
+        temperature (``T_return_layer > T_return``) the discharge creates
+        ``rho*c_p*(T_return_layer - T_return)`` of heat per m3 — a free lunch.
+
+        To stay conservative the layer temperatures should be chosen (in config)
+        so the return-level layer is at or below the return temperature. This
+        returns a human-readable warning per node where that does not hold (empty
+        list if the discretisation is safe everywhere).
+        """
+        layer_t = self.layer_temperatures_da
+        return_t = self.return_temperature
+        # Per-node return temperature reduced to a scalar (mean over time if the
+        # return profile is time-resolved).
+        if self._time_dim in getattr(return_t, "dims", ()):
+            return_t = return_t.mean(dim=self._time_dim)
+        return_layer_t = layer_t.sel(layer=self.return_temp_layer)
+        gap = (return_layer_t - return_t).compute()
+        warnings = []
+        for name in np.atleast_1d(gap["name"].values):
+            g = float(gap.sel(name=name))
+            if g > tol:
+                warnings.append(
+                    f"  {name}: return-level layer {float(return_layer_t.sel(name=name)):.1f} C "
+                    f"> return T {float(return_t.sel(name=name)):.1f} C by {g:.1f} K"
+                )
+        return warnings
+
+    def booster_cop(
+        self,
+        cop_approximator_cls,
+        refrigerant,
+        delta_t_pinch_point,
+        isentropic_compressor_efficiency,
+        heat_loss,
+        min_delta_t_lift,
+    ) -> xr.DataArray:
+        """
+        Per-layer booster COP recomputed at the actual evaporator outlet.
+
+        The build_cop_profiles COP fixes the source outlet a shallow
+        ``heat_source_cooling`` below the inlet. For the PTES booster the spent
+        volume is in fact cooled all the way down to the reinjection
+        (``hp_return``) layer, so the evaporator glide is ``T_source_inlet ->
+        T_deposit``. Recomputing the COP with that outlet makes it reflect the
+        real cooling depth (deeper cooling -> lower COP -> more electricity).
+
+        Energy conservation is unaffected (heat = evaporator + electricity holds
+        for any COP); this only sharpens the electricity/source split. Returns
+        dimensions (layer, time, name).
+        """
+        layer_t = self.layer_temperatures_da
+        ret = self.return_temperature
+        hp_return = self.hp_return_layer  # (layer, name)
+        cops = []
+        for layer in range(self.num_layers):
+            t_layer = float(self.layer_temperatures[layer])
+            # preheater raises the return flow to T_layer when T_layer > T_ret, so
+            # the heat pump source inlet is min(T_layer, T_ret) and its sink inlet
+            # max(T_layer, T_ret).
+            source_inlet = xr.where(ret < t_layer, ret, t_layer)
+            sink_inlet = xr.where(ret < t_layer, t_layer, ret)
+            source_outlet = layer_t.sel(layer=hp_return.sel(layer=layer)).drop_vars(
+                "layer", errors="ignore"
+            )
+            # the evaporator can only cool (deposit at/below the inlet); clamp for
+            # the non-boosted layers whose hp_return value is unused anyway.
+            source_outlet = np.minimum(source_outlet, source_inlet)
+            cop_layer = cop_approximator_cls(
+                sink_outlet_temperature_celsius=self.forward_temperature,
+                sink_inlet_temperature_celsius=sink_inlet,
+                source_inlet_temperature_celsius=source_inlet,
+                source_outlet_temperature_celsius=source_outlet,
+                refrigerant=refrigerant,
+                delta_t_pinch_point=delta_t_pinch_point,
+                isentropic_compressor_efficiency=isentropic_compressor_efficiency,
+                heat_loss=heat_loss,
+                min_delta_t_lift=min_delta_t_lift,
+            ).cop
+            cops.append(cop_layer.drop_vars("layer", errors="ignore"))
+        return xr.concat(
+            cops, dim=pd.Index(np.arange(self.num_layers), name="layer")
+        )
 
     def to_dataset(self) -> xr.Dataset:
         """

--- a/scripts/build_ptes_operations/ptes_approximator.py
+++ b/scripts/build_ptes_operations/ptes_approximator.py
@@ -419,9 +419,7 @@ class PtesApproximator:
                 min_delta_t_lift=min_delta_t_lift,
             ).cop
             cops.append(cop_layer.drop_vars("layer", errors="ignore"))
-        return xr.concat(
-            cops, dim=pd.Index(np.arange(self.num_layers), name="layer")
-        )
+        return xr.concat(cops, dim=pd.Index(np.arange(self.num_layers), name="layer"))
 
     def to_dataset(self) -> xr.Dataset:
         """

--- a/scripts/build_ptes_operations/ptes_approximator.py
+++ b/scripts/build_ptes_operations/ptes_approximator.py
@@ -50,10 +50,16 @@ class PtesApproximator:
 
     @property
     def cop(self):
+        # build_cop_profiles only expands to per-layer "ptes layer {i}" labels when
+        # num_layers > 1; the single-layer build keeps the plain "ptes" source. Fall
+        # back to it here instead of selecting a non-existent "ptes layer 0".
+        def _heat_source(i: int) -> str:
+            return f"ptes layer {i}" if self.num_layers > 1 else "ptes"
+
         return xr.concat(
             [
                 self._cop.sel(
-                    heat_system="urban central", heat_source=f"ptes layer {i}"
+                    heat_system="urban central", heat_source=_heat_source(i)
                 ).drop("heat_source")
                 for i in range(self.num_layers)
             ],

--- a/scripts/build_ptes_operations/run.py
+++ b/scripts/build_ptes_operations/run.py
@@ -49,6 +49,9 @@ import logging
 import xarray as xr
 
 from scripts._helpers import set_scenario_config
+from scripts.build_cop_profiles.central_heating_cop_approximator import (
+    CentralHeatingCopApproximator,
+)
 from scripts.build_ptes_operations.ptes_approximator import PtesApproximator
 
 logger = logging.getLogger(__name__)
@@ -84,7 +87,51 @@ if __name__ == "__main__":
         design_standing_losses=0.0,  # placeholder; actual value set from costs data
         interlayer_heat_transfer_coefficient=snakemake.params.interlayer_heat_transfer_coefficient,
         cop=xr.open_dataarray(snakemake.input.cop_profiles),
+        conservative_return_layer=snakemake.params.conservative_return_layer,
     )
 
-    # Write single dataset with all pre-computed PTES parameters
-    approximator.to_dataset().to_netcdf(snakemake.output.ptes_operations)
+    # Warn if the chosen layer temperatures place the return-level layer above the
+    # actual return temperature, which lets direct discharge create energy. Stay
+    # conservative by configuring a layer at/below the return temperature.
+    free_lunch_warnings = approximator.discharge_free_lunch_warnings()
+    if free_lunch_warnings:
+        logger.warning(
+            "PTES discretisation may create energy on discharge for %d node(s): "
+            "the return-level layer sits ABOVE the district-heating return "
+            "temperature. Add a layer at or below the return temperature in "
+            "sector.district_heating.ptes.layered.layer_temperatures to stay "
+            "conservative.\n%s",
+            len(free_lunch_warnings),
+            "\n".join(free_lunch_warnings),
+        )
+
+    # Write single dataset with all pre-computed PTES parameters, including the
+    # booster COP recomputed at the actual evaporator outlet (the reinjection
+    # layer depth) so the electricity/source split reflects the real cooling depth.
+    dataset = approximator.to_dataset()
+    hp_cop_params = snakemake.params.heat_pump_cop_approximation_central_heating
+    dataset["booster_cop"] = approximator.booster_cop(
+        CentralHeatingCopApproximator,
+        refrigerant=hp_cop_params["refrigerant"],
+        delta_t_pinch_point=hp_cop_params[
+            "heat_exchanger_pinch_point_temperature_difference"
+        ],
+        isentropic_compressor_efficiency=hp_cop_params[
+            "isentropic_compressor_efficiency"
+        ],
+        heat_loss=hp_cop_params["heat_loss"],
+        min_delta_t_lift=hp_cop_params["min_delta_t_lift"],
+    )
+    # Clear inherited encodings (the booster COP carries the temperature profile's
+    # time encoding, which can conflict with the dataset's and overflow on decode)
+    # and write the time axis with an explicit, safe reference so it round-trips.
+    for name in list(dataset.variables):
+        dataset[name].encoding.clear()
+    encoding = {}
+    if "time" in dataset.coords:
+        encoding["time"] = {
+            "units": "hours since 1900-01-01 00:00:00",
+            "calendar": "proleptic_gregorian",
+            "dtype": "int64",
+        }
+    dataset.to_netcdf(snakemake.output.ptes_operations, encoding=encoding)

--- a/scripts/build_ptes_operations/run.py
+++ b/scripts/build_ptes_operations/run.py
@@ -108,20 +108,24 @@ if __name__ == "__main__":
     # Write single dataset with all pre-computed PTES parameters, including the
     # booster COP recomputed at the actual evaporator outlet (the reinjection
     # layer depth) so the electricity/source split reflects the real cooling depth.
+    # The booster COP only feeds the layered (num_layers > 1) discharge chain; the
+    # single-tank case never uses it, so skip it there (its per-layer source lookup
+    # would also be meaningless with one layer).
     dataset = approximator.to_dataset()
-    hp_cop_params = snakemake.params.heat_pump_cop_approximation_central_heating
-    dataset["booster_cop"] = approximator.booster_cop(
-        CentralHeatingCopApproximator,
-        refrigerant=hp_cop_params["refrigerant"],
-        delta_t_pinch_point=hp_cop_params[
-            "heat_exchanger_pinch_point_temperature_difference"
-        ],
-        isentropic_compressor_efficiency=hp_cop_params[
-            "isentropic_compressor_efficiency"
-        ],
-        heat_loss=hp_cop_params["heat_loss"],
-        min_delta_t_lift=hp_cop_params["min_delta_t_lift"],
-    )
+    if approximator.num_layers > 1:
+        hp_cop_params = snakemake.params.heat_pump_cop_approximation_central_heating
+        dataset["booster_cop"] = approximator.booster_cop(
+            CentralHeatingCopApproximator,
+            refrigerant=hp_cop_params["refrigerant"],
+            delta_t_pinch_point=hp_cop_params[
+                "heat_exchanger_pinch_point_temperature_difference"
+            ],
+            isentropic_compressor_efficiency=hp_cop_params[
+                "isentropic_compressor_efficiency"
+            ],
+            heat_loss=hp_cop_params["heat_loss"],
+            min_delta_t_lift=hp_cop_params["min_delta_t_lift"],
+        )
     # Clear inherited encodings (the booster COP carries the temperature profile's
     # time encoding, which can conflict with the dataset's and overflow on decode)
     # and write the time axis with an explicit, safe reference so it round-trips.

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3274,11 +3274,17 @@ def add_heat(
                     )
                     t_ret = layer_t[ret_idx.values]
                     t_boost = layer_t[boost_idx.values]
-                    direct_drop = np.clip(t_layer - t_ret, 0.0, None)  # delivered direct
+                    direct_drop = np.clip(
+                        t_layer - t_ret, 0.0, None
+                    )  # delivered direct
                     extract_dt = np.clip(t_layer - t_boost, 0.0, None)  # total released
-                    below_drop = np.clip(extract_dt - direct_drop, 0.0, None)  # evaporator
+                    below_drop = np.clip(
+                        extract_dt - direct_drop, 0.0, None
+                    )  # evaporator
                     with np.errstate(divide="ignore", invalid="ignore"):
-                        direct_frac = np.where(extract_dt > 0, direct_drop / extract_dt, 0.0)
+                        direct_frac = np.where(
+                            extract_dt > 0, direct_drop / extract_dt, 0.0
+                        )
                         hp_frac = np.where(extract_dt > 0, below_drop / extract_dt, 0.0)
                     direct_drop = pd.Series(direct_drop, index=nodes)
                     extract_dt = pd.Series(extract_dt, index=nodes)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2877,9 +2877,7 @@ def add_heat(
         # 1e3 converts from W/m^2 to MW/(1000m^2) = kW/m^2
         solar_thermal = options["solar_cf_correction"] * solar_thermal / 1e3
 
-    for (
-        heat_system
-    ) in (
+    for heat_system in (
         HeatSystem
     ):  # this loops through all heat systems defined in _entities.HeatSystem
         overdim_factor = options["overdimension_heat_generators"][
@@ -3770,18 +3768,14 @@ def add_heat(
                     bus0=heat_source.resource_bus(nodes, heat_system),
                     bus1=nodes + f" {heat_system} heat",
                     bus2=nodes + f" {heat_source.intermediate_carrier(heat_system)}",
-                    efficiency=(
-                        1 + boosting_profile / cop_heat_pump
-                        if heat_source.supports_preheating
-                        else 0
-                    ),
-                    efficiency2=(
-                        -boosting_profile
-                        * cop_heat_pump
-                        / (boosting_profile + cop_heat_pump)
-                        if heat_source.supports_preheating
-                        else 1
-                    ),
+                    efficiency=1 + boosting_profile / cop_heat_pump
+                    if heat_source.supports_preheating
+                    else 0,
+                    efficiency2=-boosting_profile
+                    * cop_heat_pump
+                    / (boosting_profile + cop_heat_pump)
+                    if heat_source.supports_preheating
+                    else 1,
                     carrier=f"{heat_system} {heat_source} heat utilisation",
                     p_nom_extendable=True,
                 )
@@ -6439,9 +6433,9 @@ def add_enhanced_geothermal(
         * Nyears
     )
 
-    assert (
-        egs_potentials["capital_cost"] > 0
-    ).all(), "Error in EGS cost, negative values found."
+    assert (egs_potentials["capital_cost"] > 0).all(), (
+        "Error in EGS cost, negative values found."
+    )
 
     orc_annuity = calculate_annuity(costs.at["organic rankine cycle", "lifetime"], dr)
     orc_capital_cost = (orc_annuity + FOM / (1 + FOM)) * orc_capex * Nyears

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2877,7 +2877,9 @@ def add_heat(
         # 1e3 converts from W/m^2 to MW/(1000m^2) = kW/m^2
         solar_thermal = options["solar_cf_correction"] * solar_thermal / 1e3
 
-    for heat_system in (
+    for (
+        heat_system
+    ) in (
         HeatSystem
     ):  # this loops through all heat systems defined in _entities.HeatSystem
         overdim_factor = options["overdimension_heat_generators"][
@@ -3090,6 +3092,8 @@ def add_heat(
             n.add("Carrier", f"{heat_system} water pits")
             n.add("Carrier", f"{heat_system} ptes preheater")
             n.add("Carrier", f"{heat_system} ptes hp input")
+            n.add("Carrier", f"{heat_system} ptes hp source")
+            n.add("Carrier", f"{heat_system} ptes hp inlet")
 
             ptes_ds = xr.open_dataset(ptes_operations_file)
             num_layers = int(ptes_ds.attrs["num_layers"])
@@ -3099,15 +3103,15 @@ def add_heat(
             ]
             e_max_pu = float(ptes_ds["e_max_pu"])
 
-            # return_layer_by_node = ptes_ds["return_layer_index"].to_pandas().astype(int)
-            # return_temperature_layer = pd.Series(
-            #     [
-            #         f"{node} {heat_system} water pits"
-            #         + (f" layer {layer_idx}" if num_layers > 1 else "")
-            #         for node, layer_idx in return_layer_by_node.items()
-            #     ],
-            #     index=return_layer_by_node.index,
-            # ).reindex(nodes)
+            # Bottom-referenced energy density per layer [MWh/m3] and the per-node
+            # return-temperature layer index. Both feed the mass-conserving
+            # volume-trade charger below: charging raises 1 m3 from a colder
+            # source layer s up to a hotter destination layer, drawing
+            # rho*c_p*(T_dest - T_s) = m3_to_mwh[dest] - m3_to_mwh[s] of DH heat.
+            m3_to_mwh = ptes_ds["m3_to_mwh"]  # (layer,)
+            return_layer_index = (
+                ptes_ds["return_temperature_layer"].to_pandas().astype(int)
+            )  # (name,)
 
             for layer in range(num_layers):
                 layer_suffix = f" layer {layer}" if num_layers > 1 else ""
@@ -3134,126 +3138,378 @@ def add_heat(
                     unit="m3",
                 )
 
-                n.add(
-                    "Bus",
-                    nodes + f" {heat_system} ptes hp input{layer_suffix}",
-                    location=nodes,
-                    carrier=f"{heat_system} ptes hp input",
-                    unit="m3",
-                )
-
-                n.add(
-                    "Link",
-                    nodes,
-                    suffix=f" {heat_system} water pits charger{layer_suffix}",
-                    bus0=nodes + f" {heat_system} heat",
-                    bus1=nodes + f" {heat_system} water pits{layer_suffix}",
-                    efficiency=charger_efficiency,
-                    carrier=f"{heat_system} water pits charger{layer_suffix}",
-                    p_nom_extendable=True,
-                    lifetime=costs.at["central water pit storage", "lifetime"],
-                    marginal_cost=costs.at[
-                        "central water pit charger", "marginal_cost"
-                    ],
-                    p_max_pu=ptes_ds["charging_availability"]
-                    .sel(layer=layer)
-                    .to_pandas(),
-                )
-
-                n.add(
-                    "Link",
-                    nodes,
-                    suffix=f" {heat_system} water pits discharger{layer_suffix}",
-                    bus0=nodes + f" {heat_system} water pits{layer_suffix}",
-                    bus1=nodes + f" {heat_system} ptes preheater{layer_suffix}",
-                    carrier=f"{heat_system} water pits discharger{layer_suffix}",
-                    efficiency=1,
-                    marginal_cost=costs.at[
-                        "central water pit discharger", "marginal_cost"
-                    ],
-                    p_nom_extendable=True,
-                    p_max_pu=0 if layer == num_layers - 1 else 1,
-                    lifetime=costs.at["central water pit storage", "lifetime"],
-                )
-
-                needs_boosting = ptes_ds["layer_needs_boosting"].sel(layer=layer)
-
-                preheater_return_layer = (
-                    nodes
-                    + f" {heat_system} water pits layer "
-                    + ptes_ds["preheater_return_layer"]
-                    .sel(layer=layer)
-                    .to_pandas()
-                    .astype(int)
-                    .astype(str)
-                )
-
-                n.add(
-                    "Link",
-                    nodes,
-                    suffix=f" {heat_system} ptes preheater{layer_suffix}",
-                    bus0=nodes + f" {heat_system} ptes preheater{layer_suffix}",
-                    bus1=nodes + f" {heat_system} heat",
-                    bus2=nodes + f" {heat_system} ptes hp input{layer_suffix}",
-                    bus3=preheater_return_layer,
-                    efficiency=preheater_efficiency.to_pandas(),
-                    efficiency2=needs_boosting.to_pandas(),
-                    efficiency3=(1 - needs_boosting).to_pandas(),
-                    p_nom_extendable=True,
-                    carrier=f"{heat_system} ptes preheater{layer_suffix}",
-                )
-
-                heat_source = HeatSource(f"ptes{layer_suffix}")
-                cop_heat_pump = (
-                    cop.sel(
-                        heat_system=heat_system.system_type.value,
-                        heat_source=heat_source.value,
-                        name=nodes,
+                if num_layers > 1:
+                    # Energy-carrying buses of the layered discharge chain: the
+                    # hp-source bus collects the full enthalpy released by the
+                    # discharged volume (rho*c_p*(T_layer - T_deposit)); the
+                    # hp-inlet bus carries the sub-return (evaporator) part fed to
+                    # the booster. Both in MWh (the volume is tracked separately on
+                    # the water-pit layer buses).
+                    n.add(
+                        "Bus",
+                        nodes + f" {heat_system} ptes hp source{layer_suffix}",
+                        location=nodes,
+                        carrier=f"{heat_system} ptes hp source",
+                        unit="MWh",
                     )
-                    .transpose("time", "name")
-                    .to_pandas()
-                    .clip(lower=0.001)
-                )
+                    n.add(
+                        "Bus",
+                        nodes + f" {heat_system} ptes hp inlet{layer_suffix}",
+                        location=nodes,
+                        carrier=f"{heat_system} ptes hp inlet",
+                        unit="MWh",
+                    )
+                else:
+                    n.add(
+                        "Bus",
+                        nodes + f" {heat_system} ptes hp input{layer_suffix}",
+                        location=nodes,
+                        carrier=f"{heat_system} ptes hp input",
+                        unit="m3",
+                    )
 
-                heat_pump_efficiency = (
-                    ptes_ds["heat_pump_efficiency"]
-                    .sel(layer=layer)
-                    .transpose("time", "name")
-                    .to_pandas()
-                    .clip(lower=0.001)
-                )
+                if num_layers > 1:
+                    # Volume-trade chargers (mass-conserving): one link per colder
+                    # source layer s, raising 1 m3 from layer s up to this hotter
+                    # destination layer and drawing rho*c_p*(T_dest - T_s) of DH
+                    # heat. Heat drawn == bottom-referenced stored-energy gained, so
+                    # charging neither creates nor destroys energy (no free lunch)
+                    # and conserves volume. This replaces the create-volume charger
+                    # plus the per-layer vents and bottom fresh-water generator.
+                    # Destination charging availability, reindexed to the exact
+                    # node order passed to n.add (PyPSA requires the p_max_pu
+                    # columns to align positionally with the component names).
+                    charging_availability = (
+                        ptes_ds["charging_availability"]
+                        .sel(layer=layer)
+                        .to_pandas()
+                        .reindex(columns=nodes)
+                        .astype(float)
+                        .fillna(0.0)
+                    )
+                    for source in range(layer + 1, num_layers):
+                        # Active only for nodes whose return level sits between the
+                        # hot destination (exclusive) and the cold source
+                        # (inclusive): destination above return (layer < ret_layer)
+                        # and source at/below return (source >= ret_layer).
+                        valid = (return_layer_index > layer) & (
+                            return_layer_index <= source
+                        )
+                        if not valid.any():
+                            continue
+                        charger_efficiency_trade = 1.0 / (
+                            m3_to_mwh.sel(layer=layer).item()
+                            - m3_to_mwh.sel(layer=source).item()
+                        )
+                        # Gate by availability and zero the nodes for which this
+                        # (dest, source) pair is invalid, keeping the node column
+                        # order intact.
+                        availability = charging_availability.copy()
+                        valid_nodes = valid.reindex(nodes).fillna(False).to_numpy()
+                        availability.loc[:, ~valid_nodes] = 0.0
+                        charger_name = (
+                            nodes
+                            + f" {heat_system} water pits charger{layer_suffix} from layer {source}"
+                        )
+                        n.add(
+                            "Link",
+                            nodes,
+                            suffix=f" {heat_system} water pits charger{layer_suffix} from layer {source}",
+                            bus0=nodes + f" {heat_system} heat",
+                            bus1=nodes + f" {heat_system} water pits{layer_suffix}",
+                            efficiency=charger_efficiency_trade,
+                            bus2=nodes + f" {heat_system} water pits layer {source}",
+                            efficiency2=-charger_efficiency_trade,
+                            carrier=f"{heat_system} water pits charger{layer_suffix}",
+                            p_nom_extendable=True,
+                            lifetime=costs.at["central water pit storage", "lifetime"],
+                            marginal_cost=costs.at[
+                                "central water pit charger", "marginal_cost"
+                            ],
+                            p_max_pu=availability,
+                        )
+                        n.links.loc[charger_name, "energy to power ratio"] = (
+                            energy_to_power_ratio_water_pit
+                        )
+                else:
+                    n.add(
+                        "Link",
+                        nodes,
+                        suffix=f" {heat_system} water pits charger{layer_suffix}",
+                        bus0=nodes + f" {heat_system} heat",
+                        bus1=nodes + f" {heat_system} water pits{layer_suffix}",
+                        efficiency=charger_efficiency,
+                        carrier=f"{heat_system} water pits charger{layer_suffix}",
+                        p_nom_extendable=True,
+                        lifetime=costs.at["central water pit storage", "lifetime"],
+                        marginal_cost=costs.at[
+                            "central water pit charger", "marginal_cost"
+                        ],
+                        p_max_pu=ptes_ds["charging_availability"]
+                        .sel(layer=layer)
+                        .to_pandas(),
+                    )
 
-                hp_return_layer = (
-                    nodes
-                    + f" {heat_system} water pits layer "
-                    + ptes_ds["hp_return_layer"]
-                    .sel(layer=layer)
-                    .to_pandas()
-                    .astype(int)
-                    .astype(str)
-                )
-                n.add(
-                    "Link",
-                    nodes,
-                    suffix=f" {heat_system} {heat_source} heat pump",
-                    bus0=nodes + f" {heat_system} heat",
-                    bus1=nodes,
-                    bus2=nodes + f" {heat_system} ptes hp input{layer_suffix}",
-                    bus3=hp_return_layer,
-                    efficiency=1 / cop_heat_pump,
-                    efficiency2=1 / heat_pump_efficiency,
-                    efficiency3=-1 / heat_pump_efficiency,
-                    capital_cost=0,
-                    p_min_pu=-needs_boosting.to_pandas(),
-                    p_max_pu=0,
-                    p_nom_extendable=True,
-                    carrier=f"{heat_system} {heat_source} heat pump",
-                )
+                if num_layers > 1:
+                    # ----- Mass- and energy-consistent layered discharge -----
+                    # (mirrors the toy-model recharge structure). The discharged
+                    # volume is moved to the return-level layer and, when boosting
+                    # is needed, further down to the reinjection layer; the released
+                    # enthalpy is delivered partly directly to DH and partly (the
+                    # sub-return part) through the booster heat pump. Every term
+                    # references the DISCRETE deposit layers, so delivered minus
+                    # electricity equals the bottom-referenced store debit exactly
+                    # (tidy energy + volume balances, no free lunch).
+                    layer_t = ptes_ds["layer_temperatures"].values
+                    rho_cp = float(
+                        ptes_ds["m3_to_mwh"].sel(layer=0).item()
+                        / (layer_t[0] - layer_t[-1])
+                    )
+                    t_layer = float(layer_t[layer])
+                    ret_idx = return_layer_index.reindex(nodes)
+                    boost_idx = (
+                        ptes_ds["hp_return_layer"]
+                        .sel(layer=layer)
+                        .to_pandas()
+                        .astype(int)
+                        .reindex(nodes)
+                    )
+                    t_ret = layer_t[ret_idx.values]
+                    t_boost = layer_t[boost_idx.values]
+                    direct_drop = np.clip(t_layer - t_ret, 0.0, None)  # delivered direct
+                    extract_dt = np.clip(t_layer - t_boost, 0.0, None)  # total released
+                    below_drop = np.clip(extract_dt - direct_drop, 0.0, None)  # evaporator
+                    with np.errstate(divide="ignore", invalid="ignore"):
+                        direct_frac = np.where(extract_dt > 0, direct_drop / extract_dt, 0.0)
+                        hp_frac = np.where(extract_dt > 0, below_drop / extract_dt, 0.0)
+                    direct_drop = pd.Series(direct_drop, index=nodes)
+                    extract_dt = pd.Series(extract_dt, index=nodes)
+                    direct_frac = pd.Series(direct_frac, index=nodes)
+                    hp_frac = pd.Series(hp_frac, index=nodes)
+                    return_layer_bus = (
+                        nodes
+                        + f" {heat_system} water pits layer "
+                        + ret_idx.astype(str)
+                    )
+                    boost_layer_bus = (
+                        nodes
+                        + f" {heat_system} water pits layer "
+                        + boost_idx.astype(str)
+                    )
+                    nb = (
+                        ptes_ds["layer_needs_boosting"]
+                        .sel(layer=layer)
+                        .transpose("time", "name")
+                        .to_pandas()
+                        .reindex(columns=nodes)
+                    )
+                    if "booster_cop" in ptes_ds:
+                        cop_booster = (
+                            ptes_ds["booster_cop"]
+                            .sel(layer=layer, name=nodes)
+                            .transpose("time", "name")
+                            .to_pandas()
+                            .clip(lower=1.0 + 1e-3)
+                        )
+                    else:
+                        cop_booster = (
+                            cop.sel(
+                                heat_system=heat_system.system_type.value,
+                                heat_source=HeatSource(f"ptes{layer_suffix}").value,
+                                name=nodes,
+                            )
+                            .transpose("time", "name")
+                            .to_pandas()
+                            .clip(lower=1.0 + 1e-3)
+                        )
 
-                n.links.loc[
-                    nodes + f" {heat_system} water pits charger{layer_suffix}",
-                    "energy to power ratio",
-                ] = energy_to_power_ratio_water_pit
+                    # Discharger: layer -> return-level layer (+1 m3) + preheater
+                    # token (+1) tracking the discharged volume.
+                    n.add(
+                        "Link",
+                        nodes,
+                        suffix=f" {heat_system} water pits discharger{layer_suffix}",
+                        bus0=nodes + f" {heat_system} water pits{layer_suffix}",
+                        bus1=return_layer_bus,
+                        bus2=nodes + f" {heat_system} ptes preheater{layer_suffix}",
+                        efficiency=1.0,
+                        efficiency2=1.0,
+                        carrier=f"{heat_system} water pits discharger{layer_suffix}",
+                        marginal_cost=costs.at[
+                            "central water pit discharger", "marginal_cost"
+                        ],
+                        p_nom_extendable=True,
+                        p_max_pu=0 if layer == num_layers - 1 else 1,
+                        lifetime=costs.at["central water pit storage", "lifetime"],
+                    )
+
+                    # Direct utilisation (no boost): preheater token -> DH heat at
+                    # rho*c_p*(T_layer - T_return_layer); active when the layer
+                    # serves forward directly (1 - needs_boosting).
+                    n.add(
+                        "Link",
+                        nodes,
+                        suffix=f" {heat_system} water pits direct util{layer_suffix}",
+                        bus0=nodes + f" {heat_system} ptes preheater{layer_suffix}",
+                        bus1=nodes + f" {heat_system} heat",
+                        efficiency=rho_cp * direct_drop,
+                        carrier=f"{heat_system} water pits direct util{layer_suffix}",
+                        p_nom_extendable=True,
+                        p_max_pu=1.0 - nb,
+                    )
+
+                    # Boost multilink: consume the preheater token, move the volume
+                    # from the return layer down to the reinjection layer, and
+                    # release the full enthalpy rho*c_p*(T_layer - T_boost_layer)
+                    # onto the hp-source bus; active when boosting is needed.
+                    n.add(
+                        "Link",
+                        nodes,
+                        suffix=f" {heat_system} water pits boost{layer_suffix}",
+                        bus0=nodes + f" {heat_system} ptes preheater{layer_suffix}",
+                        bus1=return_layer_bus,
+                        bus2=boost_layer_bus,
+                        bus3=nodes + f" {heat_system} ptes hp source{layer_suffix}",
+                        efficiency=-1.0,
+                        efficiency2=1.0,
+                        efficiency3=rho_cp * extract_dt,
+                        carrier=f"{heat_system} water pits boost{layer_suffix}",
+                        p_nom_extendable=True,
+                        p_max_pu=nb,
+                    )
+
+                    # Heat-exchanger split: hp-source energy -> direct DH part
+                    # (above return) + evaporator part (sub-return) to the booster.
+                    n.add(
+                        "Link",
+                        nodes,
+                        suffix=f" {heat_system} water pits hx{layer_suffix}",
+                        bus0=nodes + f" {heat_system} ptes hp source{layer_suffix}",
+                        bus1=nodes + f" {heat_system} heat",
+                        bus2=nodes + f" {heat_system} ptes hp inlet{layer_suffix}",
+                        efficiency=direct_frac,
+                        efficiency2=hp_frac,
+                        carrier=f"{heat_system} water pits hx{layer_suffix}",
+                        p_nom_extendable=True,
+                    )
+
+                    # Booster heat pump: lift the evaporator heat to DH consuming
+                    # electricity (q_out = evaporator*COP/(COP-1), elec = q_out/COP).
+                    # Oriented bus0 = heat with p <= 0, so p_nom is the MW_th rating.
+                    # NB electricity must be on bus1 (the distribution-grid rewiring
+                    # in add_heat keys off bus1 for heat-pump electricity); the
+                    # evaporator (hp-inlet) goes on bus2.
+                    n.add(
+                        "Link",
+                        nodes,
+                        suffix=f" {heat_system} ptes{layer_suffix} heat pump",
+                        bus0=nodes + f" {heat_system} heat",
+                        bus1=nodes,
+                        bus2=nodes + f" {heat_system} ptes hp inlet{layer_suffix}",
+                        efficiency=1.0 / cop_booster,
+                        efficiency2=(cop_booster - 1.0) / cop_booster,
+                        capital_cost=0,
+                        p_min_pu=-nb,
+                        p_max_pu=0,
+                        p_nom_extendable=True,
+                        carrier=f"{heat_system} ptes{layer_suffix} heat pump",
+                    )
+                else:
+                    n.add(
+                        "Link",
+                        nodes,
+                        suffix=f" {heat_system} water pits discharger{layer_suffix}",
+                        bus0=nodes + f" {heat_system} water pits{layer_suffix}",
+                        bus1=nodes + f" {heat_system} ptes preheater{layer_suffix}",
+                        carrier=f"{heat_system} water pits discharger{layer_suffix}",
+                        efficiency=1,
+                        marginal_cost=costs.at[
+                            "central water pit discharger", "marginal_cost"
+                        ],
+                        p_nom_extendable=True,
+                        p_max_pu=0 if layer == num_layers - 1 else 1,
+                        lifetime=costs.at["central water pit storage", "lifetime"],
+                    )
+
+                    needs_boosting = ptes_ds["layer_needs_boosting"].sel(layer=layer)
+
+                    preheater_return_layer = (
+                        nodes
+                        + f" {heat_system} water pits layer "
+                        + ptes_ds["preheater_return_layer"]
+                        .sel(layer=layer)
+                        .to_pandas()
+                        .astype(int)
+                        .astype(str)
+                    )
+
+                    n.add(
+                        "Link",
+                        nodes,
+                        suffix=f" {heat_system} ptes preheater{layer_suffix}",
+                        bus0=nodes + f" {heat_system} ptes preheater{layer_suffix}",
+                        bus1=nodes + f" {heat_system} heat",
+                        bus2=nodes + f" {heat_system} ptes hp input{layer_suffix}",
+                        bus3=preheater_return_layer,
+                        efficiency=preheater_efficiency.to_pandas(),
+                        efficiency2=needs_boosting.to_pandas(),
+                        efficiency3=(1 - needs_boosting).to_pandas(),
+                        p_nom_extendable=True,
+                        carrier=f"{heat_system} ptes preheater{layer_suffix}",
+                    )
+
+                    heat_source = HeatSource(f"ptes{layer_suffix}")
+                    cop_heat_pump = (
+                        cop.sel(
+                            heat_system=heat_system.system_type.value,
+                            heat_source=heat_source.value,
+                            name=nodes,
+                        )
+                        .transpose("time", "name")
+                        .to_pandas()
+                        .clip(lower=0.001)
+                    )
+
+                    heat_pump_efficiency = (
+                        ptes_ds["heat_pump_efficiency"]
+                        .sel(layer=layer)
+                        .transpose("time", "name")
+                        .to_pandas()
+                        .clip(lower=0.001)
+                    )
+
+                    hp_return_layer = (
+                        nodes
+                        + f" {heat_system} water pits layer "
+                        + ptes_ds["hp_return_layer"]
+                        .sel(layer=layer)
+                        .to_pandas()
+                        .astype(int)
+                        .astype(str)
+                    )
+                    n.add(
+                        "Link",
+                        nodes,
+                        suffix=f" {heat_system} {heat_source} heat pump",
+                        bus0=nodes + f" {heat_system} heat",
+                        bus1=nodes,
+                        bus2=nodes + f" {heat_system} ptes hp input{layer_suffix}",
+                        bus3=hp_return_layer,
+                        efficiency=1 / cop_heat_pump,
+                        efficiency2=1 / heat_pump_efficiency,
+                        efficiency3=-1 / heat_pump_efficiency,
+                        capital_cost=0,
+                        p_min_pu=-needs_boosting.to_pandas(),
+                        p_max_pu=0,
+                        p_nom_extendable=True,
+                        carrier=f"{heat_system} {heat_source} heat pump",
+                    )
+
+                if num_layers == 1:
+                    n.links.loc[
+                        nodes + f" {heat_system} water pits charger{layer_suffix}",
+                        "energy to power ratio",
+                    ] = energy_to_power_ratio_water_pit
                 n.add(
                     "Store",
                     nodes,
@@ -3262,10 +3518,20 @@ def add_heat(
                     e_initial=0,
                     e_nom_extendable=True,
                     carrier=f"{heat_system} water pits{layer_suffix}",
-                    standing_loss=costs.at[
-                        "central water pit storage", "standing_losses"
-                    ]
-                    / 100,
+                    # With the mass-conserving volume-trade charger (num_layers > 1)
+                    # the per-layer standing loss is carried entirely by the
+                    # interlayer-flow constraint (downward volume flux). A PyPSA
+                    # store standing_loss would both double-count that loss and
+                    # destroy volume, which under e_cyclic forces Sigma_l e_l -> 0
+                    # (an empty PTES). The single-tank case (num_layers == 1) has no
+                    # interlayer channel, so it keeps the PyPSA standing loss.
+                    standing_loss=(
+                        0.0
+                        if num_layers > 1
+                        else costs.at["central water pit storage", "standing_losses"]
+                        / 100
+                    ),
+                    e_cyclic=True,
                 )
 
                 # Inter-layer links: bidirectional flow between adjacent layers
@@ -3281,19 +3547,24 @@ def add_heat(
                         p_nom_extendable=True,
                     )
 
-                n.add(
-                    "Generator",
-                    nodes + f" {heat_system} ptes{layer_suffix} vent",
-                    bus=nodes + f" {heat_system} water pits{layer_suffix}",
-                    location=nodes,
-                    carrier=f"{heat_system} water pits",
-                    unit="m3",
-                    p_max_pu=0,
-                    p_min_pu=-1,
-                    marginal_cost=-1,
-                    p_nom_extendable=True,
-                )
-            if layer == num_layers - 1:
+                # Vents and the bottom fresh-water generator only exist for the
+                # single-tank case. With the volume-trade charger (num_layers > 1)
+                # volume is strictly conserved, so free volume creation/destruction
+                # (the source of the workflow free lunch) is removed.
+                if num_layers == 1:
+                    n.add(
+                        "Generator",
+                        nodes + f" {heat_system} ptes{layer_suffix} vent",
+                        bus=nodes + f" {heat_system} water pits{layer_suffix}",
+                        location=nodes,
+                        carrier=f"{heat_system} water pits",
+                        unit="m3",
+                        p_max_pu=0,
+                        p_min_pu=-1,
+                        marginal_cost=-1,
+                        p_nom_extendable=True,
+                    )
+            if num_layers == 1:
                 n.add(
                     "Generator",
                     nodes + f" {heat_system} ptes bottom layer water",
@@ -3499,14 +3770,18 @@ def add_heat(
                     bus0=heat_source.resource_bus(nodes, heat_system),
                     bus1=nodes + f" {heat_system} heat",
                     bus2=nodes + f" {heat_source.intermediate_carrier(heat_system)}",
-                    efficiency=1 + boosting_profile / cop_heat_pump
-                    if heat_source.supports_preheating
-                    else 0,
-                    efficiency2=-boosting_profile
-                    * cop_heat_pump
-                    / (boosting_profile + cop_heat_pump)
-                    if heat_source.supports_preheating
-                    else 1,
+                    efficiency=(
+                        1 + boosting_profile / cop_heat_pump
+                        if heat_source.supports_preheating
+                        else 0
+                    ),
+                    efficiency2=(
+                        -boosting_profile
+                        * cop_heat_pump
+                        / (boosting_profile + cop_heat_pump)
+                        if heat_source.supports_preheating
+                        else 1
+                    ),
                     carrier=f"{heat_system} {heat_source} heat utilisation",
                     p_nom_extendable=True,
                 )
@@ -6164,9 +6439,9 @@ def add_enhanced_geothermal(
         * Nyears
     )
 
-    assert (egs_potentials["capital_cost"] > 0).all(), (
-        "Error in EGS cost, negative values found."
-    )
+    assert (
+        egs_potentials["capital_cost"] > 0
+    ).all(), "Error in EGS cost, negative values found."
 
     orc_annuity = calculate_annuity(costs.at["organic rankine cycle", "lifetime"], dr)
     orc_capital_cost = (orc_annuity + FOM / (1 + FOM)) * orc_capex * Nyears

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1136,6 +1136,10 @@ def add_layered_ptes_aggregate_throughput_constraint(
         n.links.index.str.contains("water pits charger")
         & n.links.index.str.contains("layer")
     ]
+    layer_dischargers = n.links.index[
+        n.links.index.str.contains("water pits discharger")
+        & n.links.index.str.contains("layer")
+    ]
     agg_stores = n.stores.index[
         n.stores.index.str.contains("water pits")
         & ~n.stores.index.str.contains("layer")
@@ -1146,23 +1150,29 @@ def add_layered_ptes_aggregate_throughput_constraint(
     for agg in agg_stores:
         prefix = agg.split("water pits")[0] + "water pits"
 
+        # The volume-trade charger uses several links per destination layer
+        # (one per colder source layer, named "... charger layer {n} from
+        # layer {s}"), so there is no 1:1 charger<->discharger mapping. Sum the
+        # heat drawn over *all* chargers (already in energy units) and the
+        # energy-equivalent volume over *all* dischargers.
         chargers = layer_chargers[layer_chargers.str.startswith(prefix + " charger")]
-        dischargers = pd.Index(
-            [c.replace(" charger ", " discharger ") for c in chargers]
-        ).intersection(n.links.index)
+        dischargers = layer_dischargers[
+            layer_dischargers.str.startswith(prefix + " discharger")
+        ]
         if chargers.empty or dischargers.empty:
             continue
 
         e2p_ratio = n.links.at[chargers[0], "energy to power ratio"]
 
         weighted_sum = None
-        for ch, dis in zip(chargers, dischargers):
-            layer_idx = int(ch.rsplit("layer ", 1)[-1])
-            m3_to_mwh = float(ptes_ds["m3_to_mwh"].sel(layer=layer_idx).item())
-            term = (
-                n.model["Link-p"].loc[:, ch] + m3_to_mwh * n.model["Link-p"].loc[:, dis]
-            )
+        for ch in chargers:
+            term = n.model["Link-p"].loc[:, ch]
             weighted_sum = term if weighted_sum is None else weighted_sum + term
+        for dis in dischargers:
+            layer_idx = int(dis.rsplit("layer ", 1)[-1])
+            m3_to_mwh = float(ptes_ds["m3_to_mwh"].sel(layer=layer_idx).item())
+            term = m3_to_mwh * n.model["Link-p"].loc[:, dis]
+            weighted_sum = weighted_sum + term
 
         agg_e_nom = n.model["Store-e_nom"].loc[agg]
         constraints.append(weighted_sum - e2p_ratio * agg_e_nom)


### PR DESCRIPTION
# Layered-PTES model notes — formulation, wiring, and the comparison with Amos' model

This documents the **current, energy-exact layered-PTES model** (the toy's
`recharge` model, now also ported into PyPSA-Eur:
`scripts/prepare_sector_network.py`, `scripts/build_ptes_operations/`,
`scripts/solve_network.py`) and compares it, component by component, with the
**Amos model** from PyPSA-Eur PR
[#2129](https://github.com/PyPSA/pypsa-eur/pull/2129) ("feat: layered ptes
model"), which the port replaces.

The two models share the same idea — a stack of fixed-temperature water layers
(one PyPSA `Store` per layer, volume in m³, energy density
`m3_to_mwh[l] = ρc_p(T_l − T_bottom)`) charged from and discharged to the
urban-central heat bus, with a booster heat pump for sub-forward layers. They
differ in **how volume and energy are tracked**, and that difference is the whole
story: the current model conserves both exactly, Amos's creates energy on
discharge.

---

## 1. Preliminaries — energy reference, temperatures, ΔT and COP

### 1a. Notation and the "bottom-referenced store debit"

| symbol | meaning |
|---|---|
| `T_l` | fixed temperature of layer `l` (exogenous, hottest-first) |
| `T_bottom` | coldest (bottom) layer temperature |
| `T_ret`, `T_fwd` | DH return / forward temperature (per node, time-varying) |
| `T_retL` | temperature of the discrete **return-level layer** (the layer chosen to represent the return) |
| `T_boost` | temperature of the discrete **reinjection / boost-deposit layer** (where boosted, cooled water is put back; = layer `hp_return_layer`) |
| `e_l` | state of charge of layer `l`'s `Store` **in m³** |
| `Δ(a,b)` | `ρc_p(T_a − T_b)` — enthalpy per m³ between two temperatures [MWh/m³] |

A layer `Store` holds **volume** (m³), not energy. Each layer is given a fixed
**energy density measured relative to the bottom layer**,

```
m3_to_mwh[l] = ρc_p (T_l − T_bottom)         (so m3_to_mwh[bottom] = 0)
```

so the energy content of the whole PTES is the *bottom-referenced* sum
`E = Σ_l m3_to_mwh[l]·e_l`. The choice of reference is arbitrary because every
operation only **moves** volume between layers: moving 1 m³ from layer `a` to
layer `b` changes `E` by `m3_to_mwh[a] − m3_to_mwh[b] = ρc_p(T_a − T_b) = Δ(a,b)`,
in which the bottom term cancels. We call that change the **store debit** (when
`E` falls, on discharge) or **store credit** (when `E` rises, on charge). The
whole point of the current model is that, on every operation,

```
heat drawn from DH (charge)        =  store credit                          (charge)
heat delivered to DH − electricity =  store debit  =  Σ Δ(from, to) per m³   (discharge)
```

i.e. delivered useful energy is backed *exactly* by a bottom-referenced volume
relocation, with no leftover.

### 1b. The heat-pump output relation (shared, and correct in both models)

A discharged m³ of layer water at `T_src` gives up heat as it cools. Part is
delivered **directly** (heating the DH return up to `T_src`); the sub-return part
is the **evaporator** heat the booster lifts to `T_fwd`:

```
q_hp_out   = COP/(COP−1) · q_evaporator                   (booster output)
q_released = q_direct + q_evaporator = Δ(src, deposit)·v  (enthalpy released)
⇒  q_delivered_to_DH − q_elec = q_released                (energy balance)
```

Both models get this relation right; they differ in how the cooling depth ΔT and the COP are
parametrised (§1c) and in how the volume is booked (§2–§4).

### 1c. Per-layer cooling depth ΔT, reinjection layer, and COP

A booster discharging layer `n` cools the water from its source-inlet temperature
down to a **deposit temperature**, and that cooling depth fixes both where the
spent volume is reinjected and how efficient the heat pump is.

* **Cooling depth / reinjection target.** The ideal evaporator outlet is
  `T_target = T_ret − ΔT_HP` with `ΔT_HP = (T_fwd − T_source)·(1 − 1/COP)`
  (`T_source = min(T_n, T_ret)`), i.e. the booster cools the return-level water
  *below* the return temperature by the amount the COP can repay. This continuous
  target is **snapped to a discrete layer** to give `hp_return_layer` ( = the
  `T_boost` layer):
  * **Amos:** the *nearest* layer to `T_target` (strictly colder than the source).
  * **Current model:** with `conservative_return_layer`, the *warmest layer at or
    below* `T_target` (a **floor**), so the deposit is never warmer than intended
    and discharge cannot create energy; otherwise nearest, with a warning when a
    layer ends up above the return temperature.
* **COP per layer per timestep.** The Jensen et-al. thermodynamic model
  (`CentralHeatingCopApproximator`) is evaluated with `sink_outlet = T_fwd`,
  `sink_inlet = max(T_n, T_ret)` (after preheating), `source_inlet = min(T_n, T_ret)`
  and a **source_outlet**:
  * **Amos:** `source_inlet − heat_source_cooling` (a fixed shallow ΔT, e.g. 6 K)
    ⟹ optimistic, the COP ignores how deep the water is actually cooled.
  * **Current model:** `source_outlet = T[hp_return_layer]` (the *real* evaporator
    depth) — recomputed in `PtesApproximator.booster_cop` and exported as
    `booster_cop`. Deeper cooling ⟹ lower COP ⟹ more booster electricity, honestly.
    Energy conservation does **not** depend on the COP value (heat = evaporator +
    elec for any COP); the deposit-depth COP only sharpens the elec/source split.

* **The ΔT–COP circularity is broken, not solved.** Note `ΔT_HP` depends on the COP
  and the COP (at `source_outlet = T_ret − ΔT_HP`) depends on `ΔT_HP` — an implicit
  equation. It is **not** solved as a fixed point. Instead a one-shot, two-pass
  forward scheme is used: (1) `build_cop_profiles` computes `COP₀` *once* with a
  fixed shallow source cooling, so `COP₀` carries no `ΔT_HP` dependence and the loop
  is cut; (2) `hp_return_layer` evaluates `ΔT_HP = (T_fwd−T_source)(1−1/COP₀)` per
  timestep, takes the min over time, and snaps it to a discrete layer; (3)
  `booster_cop` re-evaluates `COP₁` once at that snapped depth, and that is the COP
  the LP uses. The COP that *picks* the layer (`COP₀`) and the COP the LP *runs*
  with (`COP₁`) are deliberately left slightly inconsistent — it does not matter,
  because the deposit is discrete anyway and (per §1a) the LP energy balance is
  COP-independent, so the residual only nudges the electricity/source split, never
  the energy total. A self-consistent value would be a scalar Picard iteration
  `ΔT ← (T_fwd−T_source)(1−1/COP(T_ret−ΔT))` per (layer, node), but it is not worth
  the cost.

---

## 2. Wiring of the current model (energy-exact, volume-conserving)

Per layer `n`, the PyPSA components and their link efficiencies (notation, incl.
`Δ(a,b)`, `T_retL`, `T_boost`, in §1a). `nb` = `needs_boosting` (1 when
`T_fwd > T_n`, else 0). The three cooling depths are clipped at zero:

```
direct_drop = max(T_n − T_retL, 0)        above-return part, delivered directly
below_drop  = max(T_retL − T_boost, 0)    sub-return part, lifted by the booster
extract_dt  = direct_drop + below_drop = max(T_n − T_boost, 0)   total cooling
```

### 2a. Charging — volume *trade* (no volume created)

```
                         ┌──────────────────────────────┐
   URBAN CENTRAL HEAT ───┤ water-pit charger (one per    │
        bus       q ────►│ cold source s, hot dest d)    │
     (charger bus0)      │                               │
                         │  bus1 → Store water pits d    │  eff  = 1 / Δ(T_d,T_s)
                         │  bus2 → Store water pits s     │  eff2 = −eff
                         └───────────────────────────────┘
   one link per (source layer s with T_s ≤ T_ret, dest layer d with T_d > T_ret).
   p_max_pu = charging_availability(d) · 1{ s ≥ return-layer > d }   (per node)
```

`+x` m³ appear at `d`, `−x` m³ leave `s` ⇒ **volume conserved**. Heat drawn
`= Δ(T_d,T_s)·x =` stored-energy gain `m3_to_mwh[d]−m3_to_mwh[s]` ⇒ **exact**.

### 2b. Discharging — discharger + the direct/boost split

```
   Store water pits n
        │  discharger      eff  = 1  → bus1  (+1 m³ to the RETURN-level layer Store)
        │  (volume)        eff2 = 1  → bus2  (+1 token to the preheater bus)
        ├───────────────────────────────► Store water pits  RETURN layer
        └───────────────────────────────► ptes preheater n  (m³ token bus)
                                                 │
              ┌──────────────────────────────────┴───────────────────────────────┐
              │ DIRECT-UTIL  (no boost)                 │ BOOST multilink          │
              │ p_max_pu = 1 − nb                        │ p_max_pu = nb            │
              │ bus0 = token                             │ bus0 = token             │
              │ bus1 = heat   eff = Δ(T_n,T_returnLayer) │ bus1 = RETURN layer eff =−1 (−1 m³)
              ▼                                          │ bus2 = BOOST  layer eff2=+1 (+1 m³)
      URBAN CENTRAL HEAT                                 │ bus3 = hp source eff3 = Δ(T_n,T_boost)
                                                         ▼
                                              ptes hp source n  (MWh bus)
                                                         │  HEAT-EXCHANGER split
                                              ┌──────────┴──────────┐
                                  direct_frac │                     │ hp_frac
                              = direct_drop   │                     │ = below_drop
                                / extract_dt  │                     │   / extract_dt
                                              ▼                     ▼
                                     URBAN CENTRAL HEAT     ptes hp inlet n  (MWh bus)
                                                                    │  BOOSTER heat pump (p ≤ 0)
                                                                    │  bus0 = heat        (q_out = −p0)
                                                                    │  bus1 = electricity eff  = 1/COP
                                                                    │  bus2 = hp inlet    eff2 = (COP−1)/COP
                                                                    ▼
                                                       URBAN CENTRAL HEAT   (+ draws elec from
                                                                             the low-voltage bus)
```

The split fractions always sum to 1 (when `extract_dt > 0`; set to 0 otherwise to
avoid 0/0), and their boundary cases say *which path the discharge takes*:

* `direct_frac = 1, hp_frac = 0`  ⟺  `below_drop = 0`  ⟺  `T_retL = T_boost`: there
  is **no usable boosting depth** — the return-level layer is already the deposit
  layer (common under the conservative floor, where `T_retL` is pushed to the
  bottom). The booster never runs and the whole release goes direct. This is why
  the solved 5-layer case draws ~0 booster electricity.
* `direct_frac = 0, hp_frac = 1`  ⟺  `direct_drop = 0`  ⟺  `T_n ≤ T_retL`: a
  **sub-return layer** is being cooled, so the entire extraction is evaporator heat
  (no above-return part) — see case (iv).
* `0 < direct_frac < 1`: a genuinely boosted warm layer (`T_n > T_retL > T_boost`),
  with both a direct part and an evaporator part.

* **NB on bus order:** electricity must sit on `bus1` of the booster — PyPSA-Eur's
  distribution-grid rewiring keys off `bus1` for heat-pump electricity and would
  otherwise append `" low voltage"` to whatever is on `bus1`, mangling the
  evaporator bus into a phantom free-energy source.

### 2c. Stores, interlayer links, generators, constraints

```
   Store water pits l  (m³, e_cyclic, standing_loss = 0)            for each layer l
        │  interlayer link  bus0=l → bus1=l+1   (downward volume flux = standing loss)
        ▼
   Store water pits l+1
   ──────────────────────────────────────────────────────────────────────────────
   Store water pits  (aggregate, e_max_pu, carries the €/m³ storage capital_cost)
   Link  ptes heat pump  (dummy, p_max_pu=0, carries the booster €/MW capital_cost)
   GENERATORS:  none on the PTES buses  (no vents, no bottom-water source)

   EXTRA CONSTRAINTS (solve_network.py):
     volume capacity      Σ_l e_l(t) = ē / m3_to_mwh[top]            (∀t; tank always full)
     interlayer flow      p_{l→l+1}(t) = Ψ_l · e_l(t)                (standing-loss channel)
     HP capacity          Σ_l p_nom(booster_l) ≤ p_nom(dummy HP)     (shared investment)
     throughput           Σ chargers + Σ m3_to_mwh·dischargers ≤ R·ē
```

Everything references the **discrete deposit layers**, so on every discharge
`delivered − elec = ρc_p(T_n − T_deposit) =` the bottom-referenced store debit.
Volume is conserved at every link. The only dissipation is the interlayer flux
(`standing_loss = 0` on the stores, so the loss is single-channel).

---

## 3. Wiring of the Amos model (PR #2129) — where energy leaks in

Same layer stores, but charging *mints* volume and discharging is a
preheater → heat-pump chain whose heat references the actual return temperature
while its volume is booked against discrete layers. Same `Δ`/`nb` notation as §2.

### 3a. Charging — create-volume (volume minted, not traded)

```
                         ┌──────────────────────────────┐
   URBAN CENTRAL HEAT ───┤ create-volume charger         │  eff = charging_avail[n] / m3_to_mwh[n]
        bus       q ────►│ (one per layer n)             ├──► Store water pits n   (+ q·eff m³,
     (charger bus0)      │                               │                          CREATED from heat)
                         └───────────────────────────────┘
   1 MWh of heat ⟹ 1/m3_to_mwh[n] m³ minted at layer n (stored energy = 1 MWh,
   bottom-referenced). No source layer is drained ⇒ Σ_l e_l is NOT conserved here;
   it is rebalanced only by the free generators below.
```

### 3b. Discharging — discharger → preheater → heat pump

```
   Store water pits n
        │  discharger   eff = 1   (moves +1 m³ as a unit onto the preheater bus)
        ▼
   ptes preheater n   (m³ bus)
        │   PREHEATER multilink   (consumes the 1 m³ unit)
        ├── bus1 = heat                    eff  = Δ(T_n, T_ret)        ◄ delivers to DH at the
        │                                                                ACTUAL return T
        ├── bus2 = hp input                eff2 = nb                   ──► +nb   m³ to the booster
        └── bus3 = preheater_return_layer  eff3 = 1 − nb               ──► +(1−nb) m³ to a
                          │                  │                              DISCRETE layer Store
                          ▼                  ▼
                 URBAN CENTRAL HEAT   Store water pits  preheater_return_layer

   ptes hp input n   (m³ bus)
        │   HEAT PUMP   (p ≤ 0)
        ├── bus0 = heat                     q_out = heat_pump_eff = Δ(T_fwd, T_n)   ◄ the LIFT,
        │                                                                            not the cooling
        ├── bus1 = electricity              eff  = 1/COP
        ├── bus2 = hp input                 eff2 = 1/heat_pump_eff
        └── bus3 = hp_return_layer          eff3 = −1/heat_pump_eff    ──► +1 m³ to a DISCRETE layer
                          │                  │                  │
                          ▼                  ▼ (draws elec)     ▼
                 URBAN CENTRAL HEAT     low-voltage bus   Store water pits  hp_return_layer
```

### 3c. Stores, generators, constraints

```
   Store water pits l  (m³, e_cyclic, standing_loss > 0)            for each layer l
        │  interlayer link  bus0=l → bus1=l+1   (constraint p = Ψ·e, FLAT Ψ = 0.001)
        ▼
   Store water pits l+1
   ──────────────────────────────────────────────────────────────────────────────
   Store water pits  (aggregate, e_max_pu, €/m³ capital_cost);  dummy ptes heat pump (€/MW)
   GENERATORS on the layer stores:
        ptes vent (per layer)     Store l        ◄── p ≤ 0, marginal_cost = −1  (destroys volume,
                                                                                  rewarded, depth-graded)
        bottom-water generator    Store bottom   ◄── p ≥ 0, marginal_cost = +1  (creates volume)
   EXTRA CONSTRAINTS: volume capacity; interlayer flow (flat Ψ); HP capacity (Σ p_nom — sum-of-peaks).
   Stores ALSO carry a PyPSA standing_loss ⇒ standing loss is double-counted (interlayer + store).
```

**Two structural mismatches make this leak (cf. the current model, which has neither):**

1. **Volume is minted/destroyed for free.** The charger mints volume from heat; the
   per-layer vents (rewarded, `marginal_cost = −1`) destroy it; the bottom-water
   generator mints more. `Σ_l e_l` is not conserved per operation, so the optimiser
   can route around the physics.
2. **Heat references the actual `T_ret`, volume references a discrete layer.** The
   preheater delivers `Δ(T_n, T_ret_actual)`, but the spent volume is debited only
   down to the nearest `preheater_return_layer` / `hp_return_layer`. When that
   discrete layer sits **above** the actual return temperature the discharge debits
   too little ⇒ every m³ conjures `ρc_p(T_layer − T_ret_actual)`; and the HP delivers
   the *lift* `Δ(T_fwd, T_n)` regardless of how deep the water was actually cooled,
   so the lift and the volume debit only reconcile if `hp_return_layer` snaps exactly
   to `T_ret − ΔT_HP`.

---

## 4. The four cases — volume & energy, current vs Amos

Notation in §1a (`T_retL`, `T_boost`, `Δ`); `v` = 1 m³ discharged. "Store debit"
is the bottom-referenced energy drop `Σ Δ(from,to)·v` (§1a).

### (i) Charging
| | volume | energy |
|---|---|---|
| **current** | trade: `−v` at a sub-return source, `+v` at the hot dest → **conserved** | heat in `= ρc_p(T_d−T_s)·v =` stored gain → **exact** |
| **Amos** | charger **creates** `+v` at the dest from nothing; balanced later by free vents / bottom-water | 1 MWh heat → 1 MWh stored (bottom-ref); but the non-physical volume balance is what later leaks |

### (ii) Direct discharge, no boost (warm layer, `T_fwd ≤ T_n`)
| | volume | energy |
|---|---|---|
| **current** | `−v` at `n`, `+v` at the return-level layer → **conserved** | delivered `ρc_p(T_n−T_retL)` = debit `m3_to_mwh[n]−m3_to_mwh[retL]` → **exact** |
| **Amos** | `−v` at `n`, `+v` at `preheater_return_layer` (discrete) | delivered `ρc_p(T_n−T_ret_actual)`, debit `ρc_p(T_n−T_prl)`; mismatch `ρc_p(T_prl−T_ret)` → **free lunch if T_prl > T_ret** |

### (iii) Boosted discharge from a layer with `T_n > T_ret` (`T_fwd > T_n`)
The discharged m³ is cooled in two stages: directly down to the return level
(`Δ(T_n,T_retL)` straight to DH), then by the booster from there down to the
reinjection layer (evaporator `Δ(T_retL,T_boost)`, lifted to DH at `COP/(COP−1)`).
| | volume | energy |
|---|---|---|
| **current** | `−v` at `n`, `+v` at the boost layer (return level is a transient pass-through) → **conserved** | `delivered − elec = Δ(T_n,T_boost)` = debit `m3_to_mwh[n]−m3_to_mwh[boost]` → **exact** (the hp-source bus carries the *full* released enthalpy, the HX splits it) |
| **Amos** | `−v` at `n`, `+v` at `hp_return_layer` (discrete) | `delivered = Δ(T_n,T_ret)+Δ(T_fwd,T_n)`; exact **only if** `T_hp_return = T_ret − (T_fwd−T_n)(1−1/COP)` lands exactly on a layer; the discrete snap leaks |

### (iv) Discharge of a sub-return layer (`T_n ≤ T_ret`)
| | behaviour |
|---|---|
| **current** | such layers are the **cold reservoir**: charging draws volume up from them, discharge deposits cooled volume into them. They deliver no *direct* heat (`Δ(T_n,T_retL) = 0` once floored); if cooled further they are pure HP-evaporator source. Volume and (low, near-bottom) energy stay exactly tracked. |
| **Amos** | `preheater_efficiency = 0` for `T_n ≤ T_ret`, so no direct heat; the volume still flows through the create/vent/bottom-water machinery, so the cold end is where most of the free volume is minted and vented. |

---

## 5. Net energy balance (legacy intermediate model omitted)

**Toy, single node, identical boundary conditions** (`created = load + losses −
elec`; SCOP `= load/elec`):

```
model      objective   elec    load   interlayer   created   SCOP
current    32.99 M€    253.6   245.1     6.3         −2.3     0.97   (≈ conservative)
Amos       24.33 M€    167.3   245.1     7.9        +85.7     1.47   (energy conjured)
```

**Workflow, PyPSA-Eur 5-layer scenario, 26 urban-central nodes** (`created = net
PTES heat to DH − elec drawn + interlayer loss`):

```
model                       created [GWh/yr]   volume drift   objective
current (this port)              0.00            5e-7         5.145e11   ← exact
Amos-style, nearest layers   +294,000            (n/a)        5.08e11    ← large free lunch
```

The current model nets to **exactly zero** energy created with volume conserved
to 5e-7; its only loss is the interlayer standing-loss channel. Amos's structure
conjures energy on discharge, which the optimiser then exploits (the objective is
artificially low and the PTES is over-cycled).

---

## 6. Discretisation bias (both models)

The model is a piecewise-constant approximation of a continuously stratified PTES.
For **evenly-spaced** layers the nominal layer temperature is the band mean, and
the Jensen COP uses **both inlet and outlet** temperatures (the glide) — already a
mean-temperature representation, more accurate than a single-mean-T COP. The
residual error is quantisation (collapsing each band to a point), bounded by ≈ ½ a
layer spacing. In the toy the `n_layers` sweep gives 3→33.5, 5→32.7, 9→31.4 M€:
coarser layers *under-value* the PTES (higher cost), converging downward as N
grows — i.e. **conservative**. Room to improve within linearity: more / non-uniform
layers concentrated near the forward and return temperatures (layer temps must
stay exogenous — endogenous temperatures are nonlinear).

**Conservative discretisation (current model).** Because the current model
references discrete deposit layers, it never *creates* energy regardless of layer
placement; the only question is whether the direct part over- or under-delivers
relative to the physical return temperature. The optional
`sector.district_heating.ptes.conservative_return_layer` flag **floors** the
return-level and reinjection layers to the warmest layer at/below the target, so
discharge stays on the conservative side; `build_ptes_operations` additionally
**warns** for any node whose return-level layer sits above its return temperature.

---

## 7. Implementation notes (current model)

* **Charge** = `~L²/2` volume-trade charger links per node (one per
  cold-source × hot-dest pair); the single-tank `num_layers == 1` case keeps the
  legacy create-volume charger.
* **Booster COP** is recomputed at `source_outlet = T[hp_return_layer]` (the real
  evaporator depth) in `PtesApproximator.booster_cop` and exported as
  `booster_cop` in `ptes_operations`; `prepare_sector_network` uses it for the
  booster. Energy conservation is independent of the COP value (heat = evaporator
  + elec for any COP); this only sharpens the electricity/source split.
* **Standing loss** is single-channel: layer-store `standing_loss = 0`, the loss
  lives entirely in the interlayer-flow constraint. A nonzero store `standing_loss`
  would, with volume-conserving charging and `e_cyclic`, drive Σ_l e_l → 0.
* **Booster bus order:** electricity on `bus1`, evaporator (hp-inlet) on `bus2`
  (see §2b note).
