### PR TITLE
fix: handle corine=false in determine_availability_matrix_MD_UA

### DIFF
--- a/scripts/determine_availability_matrix_MD_UA.py
+++ b/scripts/determine_availability_matrix_MD_UA.py
@@ -60,6 +60,8 @@ if __name__ == "__main__":
     excluder = atlite.ExclusionContainer(crs=3035, res=100)
 
     corine = config.get("corine", {})
+    if not isinstance(corine, dict):
+        corine = {}
     if "grid_codes" in corine:
         # Land cover codes to emulate CORINE results
         if snakemake.wildcards.technology == "solar":


### PR DESCRIPTION
When corine is set to false for offshore technologies, convert it to an empty dict so downstream 'key in corine' checks are skipped.

Fixes #2111

From #2113 by @MarcoAnarmo
