### PR TITLE
fix: add missing regular expression anchor with re.fullmatch

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -49,6 +49,8 @@
 
 - doc: Disable root TOC entries in order to declutter the table of contents for the rules overview ([2216](https://github.com/PyPSA/pypsa-eur/pull/2216)).
 
+* Add missing regex anchor with `re.fullmatch` to `create_zenodo_deposition_cli` utils script ([#2225](https://github.com/PyPSA/pypsa-eur/pull/2225)).
+
 ## PyPSA-Eur v2026.02.0 (18th February 2026)
 
 **Features**

--- a/utils/create_zenodo_deposition_cli.py
+++ b/utils/create_zenodo_deposition_cli.py
@@ -428,8 +428,8 @@ def extract_zenodo_deposition_url(record_url: str) -> tuple[str, str]:
         The Zenodo deposition API URL, or None if extraction fails.
     """
     # Match both sandbox and production, with or without /files/...
-    m = re.match(
-        r"https://(?:sandbox\.)?zenodo\.org/records/(\d+)(/files/.*)?", record_url
+    m = re.fullmatch(
+        r"https://(?:sandbox\.)?zenodo\.org/records/(\d+)(/files(/.*)?)?", record_url
     )
     if not m:
         raise ValueError(f"Invalid Zenodo record URL format: {record_url}. ")


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR adds a missing regex anchor with `re.fullmatch` to `create_zenodo_deposition_cli` utils script.

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.md` files.