### PR TITLE
Fix future warnings

### DIFF
--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -912,9 +912,7 @@ def get_snapshots(
         )
         time_periods.append(period)
 
-    time = pd.DatetimeIndex([])
-    for period in time_periods:
-        time = time.append(period)
+    time = pd.DatetimeIndex([ts for period in time_periods for ts in period])
 
     if drop_leap_day and time.is_leap_year.any():
         time = time[~((time.month == 2) & (time.day == 29))]

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -424,7 +424,9 @@ def _remove_dangling_branches(branches, buses):
 
 
 def _remove_unconnected_components(network, threshold=6):
-    _, labels = csgraph.connected_components(network.adjacency_matrix(return_dataframe=False), directed=False)
+    _, labels = csgraph.connected_components(
+        network.adjacency_matrix(return_dataframe=False), directed=False
+    )
     component = pd.Series(labels, index=network.buses.index)
 
     component_sizes = component.value_counts()

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -424,7 +424,7 @@ def _remove_dangling_branches(branches, buses):
 
 
 def _remove_unconnected_components(network, threshold=6):
-    _, labels = csgraph.connected_components(network.adjacency_matrix(), directed=False)
+    _, labels = csgraph.connected_components(network.adjacency_matrix(return_dataframe=False), directed=False)
     component = pd.Series(labels, index=network.buses.index)
 
     component_sizes = component.value_counts()

--- a/scripts/build_biomass_potentials.py
+++ b/scripts/build_biomass_potentials.py
@@ -14,6 +14,9 @@ import pandas as pd
 
 from scripts._helpers import configure_logging, set_scenario_config
 
+pd.set_option("future.no_silent_downcasting", True)
+
+
 logger = logging.getLogger(__name__)
 AVAILABLE_BIOMASS_YEARS = [2010, 2020, 2030, 2040, 2050]
 
@@ -329,7 +332,11 @@ def add_unsustainable_potentials(df, input_eurostat):
     share_sus = params.get("share_sustainable_potential_available").get(investment_year)
     df.loc[df_wo_ch.index] *= share_sus
 
-    df = df.join(df_wo_ch.filter(like="unsustainable")).fillna(0)
+    df = (
+        df.join(df_wo_ch.filter(like="unsustainable"))
+        .fillna(0)
+        .infer_objects(copy=False)
+    )
 
     return df
 

--- a/scripts/build_energy_totals.py
+++ b/scripts/build_energy_totals.py
@@ -31,6 +31,9 @@ from tqdm import tqdm
 
 from scripts._helpers import configure_logging, mute_print, set_scenario_config
 
+pd.set_option("future.no_silent_downcasting", True)
+
+
 cc = coco.CountryConverter()
 logger = logging.getLogger(__name__)
 idx = pd.IndexSlice
@@ -657,7 +660,9 @@ def build_energy_totals(
                 df[f"total {sector} {use}"] - df[f"electricity {sector} {use}"]
             )
             nonelectric = df[f"total {sector}"] - df[f"electricity {sector}"]
