### PR TITLE
fix: apply backward fill to country groups

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -61,6 +61,8 @@
 
 * chore: Bump the python version to 3.12 ([#2235](https://github.com/PyPSA/pypsa-eur/pull/2235)). This does not increase the real requirement, because 3.12 is already the effective minimum.
 
+* Fix: `fill_missing_years` applied the backward fill across country boundaries, so countries without any Eurostat value silently inherited the values of the next country.
+
 ## PyPSA-Eur v2026.02.0 (18th February 2026)
 
 **Features**

--- a/scripts/build_energy_totals.py
+++ b/scripts/build_energy_totals.py
@@ -486,24 +486,27 @@ def fill_missing_years(fill_values: pd.Series) -> pd.Series:
     ----------
     fill_values : pd.Series
         A pandas Series with a MultiIndex (levels: country and year) representing
-        energy values, where some values may be zero and need to be filled.
+        energy values, where some values may be missing and need to be filled.
 
     Returns
     -------
     pd.Series
-        A pandas Series with zero values replaced by the forward-filled and
+        A pandas Series with missing values replaced by the forward-filled and
         backward-filled values of the corresponding country.
 
     Notes
     -----
     - The function groups the data by the 'country' level and performs forward fill
-      and backward fill to fill zero values.
-    - Zero values in the original Series are replaced by the ffilled and bfilled
-      value of their respective country group.
+      and backward fill to fill missing values.
+    - Missing values in the original Series are replaced by the ffilled and bfilled
+      value of their respective country group. Countries without any value remain
+      missing.
     """
 
     # Forward fill and then backward fill within each country group
-    fill_values = fill_values.groupby(level="country").ffill().bfill()
+    fill_values = fill_values.groupby(level="country").transform(
+        lambda x: x.ffill().bfill()
+    )
 
     return fill_values
 


### PR DESCRIPTION
Closes https://github.com/PyPSA/pypsa-eur/issues/2242

## Changes proposed in this Pull Request
Fixes the logic of the gap filling in build energy totals. The backwards filling `.bfill()` method wrongly applied to the full cross-country data set. This caused 1990s values from the next country to fill values for countries without values. 

I found this bug because `electricity rail` values for Albania are very large in PyPSA-AT. Turns out the values are from AT 1990 because that's the next value in the data set. Claude provided the release notes and updated the docs. 

The function now may return NaN in the returned DataFrame object. 

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.md` files.