### PR TITLE
feat: add index name to cluster weights

### DIFF
--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -298,7 +298,7 @@ def distribute_n_clusters_to_countries(
         .sum()
         .pipe(normed)
     )
-
+    L.index.name = "cluster"
     N = n.buses.groupby(["country", "sub_network"]).size()[L.index]
 
     assert n_clusters >= len(N) and n_clusters <= N.sum(), (


### PR DESCRIPTION
Ensure compatibility with `linopy => v0.8` which is stricter on dimensioning names for multiindexes


## Changes proposed in this Pull Request

add a explicit index name to the cluster weights index 

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.rst`.

**If applicable:**
- [x] Changes in configuration options are reflected in `scripts/lib/validation`.
- [x] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.