### PR TITLE
Make build_ambient_air_temperature_yearly_average thread-safe

### DIFF
--- a/scripts/build_ambient_air_temperature_yearly_average.py
+++ b/scripts/build_ambient_air_temperature_yearly_average.py
@@ -70,7 +70,9 @@ if __name__ == "__main__":
     configure_logging(snakemake)
     set_scenario_config(snakemake)
 
-    ambient_temperature = xr.open_mfdataset(snakemake.input.cutout).temperature - 273.15
+    ambient_temperature = (
+        xr.open_mfdataset(snakemake.input.cutout, chunks="auto").temperature - 273.15
+    )
 
     # Load onshore regions
     regions_onshore = gpd.read_file(snakemake.input.regions_onshore)
@@ -100,6 +102,6 @@ if __name__ == "__main__":
     )
 
     # Save the result
-    average_temperature_by_region.to_netcdf(
-        snakemake.output.average_ambient_air_temperature
+    average_temperature_by_region.compute(scheduler="single-threaded").to_netcdf(
+        snakemake.output.average_ambient_air_temperature,
     )


### PR DESCRIPTION
closes #2195 

Re-introduces the change from 920afcac as a proper reviewed PR (it had been pushed directly to `master` and was reverted in #2196).

## Changes
- Open the cutout with `chunks="auto"` so dask handles the dataset lazily.
- Force a single-threaded scheduler on `.compute()` before writing the NetCDF output, avoiding thread-safety issues during concurrent Snakemake execution.