### PR TITLE
fix: resolve silent NaN load data when fixed_year differs from snapshot year

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -5,6 +5,8 @@
 
 <!-- Upcoming Release -->
 <!-- ================= -->
+* Fix: Resolve silent NaN load data when `fixed_year` differs from snapshot year ([#2187](https://github.com/PyPSA/pypsa-eur/issues/2187)).
+
 * Security: SBOM security scan included in CI.
 
 * Security: Development dependencies (pre-commit, pylint, jupyter, etc.) moved to `dev` `pixi` environment.

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -221,6 +221,35 @@ def repeat_years(s: pd.Series, years: list) -> pd.Series:
     )
 
 
+def reindex_load_fixed_year(load: pd.DataFrame, snapshots: pd.DatetimeIndex, fixed_year) -> pd.DataFrame:
+    """
+    Reindex load data for a fixed_year onto the snapshot timeline.
+    """
+    if fixed_year:
+        fixed_year = int(fixed_year)
+
+        # Guard against leap year mismatch: if snapshots contain Feb 29
+        # but fixed_year has no Feb 29, there is no load data to map
+        has_feb29 = ((snapshots.month == 2) & (snapshots.day == 29)).any()
+        if has_feb29 and not calendar.isleap(fixed_year):
+            raise ValueError(
+                f"Snapshots contain Feb 29 but fixed_year={fixed_year} is not a "
+                f"leap year. Set 'drop_leap_day: true' in the snapshots config "
+                f"or choose a leap fixed_year."
+            )
+
+        # Map snapshot timestamps to fixed_year to index into load data,
+        # then restore the original snapshot index
+        fixed_year_index = snapshots.map(lambda t: t.replace(year=fixed_year))
+        load = load.loc[fixed_year_index]
+        load.index = snapshots
+    else:
+        years = slice(snapshots[0], snapshots[-1])
+        load = load.loc[years].reindex(index=snapshots)
+
+    return load
+
+
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from scripts._helpers import mock_snakemake
@@ -324,27 +353,7 @@ if __name__ == "__main__":
 
     fixed_year = snakemake.params["load"].get("fixed_year", False)
 
-    if fixed_year:
-        fixed_year = int(fixed_year)
-
-        # Guard against leap year mismatch: if snapshots contain Feb 29
-        # but fixed_year has no Feb 29, there is no load data to map
-        has_feb29 = ((snapshots.month == 2) & (snapshots.day == 29)).any()
-        if has_feb29 and not calendar.isleap(fixed_year):
-            raise ValueError(
-                f"Snapshots contain Feb 29 but fixed_year={fixed_year} is not a "
-                f"leap year. Set 'drop_leap_day: true' in the snapshots config "
-                f"or choose a leap fixed_year."
-            )
-
-        # Map snapshot timestamps to fixed_year to index into load data,
-        # then restore the original snapshot index
-        fixed_year_index = snapshots.map(lambda t: t.replace(year=fixed_year))
-        load = load.loc[fixed_year_index]
-        load.index = snapshots
-    else:
-        years = slice(snapshots[0], snapshots[-1])
-        load = load.loc[years].reindex(index=snapshots)
+    load = reindex_load_fixed_year(load, snapshots, fixed_year)
 
     assert not load.isna().any().any(), (
         f"Load data contains NaN after reindexing. Ensure load data "

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -241,7 +241,7 @@ def reindex_load_fixed_year(load: pd.DataFrame, snapshots: pd.DatetimeIndex, fix
         # Map snapshot timestamps to fixed_year to index into load data,
         # then restore the original snapshot index
         fixed_year_index = snapshots.map(lambda t: t.replace(year=fixed_year))
-        load = load.loc[fixed_year_index]
+        load = load.reindex(index=fixed_year_index)
         load.index = snapshots
     else:
         years = slice(snapshots[0], snapshots[-1])

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -8,8 +8,8 @@ After filling small gaps linearly and large gaps by copying time-slice of a
 given period, the load data is exported to a `.csv` file.
 """
 
-import logging
 import calendar
+import logging
 
 import numpy as np
 import pandas as pd

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -9,6 +9,7 @@ given period, the load data is exported to a `.csv` file.
 """
 
 import logging
+import calendar
 
 import numpy as np
 import pandas as pd
@@ -322,16 +323,32 @@ if __name__ == "__main__":
     )
 
     fixed_year = snakemake.params["load"].get("fixed_year", False)
-    years = (
-        slice(str(fixed_year), str(fixed_year))
-        if fixed_year
-        else slice(snapshots[0], snapshots[-1])
-    )
 
-    load = load.loc[years].reindex(index=snapshots)
-
-    # need to reindex load time series to target year
     if fixed_year:
-        load.index = load.index.map(lambda t: t.replace(year=snapshots.year[0]))
+        fixed_year = int(fixed_year)
+
+        # Guard against leap year mismatch: if snapshots contain Feb 29
+        # but fixed_year has no Feb 29, there is no load data to map
+        has_feb29 = ((snapshots.month == 2) & (snapshots.day == 29)).any()
+        if has_feb29 and not calendar.isleap(fixed_year):
+            raise ValueError(
+                f"Snapshots contain Feb 29 but fixed_year={fixed_year} is not a "
+                f"leap year. Set 'drop_leap_day: true' in the snapshots config "
+                f"or choose a leap fixed_year."
+            )
+
+        # Map snapshot timestamps to fixed_year to index into load data,
+        # then restore the original snapshot index
+        fixed_year_index = snapshots.map(lambda t: t.replace(year=fixed_year))
+        load = load.loc[fixed_year_index]
+        load.index = snapshots
+    else:
+        years = slice(snapshots[0], snapshots[-1])
+        load = load.loc[years].reindex(index=snapshots)
+
+    assert not load.isna().any().any(), (
+        f"Load data contains NaN after reindexing. Ensure load data "
+        f"covers the requested snapshots (fixed_year={fixed_year})."
+    )
 
     load.to_csv(snakemake.output[0])

--- a/test/test_build_electricity_demand.py
+++ b/test/test_build_electricity_demand.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+#
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for build_electricity_demand.py.
+
+Tests for the fixed_year reindexing logic that was silently producing
+NaN load data when fixed_year differed from the snapshot year.
+See https://github.com/PyPSA/pypsa-eur/issues/2187
+"""
+
+import calendar
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def reindex_load_fixed_year(load, snapshots, fixed_year):
+    """
+    Reindex load data for a fixed_year onto the snapshot timeline.
+
+    Mirrors the logic in build_electricity_demand.py.
+    """
+    if fixed_year:
+        fixed_year = int(fixed_year)
+
+        has_feb29 = ((snapshots.month == 2) & (snapshots.day == 29)).any()
+        if has_feb29 and not calendar.isleap(fixed_year):
+            raise ValueError(
+                f"Snapshots contain Feb 29 but fixed_year={fixed_year} is not a "
+                f"leap year. Set 'drop_leap_day: true' in the snapshots config "
+                f"or choose a leap fixed_year."
+            )
+
+        fixed_year_index = snapshots.map(lambda t: t.replace(year=fixed_year))
+        load = load.loc[fixed_year_index]
+        load.index = snapshots
+    else:
+        years = slice(snapshots[0], snapshots[-1])
+        load = load.loc[years].reindex(index=snapshots)
+
+    return load
+
+
+def _make_load(year, countries=("DE", "FR")):
+    """Create synthetic hourly load data for a given year."""
+    idx = pd.date_range(f"{year}-01-01", f"{year}-12-31 23:00", freq="h")
+    rng = np.random.default_rng(42)
+    data = {c: rng.random(len(idx)) * 1000 + 500 for c in countries}
+    return pd.DataFrame(data, index=idx)
+
+
+class TestFixedYearReindex:
+    """Regression tests for #2187: fixed_year must not produce NaN load."""
+
+    def test_same_year(self):
+        """fixed_year == snapshot year: trivial case, must work."""
+        load = _make_load(2018)
+        snapshots = pd.date_range("2018-01-01", "2018-12-31 23:00", freq="h")
+        result = reindex_load_fixed_year(load, snapshots, fixed_year=2018)
+        assert not result.isna().any().any()
+        assert len(result) == len(snapshots)
+
+    def test_different_year_no_nans(self):
+        """Core regression test for #2187: fixed_year != snapshot year."""
+        load = _make_load(2018)
+        snapshots = pd.date_range("2013-01-01", "2013-12-31 23:00", freq="h")
+        result = reindex_load_fixed_year(load, snapshots, fixed_year=2018)
+        assert not result.isna().any().any(), "fixed_year produced NaN load data"
+        assert len(result) == len(snapshots)
+
+    def test_leap_fixed_year_to_non_leap_snapshots(self):
+        """Leap fixed_year (2024) mapped to non-leap snapshots (2013)."""
+        load = _make_load(2024)
+        snapshots = pd.date_range("2013-01-01", "2013-12-31 23:00", freq="h")
+        result = reindex_load_fixed_year(load, snapshots, fixed_year=2024)
+        assert not result.isna().any().any()
+        assert len(result) == 8760  # non-leap year hours
+
+    def test_non_leap_fixed_year_with_leap_snapshots_raises(self):
+        """Non-leap fixed_year (2018) with leap snapshots containing Feb 29."""
+        load = _make_load(2018)
+        # Leap year snapshots WITH Feb 29
+        snapshots = pd.date_range("2024-01-01", "2024-12-31 23:00", freq="h")
+        with pytest.raises(ValueError, match="Feb 29"):
+            reindex_load_fixed_year(load, snapshots, fixed_year=2018)
+
+    def test_no_fixed_year(self):
+        """No fixed_year: standard reindex, must not regress."""
+        load = _make_load(2018)
+        snapshots = pd.date_range("2018-01-01", "2018-12-31 23:00", freq="h")
+        result = reindex_load_fixed_year(load, snapshots, fixed_year=False)
+        assert not result.isna().any().any()
+
+    def test_values_are_preserved(self):
+        """Verify actual load values are mapped correctly, not just non-NaN."""
+        load = _make_load(2018)
+        snapshots = pd.date_range("2013-01-01", "2013-12-31 23:00", freq="h")
+        result = reindex_load_fixed_year(load, snapshots, fixed_year=2018)
+        # First hour of 2013 should have the value from first hour of 2018
+        assert result.iloc[0]["DE"] == load.iloc[0]["DE"]
+        # Last hour likewise
+        assert result.iloc[-1]["FR"] == load.iloc[-1]["FR"]

--- a/test/test_build_electricity_demand.py
+++ b/test/test_build_electricity_demand.py
@@ -9,38 +9,11 @@ NaN load data when fixed_year differed from the snapshot year.
 See https://github.com/PyPSA/pypsa-eur/issues/2187
 """
 
-import calendar
-
 import numpy as np
 import pandas as pd
 import pytest
 
-
-def reindex_load_fixed_year(load, snapshots, fixed_year):
-    """
-    Reindex load data for a fixed_year onto the snapshot timeline.
-
-    Mirrors the logic in build_electricity_demand.py.
-    """
-    if fixed_year:
-        fixed_year = int(fixed_year)
-
-        has_feb29 = ((snapshots.month == 2) & (snapshots.day == 29)).any()
-        if has_feb29 and not calendar.isleap(fixed_year):
-            raise ValueError(
-                f"Snapshots contain Feb 29 but fixed_year={fixed_year} is not a "
-                f"leap year. Set 'drop_leap_day: true' in the snapshots config "
-                f"or choose a leap fixed_year."
-            )
-
-        fixed_year_index = snapshots.map(lambda t: t.replace(year=fixed_year))
-        load = load.loc[fixed_year_index]
-        load.index = snapshots
-    else:
-        years = slice(snapshots[0], snapshots[-1])
-        load = load.loc[years].reindex(index=snapshots)
-
-    return load
+from scripts.build_electricity_demand import reindex_load_fixed_year
 
 
 def _make_load(year, countries=("DE", "FR")):

--- a/test/test_build_electricity_demand.py
+++ b/test/test_build_electricity_demand.py
@@ -16,9 +16,14 @@ import pytest
 from scripts.build_electricity_demand import reindex_load_fixed_year
 
 
+def _make_snapshots(year):
+    """Create a standard hourly DatetimeIndex for a given year."""
+    return pd.date_range(f"{year}-01-01", f"{year}-12-31 23:00", freq="h")
+
+
 def _make_load(year, countries=("DE", "FR")):
     """Create synthetic hourly load data for a given year."""
-    idx = pd.date_range(f"{year}-01-01", f"{year}-12-31 23:00", freq="h")
+    idx = _make_snapshots(year)
     rng = np.random.default_rng(42)
     data = {c: rng.random(len(idx)) * 1000 + 500 for c in countries}
     return pd.DataFrame(data, index=idx)
@@ -30,23 +35,28 @@ class TestFixedYearReindex:
     def test_same_year(self):
         """fixed_year == snapshot year: trivial case, must work."""
         load = _make_load(2018)
-        snapshots = pd.date_range("2018-01-01", "2018-12-31 23:00", freq="h")
+        snapshots = _make_snapshots(2018)
         result = reindex_load_fixed_year(load, snapshots, fixed_year=2018)
         assert not result.isna().any().any()
         assert len(result) == len(snapshots)
 
-    def test_different_year_no_nans(self):
-        """Core regression test for #2187: fixed_year != snapshot year."""
+    def test_different_year_mapping(self):
+        """Core regression test for #2187: fixed_year != snapshot year.
+        Verify no NaNs are produced and values are correctly mapped."""
         load = _make_load(2018)
-        snapshots = pd.date_range("2013-01-01", "2013-12-31 23:00", freq="h")
+        snapshots = _make_snapshots(2013)
         result = reindex_load_fixed_year(load, snapshots, fixed_year=2018)
         assert not result.isna().any().any(), "fixed_year produced NaN load data"
         assert len(result) == len(snapshots)
+        # First hour of 2013 should have the value from first hour of 2018
+        assert result.iloc[0]["DE"] == load.iloc[0]["DE"]
+        # Last hour likewise
+        assert result.iloc[-1]["FR"] == load.iloc[-1]["FR"]
 
     def test_leap_fixed_year_to_non_leap_snapshots(self):
         """Leap fixed_year (2024) mapped to non-leap snapshots (2013)."""
         load = _make_load(2024)
-        snapshots = pd.date_range("2013-01-01", "2013-12-31 23:00", freq="h")
+        snapshots = _make_snapshots(2013)
         result = reindex_load_fixed_year(load, snapshots, fixed_year=2024)
         assert not result.isna().any().any()
         assert len(result) == 8760  # non-leap year hours
@@ -55,23 +65,13 @@ class TestFixedYearReindex:
         """Non-leap fixed_year (2018) with leap snapshots containing Feb 29."""
         load = _make_load(2018)
         # Leap year snapshots WITH Feb 29
-        snapshots = pd.date_range("2024-01-01", "2024-12-31 23:00", freq="h")
+        snapshots = _make_snapshots(2024)
         with pytest.raises(ValueError, match="Feb 29"):
             reindex_load_fixed_year(load, snapshots, fixed_year=2018)
 
     def test_no_fixed_year(self):
         """No fixed_year: standard reindex, must not regress."""
         load = _make_load(2018)
-        snapshots = pd.date_range("2018-01-01", "2018-12-31 23:00", freq="h")
+        snapshots = _make_snapshots(2018)
         result = reindex_load_fixed_year(load, snapshots, fixed_year=False)
         assert not result.isna().any().any()
-
-    def test_values_are_preserved(self):
-        """Verify actual load values are mapped correctly, not just non-NaN."""
-        load = _make_load(2018)
-        snapshots = pd.date_range("2013-01-01", "2013-12-31 23:00", freq="h")
-        result = reindex_load_fixed_year(load, snapshots, fixed_year=2018)
-        # First hour of 2013 should have the value from first hour of 2018
-        assert result.iloc[0]["DE"] == load.iloc[0]["DE"]
-        # Last hour likewise
-        assert result.iloc[-1]["FR"] == load.iloc[-1]["FR"]


### PR DESCRIPTION
Fixes #2187. When fixed_year differs from the snapshot year, load data was silently filled with NaN due to reindexing before year mapping.

- Reverse mapping direction: map snapshots to fixed_year first, then index into load data (approach by @gianvicolux)
- Add leap year validation guard (analysis by @luciboon)
- Add regression tests covering normal, leap year, and edge cases
- Move assert after reindexing to catch mapping failures

Closes #2187.

## Changes proposed in this Pull Request

This PR resolves a critical issue where setting `load.fixed_year` different from the snapshots' year results in a DataFrame containing only `NaN` values. The problem stems from performing `.reindex(index=snapshots)` on load data that has not yet had its year replaced.

To address this, we implemented the following changes:
1. **Added `import calendar`** at the top of the `scripts/build_electricity_demand.py` file to enable leap year verification.
2. **Reversed mapping order**: Instead of slicing the year and reindexing immediately, we now map the snapshots' timestamps to the target `fixed_year` using `snapshots.map(lambda t: t.replace(year=fixed_year))` first, index into the loaded dataset using this new index, and then restore the original snapshots index on the result.
3. **Leap year guard**: Added a check that raises a descriptive `ValueError` if the snapshots contain February 29th but the target `fixed_year` is not a leap year, prompting the user to drop the leap day or select a leap year.
4. **Moved asset checks**: Relocated the `isna()` assert statement to the end of the script (after reindexing) to catch any potential alignment failures.
5. **Added Regression Tests**: Created `test/test_build_electricity_demand.py` to cover same-year mappings, different-year mappings (regression test for #2187), leap-to-non-leap mappings, non-leap-to-leap error raising, default behavior when no `fixed_year` is set, and correctness of mapped values.
6. **Added Release Notes**: Documented this bugfix under the "Upcoming Release" section in `doc/release_notes.md`.

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
