### PR TITLE
fix: partial assignment causes pandas to drop index.name during clustering

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -8,6 +8,8 @@
 
 * Fix: fix bugs in retrofitting scripts which happens due to pandas version change and other code changes ([#2273](https://github.com/PyPSA/pypsa-eur/pull/2273))
 
+* Fix: focus_weights related TypeError during cluster_network ([#2277](https://github.com/PyPSA/pypsa-eur/pull/2277))
+
 ## PyPSA-Eur v2026.08.0 (19th August 2026)
 
 **Features**

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -306,7 +306,7 @@ def distribute_n_clusters_to_countries(
             c not in focus_weights.keys() for c in L.index.get_level_values("country")
         ]
         L[remainder] = L.loc[remainder].pipe(normed) * (1 - total_focus)
-
+        L.index.name = "cluster"
         logger.warning("Using custom focus weights for determining number of clusters.")
 
     assert np.isclose(L.sum(), 1.0, rtol=1e-3), (


### PR DESCRIPTION
Might be only ocurring with pandas >=3.0 - but i did not check older versions

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

**Required:**
- [ ] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.md`.
- [ ] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.md` files.