### PR TITLE
fix: two crashes when building cutouts and using years outside the input data

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -5,6 +5,12 @@
 
 <!-- Upcoming Release -->
 <!-- ================= -->
+* Bugfix: Fixed a ``TypeError`` when building cutouts locally, caused by using the
+  ``/`` operator on ``CUTOUT_DATASET["folder"]``, which is a string.
+
+* Bugfix: The fallback to the last column in ``attach_conventional_generators`` now
+  also catches ``KeyError``, so a snapshot year that is missing from a conventional
+  input file no longer aborts the run.
 
 * Fix: fix bugs in retrofitting scripts which happens due to pandas version change and other code changes ([#2273](https://github.com/PyPSA/pypsa-eur/pull/2273))
 

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -233,7 +233,7 @@ if CUTOUT_DATASET["source"] in ["build"]:
 
     rule build_cutout:
         output:
-            cutout=CUTOUT_DATASET["folder"] / "{cutout}.nc",
+            cutout=CUTOUT_DATASET["folder"] + "/{cutout}.nc",
         log:
             "logs/build_cutout/{cutout}.log",
         benchmark:

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -683,7 +683,7 @@ def attach_conventional_generators(
                     df.columns = df.columns.astype(int)
                     year = n.snapshots[0].year
                     values = df[year]
-                except (ValueError, TypeError):
+                except (ValueError, TypeError, KeyError):
                     values = df.iloc[:, -1]  # take last column if year selection fails
                 bus_values = n.buses.country.map(values)
                 n.generators.update(


### PR DESCRIPTION
Fixes #2156, which I reported in April.

Both issues surfaced when running the workflow with a locally built cutout for a historical weather year (1990). They are independent, so feel free to ask me to split this PR.

1. TypeError on the cutout path in rules/build_electricity.smk

dataset_version() in rules/common.smk builds the field with Path(...).as_posix(), so CUTOUT_DATASET["folder"] is a string. The build rule joins the filename with the / operator, which raises TypeError: unsupported operand type(s) for /: 'str' and 'str'. rules/retrieve.smk already uses + for the same variable, so this is an inconsistency between the two files. Only affects source: build, which is why it is easy to miss when using the pre-built cutouts.

2. KeyError instead of the intended fallback in attach_conventional_generators

The code selects the snapshot year from a conventional input file and falls back to the last column, with the comment "take last column if year selection fails". However df[year] raises KeyError for a year that is not among the columns, and KeyError is not caught, so the fallback never triggers for the most common failure case.

This is not limited to unusual years: data/nuclear_p_max_pu.csv covers 2009 to 2024 but skips 2014, so even a year inside the nominal range aborts the run.

Adding KeyError to the existing except clause restores the documented behaviour.