### PR TITLE
fix: read population weight from correct config key in build_electric…

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -61,6 +61,8 @@
 
 * chore: Bump the python version to 3.12 ([#2235](https://github.com/PyPSA/pypsa-eur/pull/2235)). This does not increase the real requirement, because 3.12 is already the effective minimum.
 
+* Fix: `build_electricity_demand_base` fetched the non-existent `load.distribution_key.pop` key instead of correct `population`, silently ignoring the configured value.
+
 ## PyPSA-Eur v2026.02.0 (18th February 2026)
 
 **Features**

--- a/scripts/build_electricity_demand_base.py
+++ b/scripts/build_electricity_demand_base.py
@@ -141,7 +141,7 @@ def nuts3_distribution_keys(
         File path to the NUTS3 GeoJSON file containing geometries and attributes.
     distribution_key : dict[str, float]
         Weights for GDP and population in the distribution key calculation.
-        Example: {"gdp": 0.6, "pop": 0.4}
+        Example: {"gdp": 0.6, "population": 0.4}
     regions : gpd.GeoDataFrame
         GeoDataFrame containing the regions with a 'country' column.
 
@@ -151,8 +151,8 @@ def nuts3_distribution_keys(
         Series of distribution keys indexed by region names.
     """
 
-    gdp_weight = distribution_key.get("gdp", 0.6)
-    pop_weight = distribution_key.get("pop", 0.4)
+    gdp_weight = distribution_key["gdp"]
+    pop_weight = distribution_key["population"]
 
     nuts3 = gpd.read_file(nuts3_fn).to_crs(epsg=3035)
     nuts3.rename(columns={"name": "nuts3_name"}, inplace=True)


### PR DESCRIPTION
Closes https://github.com/PyPSA/pypsa-eur/issues/2240

## Changes proposed in this Pull Request
fixes the configuration key access in `scripts.build_electricity_demand_base.nuts3_distribution_keys` and hardens the workflow by avoiding the `.get()` call with defaults. 

Claude found the bug and wrote the release notes. 

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.md` files.