### PR TITLE
doc: disable root toc entry

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -36,6 +36,8 @@
 
 - Added solar rooftop ratio setting to `add_existing_baseyear` for heuristically splitting existing solar capacity between rooftop and utility-scale (defaults to a 50:50 split).
 
+- doc: Disable root TOC entries in order to declutter the table of contents for the rules overview ([2216](https://github.com/PyPSA/pypsa-eur/pull/2216)).
+
 ## PyPSA-Eur v2026.02.0 (18th February 2026)
 
 **Features**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ plugins:
           show_source: false
           show_root_heading: false
           show_root_full_path: false
+          show_root_toc_entry: false
           members: false
           allow_inspection: true
         inventories:


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

This PR suggests to disable root TOC entries in order to declutter the table of contents for the rules overview.

### Master

<img width="1394" height="659" alt="image" src="https://github.com/user-attachments/assets/06389530-ac52-46fa-9f10-ba755a0816f3" />

### Current PR

<img width="1394" height="670" alt="image" src="https://github.com/user-attachments/assets/3f80dc66-5e20-4bfd-98c8-e83a6b125475" />


## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.md` files.