### PR TITLE
doc: change linting and formatting documentation to correctly show ruff

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -18,7 +18,7 @@ repository](https://github.com/PyPSA/PyPSA-Eur).
 ## Setting up the development environment
 
 For linting, formatting and checking your code contributions
-against our guidelines (e.g. we use [Black](https://github.com/psf/black) as code style
+against our guidelines (e.g. we use [Ruff](https://github.com/astral-sh/ruff) as code style)
 use [pre-commit](https://pre-commit.com/index.html):
 
 1. Install [pixi](https://pixi.sh/latest/).

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -6,6 +6,7 @@
 <!-- Upcoming Release -->
 <!-- ================= -->
 
+* fix: update stale contribution docs (linting and formatting ruff)
 * feat: data version CSV / YAML file can be specified separately or extended by the user in the `data.version_files` config entry ([#2016](https://github.com/PyPSA/pypsa-eur/issues/2016)).
 * Fix: Resolve plotting crashes from missing `tech_colors` entries by adding `heat dsm` color and implementing upfront validation for missing keys in `plot_summary.py` ([#2108](https://github.com/PyPSA/pypsa-eur/issues/2108)).
 * feat: Make the default target rule configurable (defaults to "all" for backwards compatibility)


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

doc: stale note on linting and formatting now to correctly mentions ruff (instead of black)

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [n/a] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [n/a] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [n/a] Changes in configuration options are reflected in `scripts/lib/validation`.
- [n/a] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [n/a] New rules are documented in the appropriate `doc/*.md` files.