### PR TITLE
Revert "make build_ambient_ait_temp script thread-safe"

### DIFF
--- a/scripts/build_ambient_air_temperature_yearly_average.py
+++ b/scripts/build_ambient_air_temperature_yearly_average.py
@@ -70,9 +70,7 @@ if __name__ == "__main__":
     configure_logging(snakemake)
     set_scenario_config(snakemake)
 
-    ambient_temperature = (
-        xr.open_mfdataset(snakemake.input.cutout, chunks="auto").temperature - 273.15
-    )
+    ambient_temperature = xr.open_mfdataset(snakemake.input.cutout).temperature - 273.15
 
     # Load onshore regions
     regions_onshore = gpd.read_file(snakemake.input.regions_onshore)
@@ -102,6 +100,6 @@ if __name__ == "__main__":
     )
 
     # Save the result
-    average_temperature_by_region.compute(scheduler="single-threaded").to_netcdf(
-        snakemake.output.average_ambient_air_temperature,
+    average_temperature_by_region.to_netcdf(
+        snakemake.output.average_ambient_air_temperature
     )


### PR DESCRIPTION
Reverts commit 920afcac, which was pushed to `master` unintentionally.

This restores `master` to the state at cf2ef77e (#2190).