-            nonelectric = nonelectric.copy().replace(0, np.nan)
+            nonelectric = (
+                nonelectric.copy().replace(0, np.nan).infer_objects(copy=False)
+            )
             avg = nonelectric_use.div(nonelectric).mean()
             logger.debug(
                 f"{sector}: average fraction of non-electric for {use} is {avg:.3f}"
@@ -694,7 +699,9 @@ def build_energy_totals(
                 nonelectric = (
                     no_norway[f"total {sector}"] - no_norway[f"electricity {sector}"]
                 )
-                nonelectric = nonelectric.copy().replace(0, np.nan)
+                nonelectric = (
+                    nonelectric.copy().replace(0, np.nan).infer_objects(copy=False)
+                )
                 fraction = nonelectric_use.div(nonelectric).mean()
                 df.loc["NO", f"total {sector} {use}"] = (
                     total_heating * fraction
@@ -827,6 +834,7 @@ def build_district_heat_share(countries: list[str], idees: pd.DataFrame) -> pd.S
         idees[["thermal uses residential", "thermal uses services"]]
         .sum(axis=1)
         .replace(0, np.nan)
+        .infer_objects(copy=False)
     )
 
     district_heat_share = district_heat / total_heat
@@ -853,7 +861,10 @@ def build_district_heat_share(countries: list[str], idees: pd.DataFrame) -> pd.S
 
     # restrict to available years
     district_heat_share = (
-        district_heat_share.unstack().dropna(how="all", axis=1).ffill(axis=1)
+        district_heat_share.unstack()
+        .dropna(how="all", axis=1)
+        .ffill(axis=1)
+        .infer_objects(copy=False)
     )
 
     return district_heat_share

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -119,6 +119,7 @@ def simplify_links(
     adjacency_matrix = n.adjacency_matrix(
         branch_components=["Link"],
         weights=dict(Link=(n.links.carrier == "DC").astype(float)),
+        return_dataframe=False,
     )
 
     _, labels = connected_components(adjacency_matrix, directed=False)
@@ -296,7 +297,7 @@ def aggregate_to_substations(
         }
     )
 
-    adj = n.adjacency_matrix(branch_components=["Line", "Link"], weights=weight).tocsr()
+    adj = n.adjacency_matrix(branch_components=["Line", "Link"], weights=weight, return_dataframe=False).tocsr()
 
     no_substation_i = n.buses.index.difference(substation_i)
     bus_indexer = n.buses.index.get_indexer(substation_i)

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -297,7 +297,9 @@ def aggregate_to_substations(
         }
     )
 
-    adj = n.adjacency_matrix(branch_components=["Line", "Link"], weights=weight, return_dataframe=False).tocsr()
+    adj = n.adjacency_matrix(
+        branch_components=["Line", "Link"], weights=weight, return_dataframe=False
+    ).tocsr()
 
     no_substation_i = n.buses.index.difference(substation_i)
     bus_indexer = n.buses.index.get_indexer(substation_i)


### PR DESCRIPTION
Fixes some future warnings. All content AI generated and human reviewed. Claude did a checksum based check of all affected output files before and after the fix and everything seems to be unchanged.

## Changes proposed in this Pull Request
[**base_network.py**](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
**Change:** Added return_dataframe=False to network.adjacency_matrix() call.

**Why:** PyPSA's adjacency_matrix() is changing its default return type from a sparse scipy matrix to a pandas [DataFrame](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in a future version. The existing code passed the result directly to scipy.sparse.csgraph.connected_components(), which requires a sparse matrix, not a DataFrame. The warning made this explicit. Adding return_dataframe=False locks in the sparse-matrix return type, making the call unambiguous and future-proof.

[**simplify_network.py**](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
**Change:** Same return_dataframe=False fix applied to two separate adjacency_matrix() calls — one in the DC-link connected-component detection block and one in aggregate_to_substations().

**Why**: Same root cause as base_network.py. Both call-sites passed the result to scipy.sparse functions that need a sparse matrix, so both needed to be explicit about the return type.

**[_helpers.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)**
**Change:** Replaced a 3-line [DatetimeIndex.append](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) loop with a single list-comprehension construction.

**Why:** DatetimeIndex.append is deprecated in pandas (replaced by [pd.DatetimeIndex.union](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) or direct construction). Beyond the deprecation, repeatedly appending to an empty index in a loop is quadratic in memory allocation. The list comprehension flattens all periods in one pass and constructs the index once — both correct and efficient.

**build_energy_totals.py**
**Two separate changes:**

**Added** [.infer_objects(copy=False)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) after four [replace](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[ffill](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) operations (lines ~660, ~697, ~829, ~856).

**Why:** Pandas is deprecating silent dtype downcasting inside [replace](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [fillna](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [ffill](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html). The message literally said: "to retain the old behavior, explicitly call result.infer_objects(copy=False)." This call is the forward-compatible way to perform the same downcast that pandas used to do silently. Without it, once pandas removes the implicit downcast, the results would change (e.g., integer 0 replacements would stay as object dtype instead of being inferred back to int64/float64).

**Added** [pd.set_option("future.no_silent_downcasting", True)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) near the top of the file (after [import pandas as pd](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)).

**Why:** The [.infer_objects(copy=False)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) calls ensure correct behaviour after the pandas change, but they do not suppress the warning in the current pandas version. The warning is emitted by [replace](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[ffill](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) itself before [infer_objects](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) even runs. Setting this option tells pandas "I've opted into the new behaviour" — pandas then skips its own internal downcast attempt and the warning is never raised. Combined with the explicit [infer_objects](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) calls, the output is bit-identical to before.

**[build_biomass_potentials.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)**
**Two** separate changes (same pattern as [build_energy_totals.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)):

**Added** [.infer_objects(copy=False)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) after [.fillna(0)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) call (line ~332) — for the same forward-compatibility reason.

**Added** [pd.set_option("future.no_silent_downcasting", True)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) near the top — to actually suppress the warning, same reasoning as above.

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.md`.
- [ ] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.md` files.