### PR TITLE
fix: add retries to WDPA/WDPA-marine download rules

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -8,6 +8,7 @@
 
 * feat: data version CSV / YAML file can be specified separately or extended by the user in the `data.version_files` config entry ([#2016](https://github.com/PyPSA/pypsa-eur/issues/2016)).
 * Fix: Resolve plotting crashes from missing `tech_colors` entries by adding `heat dsm` color and implementing upfront validation for missing keys in `plot_summary.py` ([#2108](https://github.com/PyPSA/pypsa-eur/issues/2108)).
+* Fix: Retry interrupted WDPA and WDPA-marine downloads ([#2138](https://github.com/PyPSA/pypsa-eur/issues/2138)).
 * feat: Make the default target rule configurable (defaults to "all" for backwards compatibility)
 
 * Fix: Keep unset `p_set` (NaN) as NaN when aggregating components in `cluster_heat_buses`, required for [PyPSA#1703](https://github.com/PyPSA/PyPSA/pull/1703).

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -1109,6 +1109,7 @@ if (WDPA_DATASET := dataset_version("wdpa"))["source"] in [
         output:
             zip_file=f"{WDPA_DATASET['folder']}/WDPA_shp.zip",
             gpkg=f"{WDPA_DATASET['folder']}/WDPA.gpkg",
+        retries: 2
         message:
             "Downloading protected area database from WDPA"
         run:
@@ -1143,6 +1144,7 @@ if (WDPA_MARINE_DATASET := dataset_version("wdpa_marine"))["source"] in [
         output:
             zip_file=f"{WDPA_MARINE_DATASET['folder']}/WDPA_WDOECM_marine.zip",
             gpkg=f"{WDPA_MARINE_DATASET['folder']}/WDPA_WDOECM_marine.gpkg",
+        retries: 2
         # Downloading Marine protected area database from WDPA
         # extract the main zip and then merge the contained 3 zipped shapefiles
         # Website: https://www.protectedplanet.net/en/thematic-areas/marine-protected-areas


### PR DESCRIPTION
## Changes proposed in this Pull Request

The two rules that download the World Database on Protected Areas fetch multi-gigabyte archives from a mirrored source that occasionally truncates a large transfer partway through. When that happens the whole workflow run aborts, even though the download would almost always succeed on a second attempt. Every other large or flaky download rule in the same file already guards against this by asking Snakemake to retry the download a couple of times, so a single transient truncation does not cost the user an entire run.

This change brings the two protected-area download rules in line with that established convention by letting Snakemake retry each of them twice before giving up. The behaviour is unchanged on a healthy network: a download that succeeds the first time still runs exactly once. Only the failure path changes, and it now recovers automatically instead of stopping the run. A short entry describing the change has been added to the release notes so users can see it in the next version.

Because this is a resilience tweak to how an existing download is retried, there are no new configuration options, no new data sources, and no new workflow rules introduced by it.

## Checklist

- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.
- [x] Changes in configuration options are reflected in `scripts/lib/validation` (no configuration options changed).
- [x] For new data sources or versions, the documented instructions have been followed (no new data source or version).
- [x] New rules are documented in the appropriate `doc/*.md` files (no new rules added).

Closes #2138

AI was used for assistance.
