### PR TITLE
Fix retrofitting

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -6,6 +6,8 @@
 <!-- Upcoming Release -->
 <!-- ================= -->
 
+* Fix: fix bugs in retrofitting scripts which happens due to pandas version change and other code changes ([#2273](https://github.com/PyPSA/pypsa-eur/pull/2273))
+
 * Adding option to include the compression step in carbon dioxide transport before transporting in dense phase and including electricity demand for post combustion carbon capture. Adjusting the capital costs for post combustion capture that differs depending on the carbon dioxide percentage in the flue gas ([#2161](https://github.com/PyPSA/pypsa-eur/pull/2161)).
 Upcoming Release
 

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -158,7 +158,7 @@ def prepare_building_stock_data():
     building_data = pd.read_csv(snakemake.input.building_stock, usecols=list(range(13)))
 
     # standardize data
-    building_data["type"].replace(
+    building_data["type"] = building_data["type"].replace(
         {
             "Covered area: heated  [Mm²]": "Heated area [Mm²]",
             "Windows ": "Window",
@@ -168,22 +168,19 @@ def prepare_building_stock_data():
             "Roof ": "Roof",
             "Floor ": "Floor",
         },
-        inplace=True,
     )
-    building_data["feature"].replace(
+    building_data["feature"] = building_data["feature"].replace(
         {
             "Construction features (U-value)": "Construction features (U-values)",
         },
-        inplace=True,
     )
 
     building_data.country_code = building_data.country_code.str.upper()
-    building_data["subsector"].replace(
-        {"Hotels and Restaurants": "Hotels and restaurants"}, inplace=True
+    building_data["subsector"] = building_data["subsector"].replace(
+        {"Hotels and Restaurants": "Hotels and restaurants"}
     )
-    building_data["sector"].replace(
-        {"Residential sector": "residential", "Service sector": "services"},
-        inplace=True,
+    building_data["sector"] = building_data["sector"].replace(
+        {"Residential sector": "residential", "Service sector": "services"}
     )
 
     # extract u-values
@@ -267,7 +264,9 @@ def prepare_building_stock_data():
 
     # u_values for Poland are missing -> take them from eurostat -----------
     u_values_PL = pd.read_csv(snakemake.input.u_values_PL)
-    u_values_PL.component.replace({"Walls": "Wall", "Windows": "Window"}, inplace=True)
+    u_values_PL["component"] = u_values_PL["component"].replace(
+        {"Walls": "Wall", "Windows": "Window"}
+    )
     area_PL = area.loc["Poland"].reset_index()
     data_PL = pd.DataFrame(columns=u_values.columns, index=area_PL.index)
     data_PL["country"] = "Poland"
@@ -461,7 +460,7 @@ def prepare_building_topology(u_values, same_building_topology=True):
     missing_ct = (
         missing_ct.unstack().unstack().fillna(missing_ct.unstack().unstack().mean())
     )
-    data_tabula = missing_ct.stack(level=[-1, -2, -3], dropna=False)
+    data_tabula = missing_ct.stack(level=[-1, -2, -3])
 
     # sets for different countries same building topology which only depends on
     # build year and subsector (MFH, SFH, AB)
@@ -898,7 +897,7 @@ def calculate_gain_utilisation_factor(heat_transfer_perm2, Q_ht, Q_gain):
     Calculates gain utilisation factor nu.
     """
     # time constant of the building tau [h] = c_m [Wh/(m^2K)] * 1 /(H_tr_e+H_tb*H_ve) [m^2 K /W]
-    tau = c_m / heat_transfer_perm2.groupby().sum()
+    tau = c_m / heat_transfer_perm2.T.groupby(level=1).sum().T
     alpha = alpha_H_0 + (tau / tau_H_0)
     # heat balance ratio
     gamma = (1 / Q_ht).mul(Q_gain.sum(axis=1), axis=0)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3671,7 +3671,7 @@ def add_heat(
         ) / heat_demand.T.groupby(level=[1]).sum().T
 
         for name in n.loads[
-            n.loads.carrier.isin([x + " heat" for x in HeatSystem])
+            n.loads.carrier.isin([str(x) + " heat" for x in HeatSystem])
         ].index:
             node = n.buses.loc[name, "location"]
             ct = pop_layout.loc[node, "ct"]


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR aims to revise the retrofitting related scripts to prevent some bugs. Due to change of the pandas versions and some other changes, the workflow with building retrofitting activated breaks. I have seen such error shown below. It is caused by depreciated `inplace` in `pandas` 3. Because of not properly functioning `inplace` the items are not replaced fine which later causes problems. Ideally, it would be good to enable retrofitting in one of the CI tests (maybe in overnight one). What do you think? It would improve the maintenance and help to retain such functionality. If it is a good idea, then I can proceed in that direction too. 

I would be glad if you can take a look into the PR and provide feedback, @fneum, @lisazeyen.

```
Traceback (most recent call last):
  File "C:\Users\Yerbol\Documents\Python\PyPSA\heat-demand-peaks\submodules\pypsa-eur\.snakemake\scripts\tmp873s5_t9.build_retro_cost.py", line 1096, in <module>
    u_values, country_iso_dic, countries, area_tot, area = prepare_building_stock_data()
                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\Users\Yerbol\Documents\Python\PyPSA\heat-demand-peaks\submodules\pypsa-eur\.snakemake\scripts\tmp873s5_t9.build_retro_cost.py", line 286, in prepare_building_stock_data
    data_PL["value"] = data_PL.apply(
                       ~~~~~~~~~~~~~^
        lambda x: u_values_PL[
        ^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
        axis=1,
        ^^^^^^^
    )
    ^
  File "C:\Users\Yerbol\Documents\Python\PyPSA\heat-demand-peaks\submodules\pypsa-eur\.pixi\envs\default\Lib\site-packages\pandas\core\frame.py", line 12435, in apply
    return op.apply().__finalize__(self, method="apply")
           ~~~~~~~~^^
  File "C:\Users\Yerbol\Documents\Python\PyPSA\heat-demand-peaks\submodules\pypsa-eur\.pixi\envs\default\Lib\site-packages\pandas\core\apply.py", line 1015, in apply
    return self.apply_standard()
           ~~~~~~~~~~~~~~~~~~~^^
  File "C:\Users\Yerbol\Documents\Python\PyPSA\heat-demand-peaks\submodules\pypsa-eur\.pixi\envs\default\Lib\site-packages\pandas\core\apply.py", line 1167, in apply_standard
    results, res_index = self.apply_series_generator()
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\Users\Yerbol\Documents\Python\PyPSA\heat-demand-peaks\submodules\pypsa-eur\.pixi\envs\default\Lib\site-packages\pandas\core\apply.py", line 1183, in apply_series_generator
    results[i] = self.func(v, *self.args, **self.kwargs)
                 ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Yerbol\Documents\Python\PyPSA\heat-demand-peaks\submodules\pypsa-eur\.snakemake\scripts\tmp873s5_t9.build_retro_cost.py", line 287, in <lambda>
    lambda x: u_values_PL[
              ~~~~~~~~~~~~
        (u_values_PL.component == component)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        & (u_values_PL.sector == x["sector"])
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ][x["bage"]].iloc[0],
    ~~~~~~~~~~~~~~~~~^^^
  File "C:\Users\Yerbol\Documents\Python\PyPSA\heat-demand-peaks\submodules\pypsa-eur\.pixi\envs\default\Lib\site-packages\pandas\core\indexing.py", line 1207, in __getitem__
    return self._getitem_axis(maybe_callable, axis=axis)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Yerbol\Documents\Python\PyPSA\heat-demand-peaks\submodules\pypsa-eur\.pixi\envs\default\Lib\site-packages\pandas\core\indexing.py", line 1773, in _getitem_axis
    self._validate_integer(key, axis)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "C:\Users\Yerbol\Documents\Python\PyPSA\heat-demand-peaks\submodules\pypsa-eur\.pixi\envs\default\Lib\site-packages\pandas\core\indexing.py", line 1706, in _validate_integer
    raise IndexError("single positional indexer is out-of-bounds")
IndexError: single positional indexer is out-of-bounds
```

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.md` files.