### PR TITLE
fix: permissions for lockfile update action

### DIFF
--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
Introduced in #2164, the current lockfile update pipeline is broken