### PR TITLE
Docs: temporal clustering (continues #2160)

### DIFF
--- a/config/schema.default.json
+++ b/config/schema.default.json
@@ -621,7 +621,7 @@
           }
         },
         "temporal": {
-          "description": "Configuration for `clustering.temporal` settings.",
+          "description": "Configuration for `clustering.temporal` settings.  Follows the convention of {n}{unit}, e.g. 3H to aggregate over 3 hours time periods. `SEG` can be used to create n segments of varying time periods based on network similarities during those time periods.",
           "properties": {
             "resolution_elec": {
               "anyOf": [
@@ -8080,7 +8080,7 @@
       }
     },
     "_TemporalConfig": {
-      "description": "Configuration for `clustering.temporal` settings.",
+      "description": "Configuration for `clustering.temporal` settings.  Follows the convention of {n}{unit}, e.g. 3H to aggregate over 3 hours time periods. `SEG` can be used to create n segments of varying time periods based on network similarities during those time periods.",
       "properties": {
         "resolution_elec": {
           "anyOf": [
@@ -12131,7 +12131,7 @@
           }
         },
         "temporal": {
-          "description": "Configuration for `clustering.temporal` settings.",
+          "description": "Configuration for `clustering.temporal` settings.  Follows the convention of {n}{unit}, e.g. 3H to aggregate over 3 hours time periods. `SEG` can be used to create n segments of varying time periods based on network similarities during those time periods.",
           "properties": {
             "resolution_elec": {
               "anyOf": [

--- a/config/schema.default.json
+++ b/config/schema.default.json
@@ -621,7 +621,7 @@
           }
         },
         "temporal": {
-          "description": "Configuration for `clustering.temporal` settings.",
+          "description": "Configuration for `clustering.temporal` settings. Follows the convention of {n}{unit}, e.g. 3H to aggregate over 3 hours time periods. `SEG` can be used to create n segments of varying time periods based on network similarities during those time periods.",
           "properties": {
             "resolution_elec": {
               "anyOf": [

--- a/config/schema.default.json
+++ b/config/schema.default.json
@@ -621,7 +621,7 @@
           }
         },
         "temporal": {
-          "description": "Configuration for `clustering.temporal` settings. Follows the convention of {n}{unit}, e.g. 3H to aggregate over 3 hours time periods. `SEG` can be used to create n segments of varying time periods based on network similarities during those time periods.",
+          "description": "Configuration for `clustering.temporal` settings.",
           "properties": {
             "resolution_elec": {
               "anyOf": [

--- a/scripts/lib/validation/config/clustering.py
+++ b/scripts/lib/validation/config/clustering.py
@@ -93,7 +93,7 @@ class _AggregationStrategiesConfig(BaseModel):
 
 
 class _TemporalConfig(BaseModel):
-    """Configuration for `clustering.temporal` settings."""
+    """Configuration for `clustering.temporal` settings.  Follows the convention of {n}{unit}, e.g. 3H to aggregate over 3 hours time periods. `SEG` can be used to create n segments of varying time periods based on network similarities during those time periods."""
 
     resolution_elec: bool | str = Field(
         False,


### PR DESCRIPTION
Continuation of #2160, moved to a branch in this repo because the head fork is org-owned and 'allow edits by maintainers' does not grant push access in that case.