### PR TITLE
Make `default_target` configurable

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -59,6 +59,7 @@ resources = path_provider("resources/", RDIR, shared_resources, exclude_from_sha
 scripts = script_path_provider(Path(workflow.snakefile).parent)
 
 RESULTS = "results/" + RDIR
+workflow.default_target = config["run"]["default_target_rule"]
 
 
 localrules:
@@ -104,7 +105,6 @@ if config["foresight"] == "perfect":
 
 
 rule all:
-    default_target: True
     input:
         expand(RESULTS + "graphs/costs.pdf", run=config["run"]["name"]),
         expand(resources("maps/power-network.pdf"), run=config["run"]["name"]),
@@ -292,6 +292,8 @@ rule rulegraph:
         pdf=resources("dag_rulegraph.pdf"),
         png=resources("dag_rulegraph.png"),
         svg=resources("dag_rulegraph.svg"),
+    params:
+        default_target=workflow.default_target,  # track default target to ensure rule is re-triggered
     message:
         "Creating RULEGRAPH dag in multiple formats using the final configuration."
     shell:
@@ -329,6 +331,8 @@ rule filegraph:
         pdf=resources("dag_filegraph.pdf"),
         png=resources("dag_filegraph.png"),
         svg=resources("dag_filegraph.svg"),
+    params:
+        default_target=workflow.default_target,  # track default target to ensure rule is re-triggered
     message:
         "Creating FILEGRAPH dag in multiple formats using the final configuration."
     shell:

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -30,6 +30,7 @@ run:
     policy: false
     exclude: []
   use_shadow_directory: false
+  default_target_rule: all
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#foresight
 foresight: overnight

--- a/config/schema.default.json
+++ b/config/schema.default.json
@@ -4077,6 +4077,18 @@
             true
           ],
           "type": "boolean"
+        },
+        "default_target_rule": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "all",
+          "description": "Default target rule for snakemake. This is the default rule that will be executed if no other rule is specified. If set to ``None``, snakemake will use its default behavior and execute the first rule in the Snakefile. NOTE: This value will be overwritten by any reference to `default_target` made in a specific rule."
         }
       }
     },
@@ -8328,6 +8340,18 @@
             true
           ],
           "type": "boolean"
+        },
+        "default_target_rule": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "all",
+          "description": "Default target rule for snakemake. This is the default rule that will be executed if no other rule is specified. If set to ``None``, snakemake will use its default behavior and execute the first rule in the Snakefile. NOTE: This value will be overwritten by any reference to `default_target` made in a specific rule."
         }
       }
     },

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -5,7 +5,10 @@
 
 <!-- Upcoming Release -->
 <!-- ================= -->
+* feat: Make the default target rule configurable (defaults to "all" for backwards compatibility)
+
 * Fix: Keep unset `p_set` (NaN) as NaN when aggregating components in `cluster_heat_buses`, required for [PyPSA#1703](https://github.com/PyPSA/PyPSA/pull/1703).
+
 * Fix: When clustering heat buses, in myopic optimization, and afterwards viewing the heat energy_balance with n.statistics (and with nice_names=True, which is the default), some assets would still be displayed as belonging to "residential" or "services" sectors, because the nice_names still lingered from the unclustered version. This has been fixed.
 
 * Security: SBOM security scan included in CI.

--- a/scripts/lib/validation/config/run.py
+++ b/scripts/lib/validation/config/run.py
@@ -73,3 +73,11 @@ class RunConfig(ConfigModel):
         description="Set to ``true`` (default) if snakemake shadow directories (``shallow``) should be used. Set to ``false`` if problems occur.",
         examples=[True],
     )
+
+    default_target_rule: str | None = Field(
+        "all",
+        description="Default target rule for snakemake. "
+        "This is the default rule that will be executed if no other rule is specified. "
+        "If set to ``None``, snakemake will use its default behavior and execute the first rule in the Snakefile. "
+        "NOTE: This value will be overwritten by any reference to `default_target` made in a specific rule.",
+    )


### PR DESCRIPTION
This allows users to leverage the `rulegraph` and `filegraph` rules in their soft forks and to point `pixi run snakemake` to their own "all"-style rule without needing to delete `default_target: True` from the existing `all` rule. 

Technically, it also allows a user to also have different default targets per `run`, so they can call `pixi run snakemake --configfile config/config.<run-with-different-target>.yaml` and it will switch out the default target for that run without the user needing to specify the target in the CLI call. Useful for tests, perhaps? 

## Checklist

**Required:**
- [ ] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.md`.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.md` files.