### PR TITLE
fix: define inflow_t before branch so it is always assigned

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -49,6 +49,8 @@
 
 - doc: Disable root TOC entries in order to declutter the table of contents for the rules overview ([2216](https://github.com/PyPSA/pypsa-eur/pull/2216)).
 
+* fix: Ensure `inflow_t` is always defined in `attach_hydro`, resolving a pylint use-before-assignment issue ([#2224](https://github.com/PyPSA/pypsa-eur/pull/2224)).
+
 ## PyPSA-Eur v2026.02.0 (18th February 2026)
 
 **Features**

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -770,6 +770,7 @@ def attach_hydro(
     country = ppl["bus"].map(n.buses.country).rename("country")
 
     inflow_idx = ror.index.union(hydro.index)
+    inflow_t = pd.DataFrame()
     if not inflow_idx.empty:
         dist_key = ppl.loc[inflow_idx, "p_nom"].groupby(country).transform(normed)
 
@@ -803,7 +804,7 @@ def attach_hydro(
             capital_cost=costs.at["ror", "capital_cost"],
             weight=ror["p_nom"],
             p_max_pu=(
-                inflow_t[ror.index]  # pylint: disable=E0606
+                inflow_t[ror.index]
                 .divide(ror["p_nom"], axis=1)
                 .where(lambda df: df <= 1.0, other=1.0)
             ),


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR introduces a minor fix ensuring `inflow_t` is always defined in `attach_hydro`, resolving a pylint use-before-assignment issue.

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.md` files.